### PR TITLE
Feature/itemsession fully responded

### DIFF
--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013-2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2
@@ -900,7 +900,7 @@ class AssessmentItemSession extends State
      * Responses provided when suspending the item session will be taken into account only if the current
      * state is different from MODAL_FEEDBACK.
      *
-     * @param \qtism\runtime\common\State (optiona) A State object containing the responses to be stored in the item session at suspend time.
+     * @param \qtism\runtime\common\State $responses (optional) A State object containing the responses to be stored in the item session at suspend time.
      * @throws \qtism\runtime\tests\AssessmentItemSessionException With code STATE_VIOLATION if the state of the session is not INTERACTING nor MODAL_FEEDBACK prior to suspension.
      */
     public function suspend(State $responses = null)
@@ -1111,11 +1111,14 @@ class AssessmentItemSession extends State
     }
 
     /**
-     * Whether the item of the session has been attempted (at least once) and for which at least one response was given.
+     * Is the Item Session Partially/Fully responded
+     * 
+     * Whether the item of the session has been attempted (at least once) and for which responses were given.
      *
+     * @param boolean $partially (optional) Whether or not consider partially responded sessions as responded.
      * @return boolean
      */
-    public function isResponded()
+    public function isResponded($partially = true)
     {
         if ($this->isPresented() === false) {
             return false;
@@ -1131,18 +1134,18 @@ class AssessmentItemSession extends State
                 $defaultValue = $var->getDefaultValue();
 
                 if (Utils::isNull($value) === true) {
-                    if (Utils::isNull($defaultValue) === false) {
-                        return true;
+                    if (Utils::isNull($defaultValue) === (($partially) ? false : true)) {
+                        return (($partially) ? true : false);
                     }
                 } else {
-                    if ($value->equals($defaultValue) === false) {
-                        return true;
+                    if ($value->equals($defaultValue) === (($partially) ? false : true)) {
+                        return (($partially) ? true : false);
                     }
                 }
             }
         }
 
-        return false;
+        return (($partially) ? false : true);
     }
 
     /**

--- a/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
@@ -661,4 +661,169 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $this->assertTrue($itemSession->isResponded());
         $this->assertTrue($itemSession->isResponded(false));
     }
+    
+    public function testIsRespondedMultipleInteractions1()
+    {
+        $doc = new XmlDocument();
+        $doc->load(self::samplesDir() . 'custom/items/is_responded/is_responded_multiple_interactions_singlechoice_textentry.xml');
+        
+        $itemSession = new AssessmentItemSession($doc->getDocumentComponent());
+        $itemSessionControl = $itemSession->getItemSessionControl();
+        $itemSessionControl->setMaxAttempts(0);
+        
+        $itemSession->beginItemSession();
+        
+        $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
+        
+        // Attempt 1. Just respond nothing.
+        $itemSession->beginAttempt();
+        
+        // Right after beginning the first attempt:
+        // - RESPONSEA has value "ChoiceC" as it is its default value.
+        // - RESPONSEB has a null value.
+        
+        $this->assertEquals('ChoiceC', $itemSession['RESPONSEA']->getValue());
+        $this->assertNull($itemSession['RESPONSEB']);
+        
+        $itemSession->endAttempt(
+            new State()
+        );
+        
+        $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
+        
+        // Attempt 2. Just respond with an empty string to the textEntryInteraction.
+        // (Note: in QTI, empty strings, empty containers and null are considered equal values).
+        $itemSession->beginAttempt();
+        $itemSession->endAttempt(
+            new State([
+                new ResponseVariable(
+                    'RESPONSEB', 
+                    Cardinality::SINGLE, 
+                    BaseType::STRING, 
+                    new QtiString('')
+                )
+            ])
+        );
+        
+        $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
+        
+        // Attempt 3. Just respond to the textEntryInteraction with a non empty string.
+        $itemSession->beginAttempt();
+        $itemSession->endAttempt(
+            new State([
+                new ResponseVariable(
+                    'RESPONSEB',
+                    Cardinality::SINGLE,
+                    BaseType::STRING, 
+                    new QtiString('Lorem Ipsum')
+                )
+            ])
+        );
+        
+        $this->assertTrue($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
+        
+        // Attempt 4. Respond to the ChoiceInteraction.
+        $itemSession->beginAttempt();
+        $itemSession->endAttempt(
+            new State([
+                new ResponseVariable(
+                    'RESPONSEA',
+                    Cardinality::SINGLE,
+                    BaseType::IDENTIFIER,
+                    new QtiIdentifier('ChoiceA')
+                )
+            ])
+        );
+        
+        $this->assertTrue($itemSession->isResponded());
+        $this->assertTrue($itemSession->isResponded(false));
+    }
+    
+    public function testIsRespondedMultipleInteractions2()
+    {
+        $doc = new XmlDocument();
+        $doc->load(self::samplesDir() . 'custom/items/is_responded/is_responded_multiple_interactions_multiplechoice_textentry.xml');
+        
+        $itemSession = new AssessmentItemSession($doc->getDocumentComponent());
+        $itemSessionControl = $itemSession->getItemSessionControl();
+        $itemSessionControl->setMaxAttempts(0);
+        
+        $itemSession->beginItemSession();
+        
+        $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
+        
+        // Attempt 1. Just respond nothing.
+        $itemSession->beginAttempt();
+        
+        // Right after beginning the first attempt:
+        // - RESPONSEA has value ["ChoiceC"] as it is its default value.
+        // - RESPONSEB has a null value.
+        
+        $this->assertEquals('ChoiceC', $itemSession['RESPONSEA'][0]->getValue());
+        $this->assertNull($itemSession['RESPONSEB']);
+        
+        $itemSession->endAttempt(
+            new State()
+        );
+        
+        $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
+        
+        // Attempt 2. Just respond with an empty string to the textEntryInteraction.
+        // (Note: in QTI, empty strings, empty containers and null are considered equal values).
+        $itemSession->beginAttempt();
+        $itemSession->endAttempt(
+            new State([
+                new ResponseVariable(
+                    'RESPONSEB',
+                    Cardinality::SINGLE,
+                    BaseType::STRING,
+                    new QtiString('')
+                )
+            ])
+        );
+        
+        $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
+        
+        // Attempt 3. Just respond to the textEntryInteraction with a non empty string.
+        $itemSession->beginAttempt();
+        $itemSession->endAttempt(
+            new State([
+                new ResponseVariable(
+                    'RESPONSEB',
+                    Cardinality::SINGLE,
+                    BaseType::STRING,
+                    new QtiString('Lorem Ipsum')
+                )
+            ])
+        );
+        
+        $this->assertTrue($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
+        
+        // Attempt 4. Respond to the ChoiceInteraction.
+        $itemSession->beginAttempt();
+        $itemSession->endAttempt(
+            new State([
+                new ResponseVariable(
+                    'RESPONSEA',
+                    Cardinality::MULTIPLE,
+                    BaseType::IDENTIFIER,
+                    new MultipleContainer(
+                        BaseType::IDENTIFIER, 
+                        [new QtiIdentifier('ChoiceA'), new QtiIdentifier('ChoiceB')]
+                    )
+                )
+            ])
+        );
+        
+        $this->assertTrue($itemSession->isResponded());
+        $this->assertTrue($itemSession->isResponded(false));
+    }
 }

--- a/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
@@ -31,6 +31,7 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $this->assertFalse($itemSession->isPresented());
         $this->assertFalse($itemSession->isCorrect());
         $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
         $this->assertTrue($itemSession->isSelected());
         
         $itemSession->beginItemSession();
@@ -39,6 +40,7 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $this->assertFalse($itemSession->isPresented());
         $this->assertFalse($itemSession->isCorrect());
         $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
         $this->assertTrue($itemSession->isSelected());
         $this->assertTrue($itemSession->isAttemptable());
         
@@ -102,6 +104,7 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $resp = new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER, new QtiIdentifier('ChoiceB'));
         $itemSession->endAttempt(new State(array($resp)));
         $this->assertTrue($itemSession->isResponded());
+        $this->assertTrue($itemSession->isResponded(false));
         
         // The ItemSessionControl for this session was not specified, it is then
         // the default one, with default values. Because maxAttempts is not specified,
@@ -538,6 +541,7 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $itemSession->endAttempt($responses);
         
         $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
         
         // Respond with an empty string.
         $itemSession->beginAttempt();
@@ -545,6 +549,7 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $itemSession->endAttempt($responses);
         
         $this->assertFalse($itemSession->isResponded());
+        $this->assertFalse($itemSession->isResponded(false));
         
         // Respond with a non-empty string.
         $itemSession->beginAttempt();
@@ -552,6 +557,7 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $itemSession->endAttempt($responses);
         
         $this->assertTrue($itemSession->isResponded());
+        $this->assertTrue($itemSession->isResponded(false));
     }
     
     public function testMultipleAttemptsSimultaneousSubmissionMode()
@@ -653,5 +659,6 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $itemSession->getVariable('RESPONSE')->setDefaultValue(new QtiIdentifier('ChoiceA'));
 
         $this->assertTrue($itemSession->isResponded());
+        $this->assertTrue($itemSession->isResponded(false));
     }
 }

--- a/test/samples/custom/items/is_responded/is_responded_multiple_interactions_multiplechoice_textentry.xml
+++ b/test/samples/custom/items/is_responded/is_responded_multiple_interactions_multiplechoice_textentry.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd" identifier="is_responded_multiple_interactions_multiplechoice_textentry" title="Is Responded Multiple Interactions Multiple Choice and Text Entry" adaptive="false" timeDependent="false">
+    <responseDeclaration identifier="RESPONSEA" cardinality="multiple" baseType="identifier">
+        <correctResponse>
+            <value>ChoiceA</value>
+            <value>ChoiceB</value>
+        </correctResponse>
+        <defaultValue>
+            <value>ChoiceC</value>
+        </defaultValue>
+    </responseDeclaration>
+    <responseDeclaration identifier="RESPONSEB" cardinality="single" baseType="string"/>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
+    <itemBody>
+        <div>
+            <p>An item with 2 interactions (ChoiceInteraction/TextEntryInteraction)</p>
+            
+            <choiceInteraction responseIdentifier="RESPONSEA" shuffle="false" maxChoices="3">
+                <prompt>Select a choice</prompt>
+                <simpleChoice identifier="ChoiceA">Choice A</simpleChoice>
+                <simpleChoice identifier="ChoiceB">Choice B</simpleChoice>
+                <simpleChoice identifier="ChoiceC">Choice C</simpleChoice>
+            </choiceInteraction>
+            
+            Enter some text: <textEntryInteraction responseIdentifier="RESPONSEB"/>
+        </div>
+    </itemBody>
+    <responseProcessing template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct"/>
+</assessmentItem>

--- a/test/samples/custom/items/is_responded/is_responded_multiple_interactions_singlechoice_textentry.xml
+++ b/test/samples/custom/items/is_responded/is_responded_multiple_interactions_singlechoice_textentry.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd" identifier="is_responded_multiple_interactions_singlechoice_textentry" title="Is Responded Multiple Interactions Single Choice and Text Entry" adaptive="false" timeDependent="false">
+    <responseDeclaration identifier="RESPONSEA" cardinality="single" baseType="identifier">
+        <correctResponse>
+            <value>ChoiceA</value>
+        </correctResponse>
+        <defaultValue>
+            <value>ChoiceC</value>
+        </defaultValue>
+    </responseDeclaration>
+    <responseDeclaration identifier="RESPONSEB" cardinality="single" baseType="string"/>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float"/>
+    <itemBody>
+        <div>
+            <p>An item with 2 interactions (ChoiceInteraction/TextEntryInteraction)</p>
+            
+            <choiceInteraction responseIdentifier="RESPONSEA" shuffle="false" maxChoices="1">
+                <prompt>Select a choice</prompt>
+                <simpleChoice identifier="ChoiceA">Choice A</simpleChoice>
+                <simpleChoice identifier="ChoiceB">Choice B</simpleChoice>
+                <simpleChoice identifier="ChoiceC">Choice C</simpleChoice>
+            </choiceInteraction>
+            
+            Enter some text: <textEntryInteraction responseIdentifier="RESPONSEB"/>
+        </div>
+    </itemBody>
+    <responseProcessing template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct"/>
+</assessmentItem>


### PR DESCRIPTION
The QTI specification declares that an itemSession is responded if

- an attempt has been begun
- at least one of the response variable have its value different than its default value

So litterally, the isResponded() method returns whether or not an itemSession is "partially" responded.

This PR enables client code to know wheter or not an itemSession is "fully" responded.