### PR TITLE
A fix for a bug which caused Iterator does not iterate when…

### DIFF
--- a/src/qtism/data/QtiComponentIterator.php
+++ b/src/qtism/data/QtiComponentIterator.php
@@ -342,7 +342,9 @@ class QtiComponentIterator implements Iterator
         $root = $this->getRootComponent();
         $this->pushOnTrail($root, $root->getComponents());
 
+        $hasTrail = false;
         while (count($this->getTrail()) > 0) {
+            $hasTrail = true;
             $trailEntry = $this->popFromTrail();
 
             $this->setValid(true);
@@ -356,7 +358,7 @@ class QtiComponentIterator implements Iterator
             }
         }
 
-        if (count($this->trail) === 0) {
+        if (count($this->trail) === 0 && !$hasTrail) {
             $this->isValid = false;
             $this->currentComponent = null;
             $this->currentContainer = null;

--- a/src/qtism/data/QtiComponentIterator.php
+++ b/src/qtism/data/QtiComponentIterator.php
@@ -343,6 +343,7 @@ class QtiComponentIterator implements Iterator
         $this->pushOnTrail($root, $root->getComponents());
 
         $hasTrail = false;
+        $foundClass = false;
         while (count($this->getTrail()) > 0) {
             $hasTrail = true;
             $trailEntry = $this->popFromTrail();
@@ -354,11 +355,12 @@ class QtiComponentIterator implements Iterator
             $this->pushOnTrail($this->currentComponent, $this->currentComponent->getComponents());
 
             if (empty($classes) === true || in_array($this->currentComponent->getQtiClassName(), $classes) === true) {
+                $foundClass = true;
                 break;
             }
         }
 
-        if (count($this->trail) === 0 && !$hasTrail) {
+        if (count($this->trail) === 0 && (($hasTrail && !$foundClass) || (!$hasTrail))) {
             $this->isValid = false;
             $this->currentComponent = null;
             $this->currentContainer = null;

--- a/test/qtismtest/data/QtiComponentIteratorTest.php
+++ b/test/qtismtest/data/QtiComponentIteratorTest.php
@@ -31,7 +31,20 @@ class QtiComponentIteratorTest extends QtiSmTestCase {
 		
 		$this->assertSame(null, $iterator->parent());
 	}
-	
+
+	public function testOneChildComponents() {
+		$baseValues = new ExpressionCollection();
+		$baseValues[] = new BaseValue(BaseType::FLOAT, 0.5);
+		$sum = new Sum($baseValues);
+		$iterator = new QtiComponentIterator($sum);
+
+		$iterations = 0;
+		foreach ($iterator as $k => $i) {
+			$iterations++;
+		}
+		$this->assertEquals(1, $iterations);
+	}
+
 	public function testNoChildComponents() {
 		$baseValue = new BaseValue(BaseType::FLOAT, 10);
 		$iterator = new QtiComponentIterator($baseValue);


### PR DESCRIPTION
… we only have one children component

@bugalot Can you please check this? I'm not sure whether this is the right fix, but I think the iterator should still work even if we only one child component, no? Thanks in advance.