### PR TITLE
AssessmentTestSession: fix condition to resume a session

### DIFF
--- a/qtism/runtime/tests/AssessmentTestSession.php
+++ b/qtism/runtime/tests/AssessmentTestSession.php
@@ -1345,7 +1345,7 @@ class AssessmentTestSession extends State {
      * Resume the current test session if it is suspended.
      */
     public function resume() {
-        if ($this->isRunning() === false) {
+        if ($this->isRunning() === false || $this->getState() === AssessmentTestSessionState::SUSPENDED) {
             $this->interactWithItemSession();
             $this->setState(AssessmentTestSessionState::INTERACTING);
         }

--- a/qtism/runtime/tests/AssessmentTestSession.php
+++ b/qtism/runtime/tests/AssessmentTestSession.php
@@ -1345,7 +1345,7 @@ class AssessmentTestSession extends State {
      * Resume the current test session if it is suspended.
      */
     public function resume() {
-        if ($this->isRunning() === false || $this->getState() === AssessmentTestSessionState::SUSPENDED) {
+        if ($this->getState() === AssessmentTestSessionState::SUSPENDED) {
             $this->interactWithItemSession();
             $this->setState(AssessmentTestSessionState::INTERACTING);
         }


### PR DESCRIPTION
Without this patch it is impossible to resume a suspended session. The `isRunning()` method considers the session is running when the state is different from INITIAL or CLOSED. So a suspended session is never considered as not running, and cannot be resumed.