### PR TITLE
Improved class detection compatibility with WC3 standard

### DIFF
--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -371,7 +371,7 @@ class Format
      */
     public static function isClass($string)
     {
-        $pattern = "/^(?:[^\s]+?(?:\x20){0,1})+$/";
+        $pattern = "/^(?:[^\s]+?(?:\x20){0,})+$/";
 
         return preg_match($pattern, $string) === 1;
     }

--- a/test/qtismtest/common/utils/FormatTest.php
+++ b/test/qtismtest/common/utils/FormatTest.php
@@ -221,6 +221,7 @@ class FormatTest extends QtiSmTestCase {
 	        array('a'),
 	        array('my-class'),
 	        array('my-class my-other-class'),
+            array('my-class    my-other-class'),
 	        array('theclass')
 	    );
 	}


### PR DESCRIPTION
@bugalot @llecaque 
This changes prevents failing delivery compilation with not so nice, but still standard class names separated with more that one space.