### PR TITLE
Fix class name typo at TextRunMarshaller.php

### DIFF
--- a/src/qtism/data/storage/xml/marshalling/TextRunMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/TextRunMarshaller.php
@@ -66,6 +66,6 @@ class TextRunMarshaller extends Marshaller
 	 */
     public function getExpectedQtiClassName()
     {
-        return 'randomInteger';
+        return 'textRun';
     }
 }


### PR DESCRIPTION
This typo prevents marshall/unmarshalling functionality to work