### PR TITLE
Turn off formatting by default of xml when it saving

### DIFF
--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -242,7 +242,7 @@ class XmlDocument extends QtiDocument
 	 * @param boolean $formatOutput Wether the XML content of the file must be formatted (new lines, indentation) or not.
 	 * @throws \qtism\data\storage\xml\XmlStorageException If an error occurs while transforming the AssessmentTest object to its QTI-XML representation.
 	 */
-    public function save($uri, $formatOutput = true)
+    public function save($uri, $formatOutput = false)
     {
         $this->saveImplementation($uri, $formatOutput);
     }


### PR DESCRIPTION
Hi @bugalot 

Here we found some annoying issue with tags inside items. It happens because during the import SDK processes content and format content (html) by default during this process. And in some cases it produces issues. The issue mostly concerns XInclude part, but I didn't find a way how to change saving only for xinclude parts.

