### PR TITLE
Feature/title labels assessment item refs

### DIFF
--- a/src/qtism/data/ExtendedAssessmentItemRef.php
+++ b/src/qtism/data/ExtendedAssessmentItemRef.php
@@ -22,6 +22,7 @@
 
 namespace qtism\data;
 
+use qtism\common\utils\Format;
 use qtism\data\content\ModalFeedbackRuleCollection;
 use qtism\data\content\ModalFeedbackRule;
 use qtism\data\state\ResponseDeclaration;
@@ -115,7 +116,7 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
     private $modalFeedbackRules;
     
     /**
-     * The template processing found in the referenced assessmentIem.
+     * The template processing found in the referenced assessmentItem.
      * 
      * @var \qtism\data\processing\TemplateProcessing
      * @qtism-bean-property
@@ -141,12 +142,16 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
     private $responseValidityConstraints;
 
     /**
+     * The title found in the referenced assessmentItem.
+     *
      * @var string
      * @qtism-bean-property
      */
     private $title = '';
 
     /**
+     * The label found (if any) in the referenced assessmentItem.
+     *
      * @var string
      * @qtism-bean-property
      */
@@ -594,6 +599,14 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
         return new QtiComponentCollection($components);
     }
 
+    /**
+     * Set the title.
+     *
+     * Set the title found in the referenced assessmentItem.
+     *
+     * @param $title
+     * @throws InvalidArgumentException
+     */
     public function setTitle($title)
     {
         if (gettype($title) === 'string') {
@@ -603,30 +616,66 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
         }
     }
 
+    /**
+     * Get the title.
+     *
+     * Get the title found in the referenced assessmentItem.
+     *
+     * @return string
+     */
     public function getTitle()
     {
         return $this->title;
     }
 
+    /**
+     * Has a title.
+     *
+     * Whether or not a title was found in the referenced assessmentItem.
+     *
+     * @return bool
+     */
     public function hasTitle()
     {
         return !empty($this->getTitle());
     }
 
+    /**
+     * Set the label.
+     *
+     * Set the label found in the referenced assessmentItem.
+     *
+     * @param $label
+     * @throws InvalidArgumentException
+     */
     public function setLabel($label)
     {
-        if (gettype($label) === 'string') {
+        if (Format::isString256($label)) {
             $this->label = $label;
         } else {
-            throw new InvalidArgumentException("The label argument must be a string, '" . gettype($label) . "' given.'");
+            throw new InvalidArgumentException("The label argument must be a string with at most 256 characters.'");
         }
     }
 
+    /**
+     * Get the label.
+     *
+     * Get the label (if any) found in the referenced assessmentItem.
+     *
+     * @return string
+     */
     public function getLabel()
     {
         return $this->label;
     }
 
+    /**
+     * Has a label.
+     *
+     * Whether or not a label was found in the referenced assessmentItem.
+     *
+     * @return bool
+     */
     public function hasLabel()
     {
         return !empty($this->getLabel());

--- a/src/qtism/data/ExtendedAssessmentItemRef.php
+++ b/src/qtism/data/ExtendedAssessmentItemRef.php
@@ -142,9 +142,14 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
 
     /**
      * @var string
+     * @qtism-bean-property
      */
     private $title = '';
 
+    /**
+     * @var string
+     * @qtism-bean-property
+     */
     private $label = '';
 
     /**
@@ -603,6 +608,11 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
         return $this->title;
     }
 
+    public function hasTitle()
+    {
+        return !empty($this->getTitle());
+    }
+
     public function setLabel($label)
     {
         if (gettype($label) === 'string') {
@@ -615,5 +625,10 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
     public function getLabel()
     {
         return $this->label;
+    }
+
+    public function hasLabel()
+    {
+        return !empty($this->getLabel());
     }
 }

--- a/src/qtism/data/ExtendedAssessmentItemRef.php
+++ b/src/qtism/data/ExtendedAssessmentItemRef.php
@@ -141,6 +141,13 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
     private $responseValidityConstraints;
 
     /**
+     * @var string
+     */
+    private $title = '';
+
+    private $label = '';
+
+    /**
      * Create a new instance of CompactAssessmentItem
      *
      * @param string $identifier A QTI Identifier.
@@ -580,5 +587,33 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
         );
 
         return new QtiComponentCollection($components);
+    }
+
+    public function setTitle($title)
+    {
+        if (gettype($title) === 'string') {
+            $this->title = $title;
+        } else {
+            throw new InvalidArgumentException("The title argument must be a string, '" . gettype($title) . "' given.");
+        }
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setLabel($label)
+    {
+        if (gettype($label) === 'string') {
+            $this->label = $label;
+        } else {
+            throw new InvalidArgumentException("The label argument must be a string, '" . gettype($label) . "' given.'");
+        }
+    }
+
+    public function getLabel()
+    {
+        return $this->label;
     }
 }

--- a/src/qtism/data/IAssessmentItem.php
+++ b/src/qtism/data/IAssessmentItem.php
@@ -169,4 +169,14 @@ interface IAssessmentItem extends QtiIdentifiable
      * @return \qtism\data\state\ResponseValidityConstraintCollection
      */
     public function getResponseValidityConstraints();
+
+    public function setTitle($title);
+
+    public function getTitle();
+
+    public function setLabel($label);
+
+    public function getLabel();
+
+    public function hasLabel();
 }

--- a/src/qtism/data/IAssessmentItem.php
+++ b/src/qtism/data/IAssessmentItem.php
@@ -170,13 +170,51 @@ interface IAssessmentItem extends QtiIdentifiable
      */
     public function getResponseValidityConstraints();
 
+
+    /**
+     * Set the title.
+     *
+     * Set the title of the assessmentItem.
+     *
+     * @param string $title
+     * @throws \InvalidArgumentException
+     */
     public function setTitle($title);
 
+    /**
+     * Get the title.
+     *
+     * Get the title of the assessmentItem.
+     *
+     * @return string
+     */
     public function getTitle();
 
+    /**
+     * Set the label.
+     *
+     * Set the label of the assessmentItem
+     *
+     * @param $label
+     * @throws \InvalidArgumentException
+     */
     public function setLabel($label);
 
+    /**
+     * Get the label.
+     *
+     * Get the label of the assessmentItem.
+     *
+     * @return string
+     */
     public function getLabel();
 
+    /**
+     * Has a label.
+     *
+     * Whether or not the assessmentItem has a label.
+     *
+     * @return string
+     */
     public function hasLabel();
 }

