### PR TITLE
fixed the individual item weight

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "qtism/qtism",
 	"description": "OAT QTI Software Module Library",
 	"type": "library",
-	"version": "0.11.1",
+	"version": "0.11.2",
 	"authors": [
 		{
 			"name": "Open Assessment Technologies S.A.",

--- a/qtism/runtime/expressions/OutcomeMaximumProcessor.php
+++ b/qtism/runtime/expressions/OutcomeMaximumProcessor.php
@@ -97,7 +97,7 @@ class OutcomeMaximumProcessor extends ItemSubsetProcessor
                     } else {
                         // If any of the items in the given subset have no declared maximum
                         // the result is NULL
-                        return NULL;
+                        return null;
                     }
                 } else {
                    // If any item has no SCORE variable, it may be an informational item with no response processing

--- a/qtism/runtime/expressions/OutcomeMaximumProcessor.php
+++ b/qtism/runtime/expressions/OutcomeMaximumProcessor.php
@@ -95,9 +95,9 @@ class OutcomeMaximumProcessor extends ItemSubsetProcessor
                             $result[] = new QtiFloat(floatval($normalMaximum *= $weight->getValue()));
                         }
                     } else {
-                        // If any of the items in the given subset have no declared maximum, possibly an item require human-based scoring)
-                        // we skip to the next item
-                        continue;
+                        // If any of the items in the given subset have no declared maximum
+                        // the result is NULL
+                        return NULL;
                     }
                 } else {
                    // If any item has no SCORE variable, it may be an informational item with no response processing

--- a/qtism/runtime/expressions/OutcomeMaximumProcessor.php
+++ b/qtism/runtime/expressions/OutcomeMaximumProcessor.php
@@ -96,12 +96,11 @@ class OutcomeMaximumProcessor extends ItemSubsetProcessor
                         }
                     } else {
                         // If any of the items in the given subset have no declared maximum
-                        // the result is NULL
+                        // the result is NULL.
                         return null;
                     }
                 } else {
-                   // If any item has no SCORE variable, it may be an informational item with no response processing
-                   continue;
+                   return null;
                 }
             }
         }

--- a/qtism/runtime/expressions/OutcomeMaximumProcessor.php
+++ b/qtism/runtime/expressions/OutcomeMaximumProcessor.php
@@ -95,12 +95,13 @@ class OutcomeMaximumProcessor extends ItemSubsetProcessor
                             $result[] = new QtiFloat(floatval($normalMaximum *= $weight->getValue()));
                         }
                     } else {
-                        // If any of the items in the given subset have no declared maximum
-                        // the result is NULL.
-                        return null;
+                        // If any of the items in the given subset have no declared maximum, possibly an item require human-based scoring)
+                        // we skip to the next item
+                        continue;
                     }
                 } else {
-                    return null;
+                   // If any item has no SCORE variable, it may be an informational item with no response processing
+                   continue;
                 }
             }
         }

--- a/qtism/runtime/expressions/OutcomeMaximumProcessor.php
+++ b/qtism/runtime/expressions/OutcomeMaximumProcessor.php
@@ -64,7 +64,6 @@ class OutcomeMaximumProcessor extends ItemSubsetProcessor
         $outcomeIdentifier = $this->getExpression()->getOutcomeIdentifier();
         // If no weightIdentifier specified, its value is an empty string ('').
         $weightIdentifier = $this->getExpression()->getWeightIdentifier();
-        $weight = (empty($weightIdentifier) === true) ? false : $testSession->getWeight($weightIdentifier);
         $result = new MultipleContainer(BaseType::FLOAT);
 
         foreach ($itemSubset as $item) {
@@ -82,6 +81,8 @@ class OutcomeMaximumProcessor extends ItemSubsetProcessor
                if (isset($itemSession[$id]) && $itemSession->getVariable($id) instanceof OutcomeVariable) {
 
                     $var = $itemSession->getVariable($id);
+                    $itemRefIdentifier = $itemSession->getAssessmentItem()->getIdentifier();
+                    $weight = (empty($weightIdentifier) === true) ? false : $testSession->getWeight("${itemRefIdentifier}.${weightIdentifier}");
 
                     // Does this OutcomeVariable contain a value for normalMaximum?
                     if (($normalMaximum = $var->getNormalMaximum()) !== false) {

--- a/qtism/runtime/expressions/OutcomeMaximumProcessor.php
+++ b/qtism/runtime/expressions/OutcomeMaximumProcessor.php
@@ -100,7 +100,7 @@ class OutcomeMaximumProcessor extends ItemSubsetProcessor
                         return null;
                     }
                 } else {
-                   return null;
+                    return null;
                 }
             }
         }

--- a/qtism/runtime/expressions/OutcomeMinimumProcessor.php
+++ b/qtism/runtime/expressions/OutcomeMinimumProcessor.php
@@ -59,7 +59,6 @@ class OutcomeMinimumProcessor extends ItemSubsetProcessor
         $outcomeIdentifier = $this->getExpression()->getOutcomeIdentifier();
         // If no weightIdentifier specified, its value is an empty string ('').
         $weightIdentifier = $this->getExpression()->getWeightIdentifier();
-        $weight = (empty($weightIdentifier) === true) ? false : $testSession->getWeight($weightIdentifier);
         $result = new MultipleContainer(BaseType::FLOAT);
 
         foreach ($itemSubset as $item) {
@@ -77,6 +76,8 @@ class OutcomeMinimumProcessor extends ItemSubsetProcessor
                if (isset($itemSession[$id]) && $itemSession->getVariable($id) instanceof OutcomeVariable) {
 
                     $var = $itemSession->getVariable($id);
+                    $itemRefIdentifier = $itemSession->getAssessmentItem()->getIdentifier();
+                    $weight = (empty($weightIdentifier) === true) ? false : $testSession->getWeight("${itemRefIdentifier}.${weightIdentifier}");
 
                     // Does this OutcomeVariable contain a value for normalMaximum?
                     if (($normalMinimum = $var->getNormalMinimum()) !== false) {


### PR DESCRIPTION
This fixes the calculation of the sum of outcome maximum processing.
With this fix, only the items having the same weight identifier used in the outcome rule will have its weight taken into account. Before the fix, the same weight is applied to all items. (code greatly inspired from TestVariablesProcessor which works well)
I have a test sample (the one with the weight) that can be used to test this behaviour, in the JIRA https://oat-sa.atlassian.net/browse/TAO-4687