### PR TITLE
GapText is now a flowStaticCollection to allow Math content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "qtism/qtism",
 	"description": "OAT QTI Software Module Library",
 	"type": "library",
-	"version": "0.10.29",
+	"version": "0.11.0",
 	"authors": [
 		{
 			"name": "Open Assessment Technologies S.A.",

--- a/qtism/data/content/interactions/GapText.php
+++ b/qtism/data/content/interactions/GapText.php
@@ -23,31 +23,31 @@
 
 namespace qtism\data\content\interactions;
 
-use qtism\data\content\TextOrVariableCollection;
+use qtism\data\content\FlowStaticCollection;
 use \InvalidArgumentException;
 
 /**
  * From IMS QTI:
- * 
- * A simple run of text to be inserted into a gap by the user, may be subject 
+ *
+ * A simple run of text to be inserted into a gap by the user, may be subject
  * to variable value substitution with printedVariable.
- * 
+ *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  *
  */
 class GapText extends GapChoice {
-    
+
     /**
      * The textOrVariable objects composing the GapText.
-     * 
-     * @var TextOrVariableCollection
+     *
+     * @var FlowStaticCollection
      * @qtism-bean-property
      */
     private $content;
-    
+
     /**
      * Create a new GapText object.
-     * 
+     *
      * @param string $identifier The identifier of the GapText.
      * @param integer $matchMax The matchMax attribute.
      * @param string $id The id of the bodyElement.
@@ -57,36 +57,36 @@ class GapText extends GapChoice {
      */
     public function __construct($identifier, $matchMax, $id = '', $class = '', $lang = '', $label = '') {
         parent::__construct($identifier, $matchMax, $id, $class, $lang, $label);
-        $this->setContent(new TextOrVariableCollection());
+        $this->setContent(new FlowStaticCollection());
     }
-    
+
     /**
-     * Get the textOrVariable objects composing the GapText.
-     * 
-     * @return TextOrVariableCollection
+     * Get the FlowStaticCollection objects composing the GapText.
+     *
+     * @return FlowStaticCollection
      */
     public function getComponents() {
         return $this->getContent();
     }
-    
+
     /**
-     * Set the textOrVariable objects composing the GapText.
-     * 
-     * @param TextOrVariableCollection $content
+     * Set the FlowStaticCollection objects composing the GapText.
+     *
+     * @param FlowStaticCollection $content
      */
-    public function setContent(TextOrVariableCollection $content) {
+    public function setContent(FlowStaticCollection $content) {
         $this->content = $content;
     }
-    
+
     /**
-     * Get the textOrVariable objects composing the GapText.
-     * 
-     * @return TextOrVariableCollection
+     * Get the FlowStaticCollection objects composing the GapText.
+     *
+     * @return FlowStaticCollection
      */
     public function getContent() {
         return $this->content;
     }
-    
+
     public function getQtiClassName() {
         return 'gapText';
     }

--- a/qtism/data/content/interactions/GapText.php
+++ b/qtism/data/content/interactions/GapText.php
@@ -38,7 +38,7 @@ use \InvalidArgumentException;
 class GapText extends GapChoice {
 
     /**
-     * The textOrVariable objects composing the GapText.
+     * The flowStaticCollection objects composing the GapText.
      *
      * @var FlowStaticCollection
      * @qtism-bean-property
@@ -61,7 +61,7 @@ class GapText extends GapChoice {
     }
 
     /**
-     * Get the FlowStaticCollection objects composing the GapText.
+     * Get the flowStaticCollection objects composing the GapText.
      *
      * @return FlowStaticCollection
      */
@@ -70,7 +70,7 @@ class GapText extends GapChoice {
     }
 
     /**
-     * Set the FlowStaticCollection objects composing the GapText.
+     * Set the flowStaticCollection objects composing the GapText.
      *
      * @param FlowStaticCollection $content
      */
@@ -79,7 +79,7 @@ class GapText extends GapChoice {
     }
 
     /**
-     * Get the FlowStaticCollection objects composing the GapText.
+     * Get the flowStaticCollection objects composing the GapText.
      *
      * @return FlowStaticCollection
      */

--- a/qtism/data/content/interactions/GapText.php
+++ b/qtism/data/content/interactions/GapText.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts, <jerome@taotesting.com>
  * @license GPLv2

--- a/qtism/data/storage/xml/marshalling/GapChoiceMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/GapChoiceMarshaller.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts, <jerome@taotesting.com>
  * @license GPLv2
@@ -38,6 +38,38 @@ use \InvalidArgumentException;
  *
  */
 class GapChoiceMarshaller extends ContentMarshaller {
+    
+    private static $gapTextAllowedContent = [
+        'textRun',
+        'printedVariable',
+        'feedbackInline',
+        'templateInline',
+        'math',
+        'include',
+        'img',
+        'br',
+        'object',
+        'em',
+        'a',
+        'code',
+        'span',
+        'sub',
+        'acronym',
+        'big',
+        'tt',
+        'kbd',
+        'q',
+        'i',
+        'dfn',
+        'abbr',
+        'strong',
+        'sup',
+        'var',
+        'small',
+        'samp',
+        'b',
+        'cite'
+    ];
 
     protected function unmarshallChildrenKnown(DOMElement $element, QtiComponentCollection $children) {
 
@@ -78,7 +110,20 @@ class GapChoiceMarshaller extends ContentMarshaller {
 
                 if ($element->localName === 'gapText') {
                     try {
-                        $component->setContent(new FlowStaticCollection($children->getArrayCopy()));
+                        // The allowed set of elements in a gapText (for QTI 2.2) is a subset of FlowStatic.
+                        // Let's make sure that children elements are in this subset.
+                        $childrenArray = $children->getArrayCopy();
+                        
+                        foreach ($childrenArray as $child) {
+                            if (in_array($child->getQtiClassName(), self::$gapTextAllowedContent) === false) {
+                                throw new UnmarshallingException(
+                                    "Element with class '" . $child->getQtiClassName() . "' is not allowed in 'gapText' elements.",
+                                    $element
+                                );
+                            }
+                        }
+                        
+                        $component->setContent(new FlowStaticCollection($childrenArray));
                     }
                     catch (InvalidArgumentException $e) {
                         $msg = "Invalid content in 'gapText' element.";

--- a/qtism/data/storage/xml/marshalling/GapChoiceMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/GapChoiceMarshaller.php
@@ -24,7 +24,6 @@
 
 namespace qtism\data\storage\xml\marshalling;
 
-use qtism\data\content\TextOrVariableCollection;
 use qtism\data\ShowHide;
 use qtism\data\content\FlowStaticCollection;
 use qtism\data\QtiComponentCollection;
@@ -34,20 +33,20 @@ use \InvalidArgumentException;
 
 /**
  * The Marshaller implementation for GapChoice(gapText/gapImg) elements of the content model.
- * 
+ *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  *
  */
 class GapChoiceMarshaller extends ContentMarshaller {
-    
+
     protected function unmarshallChildrenKnown(DOMElement $element, QtiComponentCollection $children) {
-        
+
         if (($identifier = self::getDOMElementAttributeAs($element, 'identifier')) !== null) {
-            
+
             if (($matchMax = self::getDOMElementAttributeAs($element, 'matchMax', 'integer')) !== null) {
-                
+
                 $fqClass = $this->lookupClass($element);
-                
+
                 if ($element->localName === 'gapImg') {
                     if (count($children) === 1) {
                         $component = new $fqClass($identifier, $matchMax, $children[0]);
@@ -60,26 +59,26 @@ class GapChoiceMarshaller extends ContentMarshaller {
                 else {
                     $component = new $fqClass($identifier, $matchMax);
                 }
-                
+
                 if (($matchMin = self::getDOMElementAttributeAs($element, 'matchMin', 'integer')) !== null) {
                     $component->setMatchMin($matchMin);
                 }
-                
+
                 if (($fixed = self::getDOMElementAttributeAs($element, 'fixed', 'boolean')) !== null) {
                     $component->setFixed($fixed);
                 }
-                
+
                 if (($templateIdentifier = self::getDOMElementAttributeAs($element, 'templateIdentifier')) !== null) {
                     $component->setTemplateIdentifier($templateIdentifier);
                 }
-                
+
                 if (($showHide = self::getDOMElementAttributeAs($element, 'showHide')) !== null) {
                     $component->setShowHide(ShowHide::getConstantByName($showHide));
                 }
-                
+
                 if ($element->localName === 'gapText') {
                     try {
-                        $component->setContent(new TextOrVariableCollection($children->getArrayCopy()));
+                        $component->setContent(new FlowStaticCollection($children->getArrayCopy()));
                     }
                     catch (InvalidArgumentException $e) {
                         $msg = "Invalid content in 'gapText' element.";
@@ -91,7 +90,7 @@ class GapChoiceMarshaller extends ContentMarshaller {
                         $component->setObjectLabel($objectLabel);
                     }
                 }
-               
+
                 self::fillBodyElement($component, $element);
                 return $component;
             }
@@ -104,45 +103,45 @@ class GapChoiceMarshaller extends ContentMarshaller {
             $msg = "The mandatory 'identifier' attribute is missing from the 'simpleChoice' element.";
             throw new UnmarshallingException($msg, $element);
         }
-        
-        
+
+
     }
-    
+
     protected function marshallChildrenKnown(QtiComponent $component, array $elements) {
-        
+
         $element = self::getDOMCradle()->createElement($component->getQtiClassName());
         self::fillElement($element, $component);
-        
+
         self::setDOMElementAttribute($element, 'identifier', $component->getIdentifier());
         self::setDOMElementAttribute($element, 'matchMax', $component->getMatchMax());
-        
+
         if ($component->getMatchMin() !== 0) {
             self::setDOMElementAttribute($element, 'matchMin', $matchMin);
         }
-        
+
         if ($component->isFixed() === true) {
             self::setDOMElementAttribute($element, 'fixed', true);
         }
-        
+
         if ($component->hasTemplateIdentifier() === true) {
             self::setDOMElementAttribute($element, 'templateIdentifier', $component->getTemplateIdentifier());
         }
-        
+
         if ($component->getShowHide() !== ShowHide::SHOW) {
             self::setDOMElementAttribute($element, 'showHide', ShowHide::getNameByConstant(ShowHide::HIDE));
         }
-        
+
         if ($element->localName === 'gapImg' && $component->hasObjectLabel() === true) {
             self::setDOMElementAttribute($element, 'objectLabel', $component->getObjectLabel());
         }
-        
+
         foreach ($elements as $e) {
             $element->appendChild($e);
         }
-        
+
         return $element;
     }
-    
+
     protected function setLookupClasses() {
         $this->lookupClasses = array("qtism\\data\\content\\interactions");
     }

--- a/test/qtism/data/storage/xml/XmlAssessmentItemDocumentTest.php
+++ b/test/qtism/data/storage/xml/XmlAssessmentItemDocumentTest.php
@@ -347,6 +347,7 @@ class XmlAssessmentItemDocumentTest extends QtiSmTestCase {
 		    
 		    // Other miscellaneous items...
 		    array(self::samplesDir() . 'custom/items/custom_operator_item.xml'),
+            array(self::samplesDir() . 'custom/items/rich_gap_text.xml')
 		);
 	}
 	

--- a/test/qtism/data/storage/xml/marshalling/GapMatchInteractionMarshallerTest.php
+++ b/test/qtism/data/storage/xml/marshalling/GapMatchInteractionMarshallerTest.php
@@ -10,7 +10,6 @@ use qtism\data\content\BlockStaticCollection;
 use qtism\data\content\interactions\GapImg;
 use qtism\data\content\xhtml\Object;
 use qtism\data\content\TextRun;
-use qtism\data\content\TextOrVariableCollection;
 use qtism\data\content\interactions\GapText;
 
 require_once (dirname(__FILE__) . '/../../../../../QtiSmTestCase.php');
@@ -18,46 +17,46 @@ require_once (dirname(__FILE__) . '/../../../../../QtiSmTestCase.php');
 class GapMatchInteractionMarshallerTest extends QtiSmTestCase {
 
 	public function testMarshall() {
-		
+
 	    $gapText = new GapText('gapText1', 1);
-	    $gapText->setContent(new TextOrVariableCollection(array(new TextRun('This is gapText1'))));
-	    
+	    $gapText->setContent(new \qtism\data\content\FlowStaticCollection(array(new TextRun('This is gapText1'))));
+
 	    $object = new Object("./myimg.png", "image/png");
 	    $gapImg = new GapImg('gapImg1', 1, $object);
-	    
+
 	    $gap1 = new Gap('G1');
 	    $gap2 = new Gap('G2');
-	    
+
 	    $p = new P();
 	    $p->setContent(new InlineCollection(array(new TextRun('A text... '), $gap1, new TextRun(' and an image... '), $gap2)));
-	    
+
 	    $gapMatch = new GapMatchInteraction('RESPONSE', new GapChoiceCollection(array($gapText, $gapImg)), new BlockStaticCollection(array($p)));
-	    
+
         $marshaller = $this->getMarshallerFactory()->createMarshaller($gapMatch);
         $element = $marshaller->marshall($gapMatch);
-        
+
         $dom = new DOMDocument('1.0', 'UTF-8');
         $element = $dom->importNode($element, true);
         $this->assertEquals('<gapMatchInteraction responseIdentifier="RESPONSE"><gapText identifier="gapText1" matchMax="1">This is gapText1</gapText><gapImg identifier="gapImg1" matchMax="1"><object data="./myimg.png" type="image/png"/></gapImg><p>A text... <gap identifier="G1"/> and an image... <gap identifier="G2"/></p></gapMatchInteraction>', $dom->saveXML($element));
 	}
-	
+
 	public function testUnmarshall() {
         $element = $this->createDOMElement('
             <gapMatchInteraction responseIdentifier="RESPONSE"><gapText identifier="gapText1" matchMax="1">This is gapText1</gapText><gapImg identifier="gapImg1" matchMax="1"><object data="./myimg.png" type="image/png"/></gapImg><p>A text... <gap identifier="G1"/> and an image... <gap identifier="G2"/></p></gapMatchInteraction>
         ');
-        
+
         $marshaller = $this->getMarshallerFactory()->createMarshaller($element);
         $gapMatch = $marshaller->unmarshall($element);
-        
+
         $this->assertInstanceOf('qtism\\data\\content\\interactions\\GapMatchInteraction', $gapMatch);
         $this->assertEquals('RESPONSE', $gapMatch->getResponseIdentifier());
         $this->assertFalse($gapMatch->mustShuffle());
-        
+
         $gapChoices = $gapMatch->getGapChoices();
         $this->assertEquals(2, count($gapChoices));
         $this->assertInstanceOf('qtism\\data\\content\\interactions\\GapText', $gapChoices[0]);
         $this->assertInstanceOf('qtism\\data\\content\\interactions\\GapImg', $gapChoices[1]);
-        
+
         $gaps = $gapMatch->getComponentsByClassName('gap');
         $this->assertEquals(2, count($gaps));
         $this->assertEquals('G1', $gaps[0]->getIdentifier());

--- a/test/qtism/data/storage/xml/marshalling/GapTextMarshallerTest.php
+++ b/test/qtism/data/storage/xml/marshalling/GapTextMarshallerTest.php
@@ -1,10 +1,10 @@
 <?php
 
+use qtism\data\content\FlowStaticCollection;
 use qtism\data\ShowHide;
 
 use qtism\data\content\PrintedVariable;
 use qtism\data\content\TextRun;
-use qtism\data\content\TextOrVariableCollection;
 use qtism\data\content\interactions\GapText;
 
 require_once (dirname(__FILE__) . '/../../../../../QtiSmTestCase.php');
@@ -13,24 +13,24 @@ class GapTextMarshallerTest extends QtiSmTestCase {
 
 	public function testMarshall() {
 		$gapText = new GapText('gapText1', 1);
-		$gapText->setContent(new TextOrVariableCollection(array(new TextRun('My var is '), new PrintedVariable('var1'))));
-		
+		$gapText->setContent(new FlowStaticCollection(array(new TextRun('My var is '), new PrintedVariable('var1'))));
+
 	    $marshaller = $this->getMarshallerFactory()->createMarshaller($gapText);
 	    $element = $marshaller->marshall($gapText);
-	    
+
 	    $dom = new DOMDocument('1.0', 'UTF-8');
 	    $element = $dom->importNode($element, true);
 	    $this->assertEquals('<gapText identifier="gapText1" matchMax="1">My var is <printedVariable identifier="var1" base="10" powerForm="false" delimiter=";" mappingIndicator="="/></gapText>', $dom->saveXML($element));
 	}
-	
+
 	public function testUnmarshall() {
 	    $element = $this->createDOMElement('
 	        <gapText identifier="gapText1" matchMax="1">My var is <printedVariable identifier="var1" base="10" powerForm="false" delimiter=";" mappingIndicator="="/></gapText>
 	    ');
-	    
+
 	    $marshaller = $this->getMarshallerFactory()->createMarshaller($element);
 	    $gapText = $marshaller->unmarshall($element);
-	    
+
 	    $this->assertInstanceOf('qtism\\data\\content\\interactions\\GapText', $gapText);
 	    $this->assertEquals('gapText1', $gapText->getIdentifier());
 	    $this->assertEquals(1, $gapText->getMatchMax());
@@ -39,13 +39,13 @@ class GapTextMarshallerTest extends QtiSmTestCase {
 	    $this->assertFalse($gapText->hasTemplateIdentifier());
 	    $this->assertEquals(ShowHide::SHOW, $gapText->getShowHide());
 	}
-	
+
 	public function testUnmarshallInvalid() {
 	    $this->setExpectedException('qtism\\data\\storage\\xml\\marshalling\\UnmarshallingException');
 	    $element = $element = $this->createDOMElement('
 	        <gapText identifier="gapText1" matchMax="1">My var is <strong>invalid</strong>!</gapText>
 	    ');
-	    
+
 	    $element = $this->getMarshallerFactory()->createMarshaller($element)->unmarshall($element);
 	}
 }

--- a/test/qtism/data/storage/xml/marshalling/GapTextMarshallerTest.php
+++ b/test/qtism/data/storage/xml/marshalling/GapTextMarshallerTest.php
@@ -2,7 +2,6 @@
 
 use qtism\data\content\FlowStaticCollection;
 use qtism\data\ShowHide;
-
 use qtism\data\content\PrintedVariable;
 use qtism\data\content\TextRun;
 use qtism\data\content\interactions\GapText;
@@ -39,13 +38,33 @@ class GapTextMarshallerTest extends QtiSmTestCase {
 	    $this->assertFalse($gapText->hasTemplateIdentifier());
 	    $this->assertEquals(ShowHide::SHOW, $gapText->getShowHide());
 	}
-
-	public function testUnmarshallInvalid() {
-	    $this->setExpectedException('qtism\\data\\storage\\xml\\marshalling\\UnmarshallingException');
+    
+    public function testUnmarshallComplexContentForQti22() {
 	    $element = $element = $this->createDOMElement('
 	        <gapText identifier="gapText1" matchMax="1">My var is <strong>invalid</strong>!</gapText>
 	    ');
 
-	    $element = $this->getMarshallerFactory()->createMarshaller($element)->unmarshall($element);
+	    $gapText = $this->getMarshallerFactory()->createMarshaller($element)->unmarshall($element);
+        $this->assertInstanceOf('qtism\\data\\content\\interactions\\GapText', $gapText);
+        $this->assertEquals('gapText1', $gapText->getIdentifier());
+	    $this->assertEquals(1, $gapText->getMatchMax());
+	    $this->assertEquals(0, $gapText->getMatchMin());
+	    $this->assertFalse($gapText->isFixed());
+	    $this->assertFalse($gapText->hasTemplateIdentifier());
+	    $this->assertEquals(ShowHide::SHOW, $gapText->getShowHide());
+        
+        $this->assertCount(3, $gapText->getContent());
+        $this->assertInstanceOf('qtism\\data\\content\\TextRun', $gapText->getContent()[0]);
+        $this->assertInstanceOf('qtism\\data\\content\\xhtml\\text\\Strong', $gapText->getContent()[1]);
+        $this->assertInstanceOf('qtism\\data\\content\\TextRun', $gapText->getContent()[2]);
+	}
+
+	public function testUnmarshallInvalid() {
+	    $this->setExpectedException('qtism\\data\\storage\\xml\\marshalling\\UnmarshallingException');
+	    $element = $element = $this->createDOMElement('
+	        <gapText identifier="gapText1" matchMax="1">My var is <div>invalid</div>!</gapText>
+	    ');
+
+	    $component = $this->getMarshallerFactory()->createMarshaller($element)->unmarshall($element);
 	}
 }

--- a/test/samples/custom/items/rich_gap_text.xml
+++ b/test/samples/custom/items/rich_gap_text.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd" identifier="i1499679982406188" title="Rich Gap match" label="Rich Gap match" xml:lang="en-US" adaptive="false" timeDependent="false" toolName="TAO" toolVersion="3.2.0-sprint55">
+  <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="directedPair"/>
+  <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" normalMaximum="0"/>
+  <outcomeDeclaration identifier="MAXSCORE" cardinality="single" baseType="float">
+    <defaultValue>
+      <value>0</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <itemBody>
+    <div class="grid-row">
+      <div class="col-12">
+        <gapMatchInteraction responseIdentifier="RESPONSE" shuffle="false">
+          <gapText identifier="choice_1" fixed="false" matchMax="1" matchMin="0">
+            <m:math>
+              <m:semantics>
+                <m:mstyle displaystyle="true" scriptlevel="0">
+                  <m:mrow class="MJX-TeXAtom-ORD">
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mrow>
+                        <m:mn>4</m:mn>
+                        <m:mi>x</m:mi>
+                      </m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                </m:mstyle>
+                <m:annotation encoding="latex">\frac{1}{4x}</m:annotation>
+              </m:semantics>
+            </m:math>
+          </gapText>
+          <gapText identifier="choice_2" fixed="false" matchMax="1" matchMin="0">  
+<m:math><m:semantics><m:mstyle displaystyle="true" scriptlevel="0"><m:mrow class="MJX-TeXAtom-ORD"><m:mfrac><m:mn>1</m:mn><m:mrow><m:mn>2</m:mn><m:mi>x</m:mi></m:mrow></m:mfrac></m:mrow></m:mstyle><m:annotation encoding="latex">\frac{1}{2x}</m:annotation></m:semantics></m:math>
+</gapText>
+          <gapText identifier="choice_3" fixed="false" matchMax="1" matchMin="0">
+            <m:math>
+              <m:semantics>
+                <m:mstyle displaystyle="true" scriptlevel="0">
+                  <m:mrow class="MJX-TeXAtom-ORD">
+                    <m:mfrac>
+                      <m:mn>1</m:mn>
+                      <m:mrow>
+                        <m:mn>3</m:mn>
+                        <m:mi>x</m:mi>
+                      </m:mrow>
+                    </m:mfrac>
+                  </m:mrow>
+                </m:mstyle>
+                <m:annotation encoding="latex">\frac{1}{3x}</m:annotation>
+              </m:semantics>
+            </m:math>
+          </gapText>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing formula est: 
+<gap identifier="gap_1" fixed="false" required="false"/>
+</p>
+        </gapMatchInteraction>
+      </div>
+    </div>
+  </itemBody>
+  <responseProcessing template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/match_correct"/>
+</assessmentItem>


### PR DESCRIPTION
This is to implement https://oat-sa.atlassian.net/browse/TAO-4554

Unit test **testUnmarshallInvalid** in **test/qtism/data/storage/xml/marshalling/GapTextMarshallerTest.php** is still failing. I don't know if it should be removed?