--- a/src/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/src/qtism/data/storage/xml/XmlCompactDocument.php
@@ -23,6 +23,7 @@
 namespace qtism\data\storage\xml;
 
 use qtism\common\collections\IdentifierCollection;
+use qtism\data\AssessmentItem;
 use qtism\data\TestFeedbackRef;
 use qtism\data\content\RubricBlockRef;
 use qtism\data\QtiComponentIterator;
@@ -289,7 +290,8 @@ class XmlCompactDocument extends XmlDocument
             // Resolve external documents.
             $doc->xInclude();
             $doc->resolveTemplateLocation();
-            
+
+            /** @var AssessmentItem $item */
             $item = $doc->getDocumentComponent();
 
             foreach ($item->getResponseDeclarations() as $resp) {
@@ -321,6 +323,8 @@ class XmlCompactDocument extends XmlDocument
             $compactAssessmentItemRef->setTimeDependent($item->isTimeDependent());
             $compactAssessmentItemRef->setEndAttemptIdentifiers($item->getEndAttemptIdentifiers());
             $compactAssessmentItemRef->setResponseValidityConstraints($item->getResponseValidityConstraints());
+            $compactAssessmentItemRef->setTitle($item->getTitle());
+            $compactAssessmentItemRef->setLabel($item->getLabel());
         } catch (Exception $e) {
             $msg = "An error occured while unreferencing item reference with identifier '" . $compactAssessmentItemRef->getIdentifier() . "'.";
             throw new XmlStorageException($msg, XmlStorageException::RESOLUTION, $e);

--- a/src/qtism/data/storage/xml/marshalling/ExtendedAssessmentItemRefMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ExtendedAssessmentItemRefMarshaller.php
@@ -95,6 +95,14 @@ class ExtendedAssessmentItemRefMarshaller extends AssessmentItemRefMarshaller
         
         $this->setDOMElementAttribute($element, 'adaptive', $component->isAdaptive());
         $this->setDOMElementAttribute($element, 'timeDependent', $component->isTimeDependent());
+
+        if ($component->hasTitle() === true) {
+            $this->setDOMElementAttribute($element, 'title', $component->getTitle());
+        }
+
+        if ($component->hasLabel() === true) {
+            $this->setDOMElementAttribute($element, 'label', $component->getLabel());
+        }
         
         $endAttemptIdentifiers = $component->getEndAttemptIdentifiers();
         if (count($endAttemptIdentifiers) > 0) {
@@ -213,6 +221,14 @@ class ExtendedAssessmentItemRefMarshaller extends AssessmentItemRefMarshaller
             if (count($identifiersArray) > 0) {
                 $compactAssessmentItemRef->setEndAttemptIdentifiers(new IdentifierCollection($identifiersArray));
             }
+        }
+
+        if (($title = $this->getDOMElementAttributeAs($element, 'title')) !== null) {
+            $compactAssessmentItemRef->setTitle($title);
+        }
+
+        if (($label = $this->getDOMElementAttributeAs($element, 'label')) !== null) {
+            $compactAssessmentItemRef->setLabel($label);
         }
 
         return $compactAssessmentItemRef;

--- a/src/qtism/data/storage/xml/schemes/qticompact_v1p0.xsd
+++ b/src/qtism/data/storage/xml/schemes/qticompact_v1p0.xsd
@@ -23,6 +23,8 @@
 	    			<xs:attribute name="adaptive" default="false" use="optional" type="xs:boolean"/>
 	    			<xs:attribute name="timeDependent" use="required" type="xs:boolean"/>
 	    			<xs:attribute name="endAttemptIdentifiers" use="optional" type="xs:string"/>
+                    <xs:attribute name="title" use="optional" type="xs:string"/>
+                    <xs:attribute name="label" use="optional" type="xs:string"/>
 	    		</xs:extension>
 	    	</xs:complexContent>
 	    </xs:complexType>

--- a/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
@@ -668,4 +668,36 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
             array(self::samplesDir() . 'custom/tests/mixed_assessment_section_refs/test_different_ids.xml')
         );
     }
