### PR TITLE
Minor Change To InterpolationTableEntry

### DIFF
--- a/src/qtism/data/state/InterpolationTableEntry.php
+++ b/src/qtism/data/state/InterpolationTableEntry.php
@@ -99,7 +99,7 @@ class InterpolationTableEntry extends QtiComponent
 	 */
     public function setSourceValue($sourceValue)
     {
-        if (is_float($sourceValue)) {
+        if (is_float($sourceValue) || is_double($sourceValue) {
             $this->sourceValue = $sourceValue;
         } else {
             $msg = "SourceValue must be a float value, '" . gettype($sourceValue) . "' given.";


### PR DESCRIPTION
This fixes a thrown exception as sometimes the InterpolationTableEntryMarshaller will occasionally grab the $sourceValue as a double, and since a float and a double in PHP are the same thing.