### PR TITLE
Adjust non-strict identifier validation. Adding unit tests.

### DIFF
--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -78,7 +78,7 @@ class Format
                 return false;
             }
         } else {
-            return preg_match("/^[a-zA-Z_][a-zA-Z0-9_\.-]*$/u", $string) === 1;
+            return preg_match("/^[a-zA-Z0-9_\.-]+$/u", $string) === 1;
         }
     }
 

--- a/test/qtismtest/common/utils/FormatTest.php
+++ b/test/qtismtest/common/utils/FormatTest.php
@@ -12,6 +12,20 @@ class FormatTest extends QtiSmTestCase {
 	public function testValidIdentifierFormat($string) {
 		$this->assertTrue(Format::isIdentifier($string));
 	}
+
+    /**
+     * @dataProvider validIdentifierNonStrictFormatProvider
+     */
+    public function testValidIdentifierNonStrictFormat($string) {
+        $this->assertTrue(Format::isIdentifier($string, false));
+    }
+
+    /**
+     * @dataProvider invalidIdentifierNonStrictFormatProvider
+     */
+    public function testInvalidIdentifierNonStrictFormat($string) {
+        $this->assertFalse(Format::isIdentifier($string, false));
+    }
 	
 	/**
 	 * @dataProvider invalidIdentifierFormatProvider
@@ -161,6 +175,24 @@ class FormatTest extends QtiSmTestCase {
 			array('myWeight1')
 		);
 	}
+
+    public function validIdentifierNonStrictFormatProvider() {
+        return array(
+            array('_good'),
+            array('g0od'),
+            array('_-goOd3'),
+            array('g.0.o.d...'),
+            array('myWeight1'),
+            array('123456')
+        );
+    }
+
+    public function invalidIdentifierNonStrictFormatProvider() {
+        return array(
+            array(''),
+            array('*')
+        );
+    }
 	
 	public function invalidIdentifierFormatProvider() {
 		return array(


### PR DESCRIPTION
It seems like there is no restrictions indicate that the identifier attribute must start with a character.

This PR is attempting to allow identifier like "123456". Additional unit tests are added to reflect the change.

Thanks.