### PR TITLE
Improved class detection compatibility with WC3 standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "qtism/qtism",
 	"description": "OAT QTI Software Module Library",
 	"type": "library",
-	"version": "0.10.13",
+	"version": "0.10.14",
 	"authors": [
 		{
 			"name": "Open Assessment Technologies S.A.",

--- a/qtism/common/utils/Format.php
+++ b/qtism/common/utils/Format.php
@@ -355,7 +355,7 @@ class Format {
 	 * @return boolean
 	 */
 	static public function isClass($string) {
-	    $pattern = "/^(?:[^\s]+?(?:\x20){0,1})+$/";
+        $pattern = "/^(?:[^\s]+?(?:\x20){0,})+$/";
 	    return preg_match($pattern, $string) === 1;
 	}
 	

--- a/test/qtism/common/utils/FormatTest.php
+++ b/test/qtism/common/utils/FormatTest.php
@@ -206,6 +206,7 @@ class FormatTest extends QtiSmTestCase {
 	        array('a'),
 	        array('my-class'),
 	        array('my-class my-other-class'),
+            array('my-class   my-other-class'),
 	        array('theclass')
 	    );
 	}


### PR DESCRIPTION
@bugalot @llecaque 
This changes prevents failing delivery compilation with not so nice, but still standard class names separated with more that one space.