+
+    public function testCreateFromAssessmentTestTitleAndLabels()
+    {
+        $doc = new XmlDocument('2.1');
+        $file = self::samplesDir() . 'custom/extended_title_label.xml';
+        $doc->load($file);
+        $compactDoc = XmlCompactDocument::createFromXmlAssessmentTestDocument($doc);
+
+        $assessmentItemRefs = $compactDoc->getDocumentComponent()->getComponentsByClassName('assessmentItemRef');
+        $this->assertEquals(3, count($assessmentItemRefs));
+
+        $assessmentItemRef = $assessmentItemRefs[0];
+        $this->assertEquals('Q01', $assessmentItemRef->getIdentifier());
+        $this->assertEquals('Unattended Luggage', $assessmentItemRef->getTitle());
+        $this->assertTrue($assessmentItemRef->hasTitle());
+        $this->assertSame('', $assessmentItemRef->getLabel());
+        $this->assertFalse($assessmentItemRef->hasLabel());
+
+        $assessmentItemRef = $assessmentItemRefs[1];
+        $this->assertEquals('Q02', $assessmentItemRef->getIdentifier());
+        $this->assertEquals('Unattended Luggage', $assessmentItemRef->getTitle());
+        $this->assertTrue($assessmentItemRef->hasTitle());
+        $this->assertEquals('My Label', $assessmentItemRef->getLabel());
+        $this->assertTrue($assessmentItemRef->hasLabel());
+
+        $assessmentItemRef = $assessmentItemRefs[2];
+        $this->assertEquals('Q03', $assessmentItemRef->getIdentifier());
+        $this->assertEquals('Unattended Luggage', $assessmentItemRef->getTitle());
+        $this->assertTrue($assessmentItemRef->hasTitle());
+        $this->assertSame('', $assessmentItemRef->getLabel());
+        $this->assertFalse($assessmentItemRef->hasLabel());
+    }
 }

