### PR TITLE
for all `setOutcomeValue` elements in the response processing (templa…

### DIFF
--- a/src/qtism/data/rules/SetOutcomeValue.php
+++ b/src/qtism/data/rules/SetOutcomeValue.php
@@ -45,6 +45,9 @@ use \InvalidArgumentException;
  */
 class SetOutcomeValue extends QtiComponent implements OutcomeRule, ResponseRule
 {
+
+    const CLASS_NAME = 'setOutcomeValue';
+
     /**
 	 * From IMS QTI:
 	 *
@@ -130,7 +133,7 @@ class SetOutcomeValue extends QtiComponent implements OutcomeRule, ResponseRule
 	 */
     public function getQtiClassName()
     {
-        return 'setOutcomeValue';
+        return self::CLASS_NAME;
     }
 
     /**


### PR DESCRIPTION
…te or not) we need to check that the identifier value has a corresponding `outcomeDeclaration`. for that I need this rules.