### PR TITLE
Fix/legacy orderedcontainer count

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "qtism/qtism",
 	"description": "OAT QTI Software Module Library",
 	"type": "library",
-	"version": "0.17.0",
+	"version": "0.17.1",
 	"authors": [
 		{
 			"name": "Open Assessment Technologies S.A.",

--- a/qtism/runtime/common/OrderedContainer.php
+++ b/qtism/runtime/common/OrderedContainer.php
@@ -32,9 +32,8 @@ class OrderedContainer extends MultipleContainer implements QtiDatatype {
 	
 	public function equals($obj) {
 		$countA = count($this);
-		$countB = count($obj);
 		
-		if (gettype($obj) === 'object' && $obj instanceof self && $countA === $countB) {
+		if (gettype($obj) === 'object' && $obj instanceof self && $countA === count($obj)) {
 			for ($i = 0; $i < $countA; $i++) {
 				$objA = $this[$i];
 				$objB = $obj[$i];

--- a/test/qtism/runtime/common/OrderedContainerTest.php
+++ b/test/qtism/runtime/common/OrderedContainerTest.php
@@ -38,6 +38,11 @@ class OrderedContainerTest extends QtiSmTestCase {
 		$this->assertEquals(BaseType::INTEGER, $container->getBaseType());
 		$this->assertEquals(Cardinality::ORDERED, $container->getCardinality());
 	}
+
+    public function testEqualsNull() {
+        $container = new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(10)));
+        $this->assertFalse($container->equals(null));
+    }
 	
 	public function equalsValidProvider() {
 		return array(


### PR DESCRIPTION
This PR prevents a PHP Warning to be yield when OrderContainer::equals() method is called with a non `\Countable` argument.