--- a/test/qtismtest/data/storage/xml/marshalling/ExtendedAssessmentItemRefMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ExtendedAssessmentItemRefMarshallerTest.php
@@ -43,7 +43,36 @@ class ExtendedAssessmentItemRefMarshallerTest extends QtiSmTestCase {
 		$this->assertEquals('Q01', $element->getAttribute('identifier'));
 		$this->assertEquals('./q01.xml', $element->getAttribute('href'));
 		$this->assertEquals('', $element->getAttribute('endAttemptIdentifiers'));
+		$this->assertFalse($element->hasAttribute('title'));
+		$this->assertFalse($element->hasAttribute('label'));
 	}
+
+    public function testMarshallMinimalWithTitle() {
+        $factory = new CompactMarshallerFactory();
+        $component = new ExtendedAssessmentItemRef('Q01', './q01.xml');
+        $component->setTitle('A title');
+        $marshaller = $factory->createMarshaller($component);
+        $element = $marshaller->marshall($component);
+
+        $this->assertInstanceOf('\\DOMElement', $element);
+        $this->assertEquals('assessmentItemRef', $element->nodeName);
+        $this->assertTrue($element->hasAttribute('title'));
+        $this->assertEquals('A title', $element->getAttribute('title'));
+        $this->assertFalse($element->hasAttribute('label'));
+    }
+
+    public function testMarshallMinimalWithLabel() {
+        $factory = new CompactMarshallerFactory();
+        $component = new ExtendedAssessmentItemRef('Q01', './q01.xml');
+        $component->setLabel('A label');
+        $marshaller = $factory->createMarshaller($component);
+        $element = $marshaller->marshall($component);
+
+        $this->assertInstanceOf('\\DOMElement', $element);
+        $this->assertEquals('assessmentItemRef', $element->nodeName);
+        $this->assertTrue($element->hasAttribute('label'));
+        $this->assertEquals('A label', $element->getAttribute('label'));
+    }
 	
 	public function testUnmarshallMinimal() {
 		$factory = new CompactMarshallerFactory();
@@ -61,7 +90,35 @@ class ExtendedAssessmentItemRefMarshallerTest extends QtiSmTestCase {
 		$this->assertEquals('Q01', $component->getIdentifier());
 		$this->assertEquals('./q01.xml', $component->getHref());
 		$this->assertEquals(0, count($component->getEndAttemptIdentifiers()));
+		$this->assertFalse($component->hasTitle());
+		$this->assertFalse($component->hasLabel());
 	}
+
+    public function testUnmarshallMinimalWithTitle() {
+        $factory = new CompactMarshallerFactory();
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML('<assessmentItemRef xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" identifier="Q01" href="./q01.xml" title="A title" timeDependent="false"/>');
+        $element = $dom->documentElement;
+        $marshaller = $factory->createMarshaller($element);
+        $component = $marshaller->unmarshall($element);
+
+        $this->assertInstanceOf('qtism\\data\\ExtendedAssessmentItemRef', $component);
+        $this->assertTrue($component->hasTitle());
+        $this->assertEquals('A title', $component->getTitle());
+    }
+
+    public function testUnmarshallMinimalWithLabel() {
+        $factory = new CompactMarshallerFactory();
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML('<assessmentItemRef xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" identifier="Q01" href="./q01.xml" label="A label" timeDependent="false"/>');
+        $element = $dom->documentElement;
+        $marshaller = $factory->createMarshaller($element);
+        $component = $marshaller->unmarshall($element);
+
+        $this->assertInstanceOf('qtism\\data\\ExtendedAssessmentItemRef', $component);
+        $this->assertTrue($component->hasLabel());
+        $this->assertEquals('A label', $component->getLabel());
+    }
 	
 	/**
 	 * @depends testMarshallMinimal

--- a/test/samples/custom/extended_title_label.xml
+++ b/test/samples/custom/extended_title_label.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+                identifier="extendedTitleLabel" title="Extended Titles and Labels">
+    <testPart identifier="P01" navigationMode="linear" submissionMode="individual">
+        <assessmentSection identifier="S01" title="Section1" visible="true">
+            <assessmentItemRef identifier="Q01" href="items/title_label/title_only.xml"/>
+            <assessmentItemRef identifier="Q02" href="items/title_label/title_and_label.xml"/>
+            <assessmentItemRef identifier="Q03" href="items/title_label/title_and_empty_label.xml"/>
+        </assessmentSection>
+    </testPart>
+</assessmentTest>

--- a/test/samples/custom/items/title_label/title_and_empty_label.xml
+++ b/test/samples/custom/items/title_label/title_and_empty_label.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Thie example adapted from the PET Handbook, copyright University of Cambridge ESOL Examinations -->
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+	identifier="choice" title="Unattended Luggage" label="" adaptive="false" timeDependent="false">
+	<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
+		<correctResponse>
+			<value>ChoiceA</value>
+		</correctResponse>
+	</responseDeclaration>
+	<outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
+		<defaultValue>
+			<value>0</value>
+		</defaultValue>
+	</outcomeDeclaration>
+	<itemBody>
+		<p>Look at the text in the picture.</p>
+		<p>
+			<img src="images/sign.png" alt="NEVER LEAVE LUGGAGE UNATTENDED"/>
+		</p>
+		<choiceInteraction responseIdentifier="RESPONSE" shuffle="false" maxChoices="1">
+			<prompt>What does it say?</prompt>
+			<simpleChoice identifier="ChoiceA">You must stay with your luggage at all times.</simpleChoice>
+			<simpleChoice identifier="ChoiceB">Do not let someone else look after your luggage.</simpleChoice>
+			<simpleChoice identifier="ChoiceC">Remember your luggage when you leave.</simpleChoice>
+		</choiceInteraction>
+	</itemBody>
+	<responseProcessing
+		template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct"/>
+</assessmentItem>

--- a/test/samples/custom/items/title_label/title_and_label.xml
+++ b/test/samples/custom/items/title_label/title_and_label.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Thie example adapted from the PET Handbook, copyright University of Cambridge ESOL Examinations -->
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+	identifier="choice" title="Unattended Luggage" label="My Label" adaptive="false" timeDependent="false">
+	<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
+		<correctResponse>
+			<value>ChoiceA</value>
+		</correctResponse>
+	</responseDeclaration>
+	<outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
+		<defaultValue>
+			<value>0</value>
+		</defaultValue>
+	</outcomeDeclaration>
+	<itemBody>
+		<p>Look at the text in the picture.</p>
+		<p>
+			<img src="images/sign.png" alt="NEVER LEAVE LUGGAGE UNATTENDED"/>
+		</p>
+		<choiceInteraction responseIdentifier="RESPONSE" shuffle="false" maxChoices="1">
+			<prompt>What does it say?</prompt>
+			<simpleChoice identifier="ChoiceA">You must stay with your luggage at all times.</simpleChoice>
+			<simpleChoice identifier="ChoiceB">Do not let someone else look after your luggage.</simpleChoice>
+			<simpleChoice identifier="ChoiceC">Remember your luggage when you leave.</simpleChoice>
+		</choiceInteraction>
+	</itemBody>
+	<responseProcessing
+		template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct"/>
+</assessmentItem>

--- a/test/samples/custom/items/title_label/title_only.xml
+++ b/test/samples/custom/items/title_label/title_only.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Thie example adapted from the PET Handbook, copyright University of Cambridge ESOL Examinations -->
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+	identifier="choice" title="Unattended Luggage" adaptive="false" timeDependent="false">
+	<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
+		<correctResponse>
+			<value>ChoiceA</value>
+		</correctResponse>
+	</responseDeclaration>
+	<outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
+		<defaultValue>
+			<value>0</value>
+		</defaultValue>
+	</outcomeDeclaration>
+	<itemBody>
+		<p>Look at the text in the picture.</p>
+		<p>
+			<img src="images/sign.png" alt="NEVER LEAVE LUGGAGE UNATTENDED"/>
+		</p>
+		<choiceInteraction responseIdentifier="RESPONSE" shuffle="false" maxChoices="1">
+			<prompt>What does it say?</prompt>
+			<simpleChoice identifier="ChoiceA">You must stay with your luggage at all times.</simpleChoice>
+			<simpleChoice identifier="ChoiceB">Do not let someone else look after your luggage.</simpleChoice>
+			<simpleChoice identifier="ChoiceC">Remember your luggage when you leave.</simpleChoice>
+		</choiceInteraction>
+	</itemBody>
+	<responseProcessing
+		template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct"/>
+</assessmentItem>


### PR DESCRIPTION
This PR aims at bringing back `assessmentItem->title` and `assessmentItem->label` attribute values at the `assessmentItemRef` level while compacting `assessmentTest` documents.