### PR TITLE
Feature/result sdk master

### DIFF
--- a/src/qtism/data/results/AssessmentResult.php
+++ b/src/qtism/data/results/AssessmentResult.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+
+/**
+ * Class AssessmentResult
+ *
+ * This is the root class to contain the assessment result data. An Assessment Result
+ * is used to report the results of a candidate's interaction with a test and/or one or more items attempted.
+ * Information about the test is optional, in some systems it may be possible to interact
+ * with items that are not organized into a test at all. For example, items that are organized
+ * with learning resources and presented individually in a formative context.
+ *
+ * @package qtism\data\results
+ */
+class AssessmentResult extends QtiComponent
+{
+    /**
+     * Contains the contextual information for the associated itemTest and itemResults. Contextual information must be supplied.
+     *
+     * Multiplicity [1]
+     * @var Context
+     */
+    protected $context;
+
+    /**
+     * A summary report for a test is represented by an assessment result containing a testResult but no itemResults.
+     *
+     * Multiplicity [0,1]
+     * @var TestResult
+     */
+    protected $testResult=null;
+
+    /**
+     * When a test result is given the following item results must relate only to items
+     * that were selected for presentation as part of the corresponding test session.
+     * Furthermore, all items selected for presentation should be reported with a corresponding itemResult.
+     *
+     * Multiplicity [0,*]
+     * @var ItemResultCollection
+     */
+    protected $itemResults=null;
+
+    /**
+     * AssessmentResult constructor.
+     *
+     * A xml representation of QTI test results. ItemResults and TestResults are optionals
+     *
+     * @param Context $context
+     * @param TestResult|null $testResult
+     * @param ItemResultCollection|null $itemResults
+     */
+    public function __construct(Context $context, TestResult $testResult=null, ItemResultCollection $itemResults=null)
+    {
+        $this->setContext($context);
+        $this->setTestResult($testResult);
+        $this->setItemResults($itemResults);
+    }
+
+    /**
+     * Returns the QTI class name as per QTI 2.1 specification.
+     *
+     * @return string A QTI class name.
+     */
+    public function getQtiClassName()
+    {
+        return 'assessmentResult';
+    }
+
+    /**
+     * Get the direct child components of this one.
+     *
+     * @return QtiComponentCollection A collection of QtiComponent objects.
+     */
+    public function getComponents()
+    {
+        $components = [
+            $this->getContext(),
+        ];
+
+        if ($this->hasTestResult()) {
+            $components[] = $this->getTestResult();
+        }
+
+        if ($this->hasItemResults()) {
+            $components[] = $this->getItemResults()->getArrayCopy();
+        }
+
+        return new QtiComponentCollection($components);
+    }
+
+    /**
+     * Get the context of assessment results.
+     *
+     * Contains data that identify session, candidate and deliveryExecution
+     *
+     * @return Context
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * Set the context
+     *
+     * @param Context $context
+     * @return $this
+     */
+    public function setContext(Context $context)
+    {
+        $this->context = $context;
+        return $this;
+    }
+
+    /**
+     * Get the test result
+     *
+     * @return TestResult
+     */
+    public function getTestResult()
+    {
+        return $this->testResult;
+    }
+
+    /**
+     * Set the test result
+     *
+     * @param TestResult $testResult
+     * @return $this
+     */
+    public function setTestResult(TestResult $testResult=null)
+    {
+        $this->testResult = $testResult;
+        return $this;
+    }
+
+    /**
+     * Check if a test result has been set for current result
+     *
+     * @return bool
+     */
+    public function hasTestResult()
+    {
+        return !is_null($this->testResult);
+    }
+
+    /**
+     * Get the item results
+     *
+     * @return ItemResultCollection
+     */
+    public function getItemResults()
+    {
+        return $this->itemResults;
+    }
+
+    /**
+     * Set item resutls
+     *
+     * @param ItemResultCollection|null $itemResults
+     * @return $this
+     */
+    public function setItemResults(ItemResultCollection $itemResults=null)
+    {
+        $this->itemResults = $itemResults;
+        return $this;
+    }
+
+    /**
+     * Check if item results has been set for current result
+     *
+     * @return bool
+     */
+    public function hasItemResults()
+    {
+        return !is_null($this->itemResults);
+    }
+
+}

--- a/src/qtism/data/results/CandidateResponse.php
+++ b/src/qtism/data/results/CandidateResponse.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+use qtism\data\state\ValueCollection;
+
+/**
+ * Class CandidateResponse
+ *
+ * The response given by the candidate.
+ *
+ * @package qtism\data\results
+ */
+class CandidateResponse extends QtiComponent
+{
+    /**
+     * The value(s) of the response variable. A NULL value, resulting from no response, is indicated by the absence of any value.
+     * The order of the values is significant only if the response was declared with ordered cardinality.
+     *
+     * Multiplicity [0,*]
+     * @var ValueCollection
+     */
+    protected $values=null;
+
+    /**
+     * CandidateResponse constructor.
+     *
+     * @param ValueCollection|null $values
+     */
+    public function __construct(ValueCollection $values=null)
+    {
+        $this->setValues($values);
+    }
+
+    /**
+     * Returns the QTI class name as per QTI 2.1 specification.
+     *
+     * @return string A QTI class name.
+     */
+    public function getQtiClassName()
+    {
+        return 'candidateResponse';
+    }
+
+    /**
+     * Get the direct child components of this one.
+     *
+     * @return QtiComponentCollection A collection of QtiComponent objects.
+     */
+    public function getComponents()
+    {
+        $components = [];
+        if ($this->hasValues()) {
+            $components = $this->getValues()->getArrayCopy();
+        }
+        return new QtiComponentCollection($components);
+    }
+
+    /**
+     * Get candidate response values
+     *
+     * @return ValueCollection
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
+     * Set candidate response values
+     *
+     * @param ValueCollection|null $values
+     * @return $this
+     */
+    public function setValues(ValueCollection $values=null)
+    {
+        $this->values = $values;
+        return $this;
+    }
+
+    /**
+     * Check if the candidate response has values
+     *
+     * @return bool
+     */
+    public function hasValues()
+    {
+        return !is_null($this->values);
+    }
+}

--- a/src/qtism/data/results/Context.php
+++ b/src/qtism/data/results/Context.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+
+/**
+ * Class Context
+ *
+ * This is the context for the 'assessmentResult'. It provides the corresponding set of identifiers.
+ *
+ * @package qtism\data\results
+ */
+class Context extends QtiComponent
+{
+    /**
+     * A unique identifier for the test candidate. The attribute is defined by the IMS Learning Information Services specification [LIS, 13].
+     *
+     * Multiplicity [0,1]
+     * @var QtiIdentifier
+     */
+    protected $sourcedId;
+
+    /**
+     * The system that creates the result (for example, the test delivery system) should assign a session identifier
+     * that it can use to identify the session. Subsequent systems that process the result might assign their own identifier
+     * to the session which should be added to the context if the result is modified and exported for transport again.
+     *
+     * Multiplicity [0,*]
+     * @var SessionIdentifierCollection
+     */
+    protected $sessionIdentifiers;
+
+    /**
+     * Context constructor.
+     *
+     * Xml representation of Result Context
+     *
+     * @param QtiIdentifier|null $sourcedId
+     * @param SessionIdentifierCollection|null $sessionIdentifiers
+     */
+    public function __construct(QtiIdentifier $sourcedId=null, SessionIdentifierCollection $sessionIdentifiers=null)
+    {
+        $this->setSourcedId($sourcedId);
+        $this->setSessionIdentifiers($sessionIdentifiers);
+    }
+
+    /**
+     * Returns the QTI class name as per QTI 2.1 specification.
+     *
+     * @return string A QTI class name.
+     */
+    public function getQtiClassName()
+    {
+        return 'context';
+    }
+
+    /**
+     * Get the direct child components of this one.
+     *
+     * @return QtiComponentCollection A collection of QtiComponent objects.
+     */
+    public function getComponents()
+    {
+        if ($this->hasSessionIdentifiers()) {
+            $components = $this->getSessionIdentifiers()->getArrayCopy();
+        } else {
+            $components = [];
+        }
+        return new QtiComponentCollection($components);
+    }
+
+    /**
+     * Get the sourcedId of the context
+     *
+     * @return QtiIdentifier
+     */
+    public function getSourcedId()
+    {
+        return $this->sourcedId;
+    }
+
+    /**
+     * Set the sourced id of the context
+     *
+     * @param QtiIdentifier $sourcedId
+     * @return $this
+     */
+    public function setSourcedId(QtiIdentifier $sourcedId=null)
+    {
+        $this->sourcedId = $sourcedId;
+        return $this;
+    }
+
+    /**
+     * Check if the context has a sourced id
+     *
+     * @return bool
+     */
+    public function hasSourcedId()
+    {
+        return !is_null($this->sourcedId);
+    }
+
+    /**
+     * Get session identifiers of context
+     *
+     * @return SessionIdentifierCollection
+     */
+    public function getSessionIdentifiers()
+    {
+        return $this->sessionIdentifiers;
+    }
+    
+    /**
+     * Set the Session identifiers
+     *
+     * @param $sessionIdentifiers
+     * @return $this
+     */
+    public function setSessionIdentifiers(SessionIdentifierCollection $sessionIdentifiers=null)
+    {
+        $this->sessionIdentifiers = $sessionIdentifiers;
+        return $this;
+    }
+
+    /**
+     * Check if the context has session identifiers
+     *
+     * @return bool
+     */
+    public function hasSessionIdentifiers()
+    {
+        return !is_null($this->sessionIdentifiers);
+    }
+
+}

--- a/src/qtism/data/results/ItemResult.php
+++ b/src/qtism/data/results/ItemResult.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use DateTime;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiInteger;
+use qtism\common\datatypes\QtiString;
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+use qtism\runtime\common\VariableCollection;
+
+/**
+ * Class ItemResult
+ *
+ * The result of an item session is reported with an itemResult.
+ * A report may contain multiple results for the same instance of an item representing multiple attempts,
+ * progression through an adaptive item or even more detailed tracking. In these cases, each item result must have a different datestamp.
+ *
+ * @package qtism\data\results
+ */
+class ItemResult extends QtiComponent
+{
+    /**
+     * The identifier of the item for which this is a result. For item results that are reported as part of a test result
+     * this is the identifier used to refer to the item in the test (see assessmentItemRef).
+     * For item results that are reported on their own, this can be any suitable identifier for the item.
+     * Where possible, the value should match the identifier attribute on the associated assessmentItem.
+     *
+     * Multiplicity [1]
+     * @var QtiIdentifier
+     */
+    protected $identifier;
+
+    /**
+     * For item results that are reported as part of a test, this attribute must be used to indicate the position of the item
+     * within the specific instance of the test. The first item of the first part of the test is defined to have sequence index 1.
+     *
+     * Multiplicity [0,1]
+     * @var QtiInteger
+     */
+    protected $sequenceIndex=null;
+
+    /**
+     * The date stamp of when this result was recorded.
+     *
+     * Multiplicity [1]
+     * @var DateTime
+     */
+    protected $datestamp;
+
+    /**
+     * The session status is used to interpret the values of the item variables. See the sessionStatus vocabulary.
+     *
+     * Multiplicity [1]
+     * @var SessionStatus = Enumerated value set of: {
+     *  - final 	The value to use when the item variables represent the values at the end of an attempt after response processing has taken place.
+     *              In other words, after the outcome values have been updated to reflect the values of the response variables.
+     *  - initial 	The value to use for sessions in the initial state, as described above. This value can only be used to describe sessions
+     *              for which the response variable numAttempts is 0. The values of the variables are set according to the rules
+     *              defined in the appropriate declarations (see responseDeclaration, outcomeDeclaration and templateDeclaration).
+     *  - pendingResponseProcessing 	The value to use when the item variables represent the values of the response variables after submission
+     *                                  but before response processing has taken place. Again, the outcomes are those assigned at the end of the previous attempt
+     *                                  as they are awaiting response processing.
+     *  - pendingSubmission 	The value to use when the item variables represent a snapshot of the current values during an attempt
+     *                          (in other words, while interacting or suspended). The values of the response variables represent work in progress
+     *                          that has not yet been submitted for response processing by the candidate. The values of the outcome variables represent
+     *                          the values assigned during response processing at the end of the previous attempt or, in the case of the first attempt,
+     *                          the default values given in the variable declarations.
+     * }
+     */
+    protected $sessionStatus;
+
+    /**
+     * During the item session the delivery engine keeps track of the current values assigned to all itemVariables.
+     * The values include the values of the built-in variables numAttempts, duration and completionStatus.
+     * Each value is represented in the report by an instance of itemVariable.
+     *
+     * Multiplicity [0,*]
+     * @var VariableCollection
+     */
+    protected $itemVariables=null;
+
+    /**
+     * An optional comment supplied by the candidate (see the allowComment in the ASI documentation [QTI, 15a]).
+     *
+     * Multiplicity [0,1]
+     * @var QtiString
+     */
+    protected $candidateComment=null;
+
+    /**
+     * ItemResult constructor.
+     *
+     * @param QtiIdentifier $identifier
+     * @param DateTime $datestamp
+     * @param $sessionStatus
+     * @param ItemVariableCollection|null $itemVariables
+     * @param QtiString|null $candidateComment
+     * @param QtiInteger|null $sequenceIndex
+     */
+    public function __construct(
+        QtiIdentifier $identifier,
+        DateTime $datestamp,
+        $sessionStatus,
+        ItemVariableCollection $itemVariables=null,
+        QtiString $candidateComment=null,
+        QtiInteger $sequenceIndex=null
+    ) {
+        $this->setIdentifier($identifier);
+        $this->setDatestamp($datestamp);
+        $this->setSessionStatus($sessionStatus);
+        $this->setItemVariables($itemVariables);
+        $this->setCandidateComment($candidateComment);
+        $this->setSequenceIndex($sequenceIndex);
+    }
+
+    /**
+     * Returns the QTI class name as per QTI 2.1 specification.
+     *
+     * @return string A QTI class name.
+     */
+    public function getQtiClassName()
+    {
+        return 'itemResult';
+    }
+
+    /**
+     * Get the direct child components of this one.
+     *
+     * @return QtiComponentCollection A collection of QtiComponent objects.
+     */
+    public function getComponents()
+    {
+        if ($this->hasItemVariables()) {
+            $components = $this->getItemVariables()->toArray();
+        } else {
+            $components = [];
+        }
+        return new QtiComponentCollection($components);
+    }
+
+    /**
+     * Get the Qti identifier of itemResult
+     *
+     * @return QtiIdentifier
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Set the identifier to itemResult component
+     *
+     * @param QtiIdentifier $identifier
+     * @return $this
+     */
+    public function setIdentifier(QtiIdentifier $identifier)
+    {
+        $this->identifier = $identifier;
+        return $this;
+    }
+
+    /**
+     * The date stamp of when this result was recorded.
+     *
+     * @return DateTime
+     */
+    public function getDatestamp()
+    {
+        return $this->datestamp;
+    }
+
+    /**
+     * Set the datestamp that must be a Datetime object
+     *
+     * @param DateTime $datestamp
+     * @return $this
+     */
+    public function setDatestamp(DateTime $datestamp)
+    {
+        $this->datestamp = $datestamp;
+        return $this;
+    }
+
+    /**
+     * Get all test variables. Can be outcome, response, candidate or tempalte variable
+     *
+     * @return mixed
+     */
+    public function getItemVariables()
+    {
+        return $this->itemVariables;
+    }
+
+    /**
+     * Set all test variables
+     *
+     * @param ItemVariableCollection $itemVariables
+     * @return $this
+     */
+    public function setItemVariables(ItemVariableCollection $itemVariables=null)
+    {
+        $this->itemVariables = $itemVariables;
+        return $this;
+    }
+
+    /**
+     * Check if the item result has item variables
+     *
+     * @return bool
+     */
+    public function hasItemVariables()
+    {
+        return !is_null($this->itemVariables);
+    }
+
+    /**
+     * Get the sequence of the item e.g. the position of the item in a test
+     *
+     * @return QtiInteger
+     */
+    public function getSequenceIndex()
+    {
+        return $this->sequenceIndex;
+    }
+
+    /**
+     * Set the sequence of the item or null if not set
+     *
+     * @param QtiInteger|null $sequenceIndex
+     * @return $this
+     */
+    public function setSequenceIndex(QtiInteger $sequenceIndex=null)
+    {
+        $this->sequenceIndex = $sequenceIndex;
+        return $this;
+    }
+
+    /**
+     * Check if the sequence index is set
+     *
+     * @return bool
+     */
+    public function hasSequenceIndex()
+    {
+        return !is_null($this->sequenceIndex);
+    }
+
+    /**
+     * Get the session status of itemResult.
+     * @return SessionStatus
+     */
+    public function getSessionStatus()
+    {
+        return $this->sessionStatus;
+    }
+
+    /**
+     * Set the session status of itemResult.
+     *
+     * @param $sessionStatus
+     * @return $this
+     *
+     * @throws \InvalidArgumentException If the sessionStatus is not a valid sessionStatus
+     */
+    public function setSessionStatus($sessionStatus)
+    {
+        $sessionStatus = intval($sessionStatus);
+        if (!in_array($sessionStatus, SessionStatus::asArray())) {
+            $msg = sprintf('Invalid session status. Should be one of "%s"', implode('", "', SessionStatus::asArray()));
+            throw new \InvalidArgumentException($msg);
+        }
+        $this->sessionStatus = $sessionStatus;
+        return $this;
+    }
+
+    /**
+     * Get the optional candidate comment or null if not set
+     *
+     * @return string
+     */
+    public function getCandidateComment()
+    {
+        return $this->candidateComment;
+    }
+
+    /**
+     * Set the candidate comment
+     *
+     * @param QtiString $candidateComment
+     * @return $this
+     */
+    public function setCandidateComment(QtiString $candidateComment=null)
+    {
+        $this->candidateComment = $candidateComment;
+        return $this;
+    }
+
+    /**
+     * Check if the candidate comment is set
+     *
+     * @return bool
+     */
+    public function hasCandidateComment()
+    {
+        return !is_null($this->candidateComment);
+    }
+
+}

--- a/src/qtism/data/results/ItemResultCollection.php
+++ b/src/qtism/data/results/ItemResultCollection.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\data\QtiComponentCollection;
+
+class ItemResultCollection extends QtiComponentCollection
+{
+    /**
+     * Check if a given $value is an instance of ItemResult.
+     *
+     * @throws InvalidArgumentException If the given $value is not an instance of ItemResult.
+     */
+    protected function checkType($value)
+    {
+        if (!$value instanceof ItemResult) {
+            throw new \InvalidArgumentException(sprintf(
+                "ItemResultCollection only accepts to store ItemResult objects, '%s' given.",
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
+    }
+}

--- a/src/qtism/data/results/ItemVariable.php
+++ b/src/qtism/data/results/ItemVariable.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ *
+ */
+
+namespace qtism\data\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\QtiComponent;
+use qtism\common\enums\Cardinality;
+use qtism\common\enums\BaseType;
+use \InvalidArgumentException;
+
+/**
+ * Class Variable
+ *
+ * The Item result information related to a { Response | Outcome | Template } variable.
+ *
+ * @package qtism\data\results
+ */
+abstract class ItemVariable extends QtiComponent
+{
+    /**
+     * The identifier of the variable.
+     *
+     * Multiplicity [1]
+     * @var QtiIdentifier
+     */
+    private $identifier;
+
+    /**
+     * The cardinality of the variable, taken from the corresponding declaration or definition.
+     *
+     * Multiplicity [1]
+     * @var integer
+     */
+    private $cardinality;
+
+    /**
+     * The baseType of the variable, taken from the corresponding declaration of definition.
+     * This value is omitted only for variables with record cardinality.
+     *
+     * Multiplicity [0,1]
+     * @var integer
+     */
+    private $baseType=null;
+
+    /**
+     * Variable constructor.
+     *
+     * @param $identifier
+     * @param $cardinality
+     * @param int $baseType
+     */
+    public function __construct(QtiIdentifier $identifier, $cardinality, $baseType=null)
+    {
+        $this->setIdentifier($identifier);
+        $this->setCardinality($cardinality);
+        $this->setBaseType($baseType);
+    }
+
+    /**
+     * Get the identifier of the Variable.
+     *
+     * @return QtiIdentifier An identifier.
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Get the identifier of the Variable.
+     *
+     * @param QtiIdentifier $identifier
+     * @return $this
+     */
+    public function setIdentifier(QtiIdentifier $identifier)
+    {
+        $this->identifier = $identifier;
+        return $this;
+    }
+
+    /**
+     * Get the cardinality of the Variable.
+     *
+     * @return integer
+     */
+    public function getCardinality()
+    {
+        return $this->cardinality;
+    }
+
+    /**
+     * Set the cardinality of the Variable.
+     *
+     * @param string $cardinality
+     * @return $this
+     *
+     * @throws InvalidArgumentException If the Cardinality is invalid
+     */
+    public function setCardinality($cardinality)
+    {
+        if (!in_array($cardinality, Cardinality::asArray())) {
+            $msg = sprintf('Invalid Cardinality. Should be one of "%s"', implode('", "', Cardinality::asArray()));
+            throw new InvalidArgumentException($msg);
+        }
+        $this->cardinality = $cardinality;
+        return $this;
+    }
+
+    /**
+     * Get the baseType of the Variable.
+     *
+     * @return integer A value from the Cardinality enumeration.
+     */
+    public function getBaseType()
+    {
+        return $this->baseType;
+    }
+
+    /**
+     * Set the baseType of the Variable.
+     *
+     * @param string $baseType
+     * @return $this
+     *
+     * @throws InvalidArgumentException If the baseType is invalid
+     */
+    public function setBaseType($baseType=null)
+    {
+        if (!is_null($baseType) && !in_array($baseType, BaseType::asArray())) {
+            $msg = sprintf('Invalid baseType. Should be one of "%s"', implode('", "', BaseType::asArray()));
+            throw new InvalidArgumentException($msg);
+        }
+        $this->baseType = $baseType;
+        return $this;
+    }
+
+    /**
+     * Check if variable has a baseType
+     *
+     * @return bool
+     */
+    public function hasBaseType()
+    {
+        return !is_null($this->baseType);
+    }
+}

--- a/src/qtism/data/results/ItemVariableCollection.php
+++ b/src/qtism/data/results/ItemVariableCollection.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\data\QtiComponentCollection;
+
+class ItemVariableCollection extends QtiComponentCollection
+{
+    /**
+     * Check if a given $value is an instance of ItemResult.
+     *
+     * @throws \InvalidArgumentException If the given $value is not an instance of ItemResult.
+     */
+    protected function checkType($value)
+    {
+        if (!$value instanceof ItemVariable) {
+            throw new \InvalidArgumentException(sprintf(
+                "ItemVariableCollection only accepts to store ItemVariable objects, '%s' given.",
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
+    }
+}

--- a/src/qtism/data/results/ResultOutcomeVariable.php
+++ b/src/qtism/data/results/ResultOutcomeVariable.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\common\datatypes\QtiFloat;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiString;
+use qtism\common\datatypes\QtiUri;
+use qtism\data\QtiComponentCollection;
+use qtism\data\state\ValueCollection;
+use qtism\data\View;
+
+/**
+ * Class ResultOutcomeVariable
+ *
+ * The Item result information related to a 'Outcome Variable'.
+ *
+ * @package qtism\data\results
+ */
+class ResultOutcomeVariable extends ItemVariable
+{
+    /**
+     * The views (if any) declared for the outcome must be copied to the report to enable systems that render the report
+     * to hide information not relevant in a specific situation. If no values are given, the outcome's value should be considered relevant in all views.
+     *
+     * Multiplicity [0,1]
+     * @var integer
+     */
+    protected $view=null;
+
+    /**
+     * A human readable interpretation of the default value.
+     *
+     * Multiplicity [0,1]
+     * @var QtiString
+     */
+    protected $interpretation=null;
+
+    /**
+     * An optional link to an extended interpretation of the outcome variable's value.
+     *
+     * Multiplicity [0,1]
+     * @var QtiUri
+     */
+    protected $longInterpretation=null;
+
+    /**
+     * The normalMaximum attribute optionally defines the maximum magnitude of numeric outcome variables, it must be a positive value.
+     * If given, the outcome's value can be divided by normalMaximum and then truncated (if necessary) to obtain a normalized score
+     * in the range [-1.0,1.0]. normalMaximum has no affect on responseProcessing or the values that the outcome variable itself can take.
+     *
+     * Multiplicity [0,1]
+     * @var QtiFloat
+     */
+    protected $normalMaximum=null;
+
+    /**
+     * The normalMinimum attribute optionally defines the minimum value of numeric outcome variables, it may be negative.
+     *
+     * Multiplicity [0,1]
+     * @var QtiFloat
+     */
+    protected $normalMinimum=null;
+
+    /**
+     * The masteryValue attribute optionally defines a value for numeric outcome variables above
+     * which the aspect being measured is considered to have been mastered by the candidate.
+     *
+     * Multiplicity [0,1]
+     * @var QtiFloat
+     */
+    protected $masteryValue=null;
+
+    /**
+     * The value(s) of the outcome variable. The order of the values is significant only if the outcome was declared with ordered cardinality.
+     *
+     * Multiplicity [0,*]
+     * @var ValueCollection
+     */
+    protected $values=null;
+
+    /**
+     * ResultOutcomeVariable constructor.
+     *
+     * @param QtiIdentifier $identifier
+     * @param $cardinality
+     * @param null $baseType
+     * @param null|ValueCollection $values
+     * @param null $view
+     * @param QtiString|null $interpretation
+     * @param QtiUri|null $longInterpretation
+     * @param QtiFloat|null $normalMaximum
+     * @param QtiFloat|null $normalMinimum
+     * @param QtiFloat|null $masteryValue
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(
+        QtiIdentifier $identifier,
+        $cardinality,
+        $baseType=null,
+        ValueCollection $values=null,
+        $view=null,
+        QtiString $interpretation=null,
+        QtiUri $longInterpretation=null,
+        QtiFloat $normalMaximum=null,
+        QtiFloat $normalMinimum=null,
+        QtiFloat $masteryValue=null
+    ) {
+        parent::__construct($identifier, $cardinality, $baseType);
+        $this->setValues($values);
+        $this->setView($view);
+        $this->setInterpretation($interpretation);
+        $this->setLongInterpretation($longInterpretation);
+        $this->setNormalMaximum($normalMaximum);
+        $this->setNormalMinimum($normalMinimum);
+        $this->setMasteryValue($masteryValue);
+    }
+
+    /**
+     * Returns the QTI class name as per QTI 2.1 specification.
+     *
+     * @return string A QTI class name.
+     */
+    public function getQtiClassName()
+    {
+        return 'outcomeVariable';
+    }
+
+    /**
+     * Get the direct child components of this one.
+     *
+     * @return QtiComponentCollection A collection of QtiComponent objects.
+     */
+    public function getComponents()
+    {
+        $components = [];
+        if ($this->hasValues()) {
+            $components = $this->getValues()->getArrayCopy();
+        }
+        return new QtiComponentCollection($components);
+    }
+
+    /**
+     * Get the outcome values
+     *
+     * @return ValueCollection
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
+     * Set the outcome values
+     *
+     * @param ValueCollection $values
+     * @return $this
+     */
+    public function setValues(ValueCollection $values=null)
+    {
+        $this->values = $values;
+        return $this;
+    }
+
+    /**
+     * Check if the values are set
+     *
+     * @return bool
+     */
+    public function hasValues()
+    {
+        return !is_null($this->values);
+    }
+
+    /**
+     * Get the view
+     *
+     * @return integer
+     */
+    public function getView()
+    {
+        return $this->view;
+    }
+
+    /**
+     * Set the view
+     *
+     * @param $view
+     * @return $this
+     * @throws \InvalidArgumentException
+     */
+    public function setView($view=null)
+    {
+        if (!is_null($view) && !in_array($view, View::asArray())) {
+            $msg = sprintf('Invalid View. Should be one of "%s"', implode('", "', View::asArray()));
+            throw new \InvalidArgumentException($msg);
+        }
+        $this->view = $view;
+        return $this;
+    }
+
+    /**
+     * Check if the view is set
+     *
+     * @return bool
+     */
+    public function hasView()
+    {
+        return !is_null($this->view);
+    }
+
+    /**
+     * Set the interpretation
+     *
+     * @return QtiString
+     */
+    public function getInterpretation()
+    {
+        return $this->interpretation;
+    }
+
+    /**
+     * Get the interpretation
+     *
+     * @param QtiString $interpretation
+     * @return $this
+     */
+    public function setInterpretation(QtiString $interpretation=null)
+    {
+        $this->interpretation = $interpretation;
+        return $this;
+    }
+
+    /**
+     * Check if the interpretation is set
+     *
+     * @return bool
+     */
+    public function hasInterpretation()
+    {
+        return !is_null($this->interpretation);
+    }
+
+    /**
+     * Get the long interpretation
+     *
+     * @return QtiUri
+     */
+    public function getLongInterpretation()
+    {
+        return $this->longInterpretation;
+    }
+
+    /**
+     * Set the long interpretation
+     *
+     * @param QtiUri $longInterpretation
+     * @return $this
+     */
+    public function setLongInterpretation(QtiUri $longInterpretation=null)
+    {
+        $this->longInterpretation = $longInterpretation;
+        return $this;
+    }
+
+    /**
+     * Check if the long interpretation is set
+     *
+     * @return bool
+     */
+    public function hasLongInterpretation()
+    {
+        return !is_null($this->longInterpretation);
+    }
+
+    /**
+     * Get the normal maximum
+     *
+     * @return QtiFloat
+     */
+    public function getNormalMaximum()
+    {
+        return $this->normalMaximum;
+    }
+
+    /**
+     * Set the normal maximum
+     *
+     * @param QtiFloat $normalMaximum
+     * @return $this
+     */
+    public function setNormalMaximum(QtiFloat $normalMaximum=null)
+    {
+        $this->normalMaximum = $normalMaximum;
+        return $this;
+    }
+
+    /**
+     * Check if the normal maximum is set
+     *
+     * @return bool
+     */
+    public function hasNormalMaximum()
+    {
+        return !is_null($this->normalMaximum);
+    }
+
+    /**
+     * Get the normal minimum
+     *
+     * @return QtiFloat
+     */
+    public function getNormalMinimum()
+    {
+        return $this->normalMinimum;
+    }
+
+    /**
+     * Set the normal minimum
+     *
+     * @param QtiFloat $normalMinimum
+     * @return $this
+     */
+    public function setNormalMinimum(QtiFloat $normalMinimum=null)
+    {
+        $this->normalMinimum = $normalMinimum;
+        return $this;
+    }
+
+    /**
+     * Check if the normal minimum is set
+     *
+     * @return bool
+     */
+    public function hasNormalMinimum()
+    {
+        return !is_null($this->normalMinimum);
+    }
+
+    /**
+     * Get the mastery value
+     *
+     * @return QtiFloat
+     */
+    public function getMasteryValue()
+    {
+        return $this->masteryValue;
+    }
+
+    /**
+     * Set the mastery value
+     *
+     * @param QtiFloat $masteryValue
+     * @return $this
+     */
+    public function setMasteryValue(QtiFloat $masteryValue=null)
+    {
+        $this->masteryValue = $masteryValue;
+        return $this;
+    }
+
+    /**
+     * Check if the mastery value is set
+     *
+     * @return bool
+     */
+    public function hasMasteryValue()
+    {
+        return !is_null($this->masteryValue);
+    }
+
+}

--- a/src/qtism/data/results/ResultResponseVariable.php
+++ b/src/qtism/data/results/ResultResponseVariable.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\QtiComponentCollection;
+use qtism\data\state\CorrectResponse;
+
+/**
+ * Class ResultResponseVariable
+ *
+ * The Item result information related to a 'Response Variable'.
+ *
+ * @package qtism\data\results
+ */
+class ResultResponseVariable extends ItemVariable
+{
+    /**
+     * When a response variable is bound to an interaction that supports the shuffling of choices,
+     * the sequence of choices experienced by the candidate will vary between test instances.
+     * When shuffling is in effect, the sequence of choices should be reported as a sequence of choice identifiers using this attribute.
+     *
+     * Multiplicity [0,1]
+     * @var QtiIdentifier
+     */
+    protected $choiceSequence=null;
+
+    /**
+     * The correct response may be output as part of the report if desired.
+     * Systems are not limited to reporting correct responses declared in responseDeclarations.
+     * For example, a correct response may be set by a templateRule or may simply have been suppressed
+     * from the declaration passed to the delivery engine e.g. for security.
+     *
+     * Multiplicity [0,1]
+     * @var CorrectResponse
+     */
+    protected $correctResponse=null;
+
+    /**
+     * The response given by the candidate.
+     *
+     * Multiplicity [1]
+     * @var CandidateResponse
+     */
+    protected $candidateResponse;
+
+    /**
+     * ResultResponseVariable constructor.
+     *
+     * @param QtiIdentifier $identifier
+     * @param $cardinality
+     * @param CandidateResponse $candidateResponse
+     * @param null $baseType
+     * @param CorrectResponse|null $correctResponse
+     * @param QtiIdentifier|null $choiceSequence
+     */
+    public function __construct(
+        QtiIdentifier $identifier,
+        $cardinality,
+        CandidateResponse $candidateResponse,
+        $baseType=null,
+        CorrectResponse $correctResponse=null,
+        QtiIdentifier $choiceSequence=null
+    ) {
+        parent::__construct($identifier, $cardinality, $baseType);
+        $this->setCandidateResponse($candidateResponse);
+        $this->setCorrectResponse($correctResponse);
+        $this->setChoiceSequence($choiceSequence);
+    }
+
+    /**
+     * Returns the QTI class name as per QTI 2.1 specification.
+     *
+     * @return string A QTI class name.
+     */
+    public function getQtiClassName()
+    {
+        return 'responseVariable';
+    }
+
+    /**
+     * Get the direct child components of this one.
+     *
+     * @return QtiComponentCollection A collection of QtiComponent objects.
+     */
+    public function getComponents()
+    {
+        $components = [$this->getCandidateResponse()];
+        if ($this->hasCorrectResponse()) {
+            $components = array_merge($components, $this->getCorrectResponse());
+        }
+        return new QtiComponentCollection($components);
+    }
+
+    /**
+     * Get the candidate response
+     *
+     * @return CandidateResponse
+     */
+    public function getCandidateResponse()
+    {
+        return $this->candidateResponse;
+    }
+
+    /**
+     * Set the candidate response
+     *
+     * @param CandidateResponse $candidateResponse
+     * @return $this
+     */
+    public function setCandidateResponse(CandidateResponse $candidateResponse)
+    {
+        $this->candidateResponse = $candidateResponse;
+        return $this;
+    }
+
+    /**
+     * Get the correct response
+     *
+     * @return CorrectResponse
+     */
+    public function getCorrectResponse()
+    {
+        return $this->correctResponse;
+    }
+
+    /**
+     * Set the correct response
+     *
+     * @param CorrectResponse $correctResponse
+     * @return $this
+     */
+    public function setCorrectResponse(CorrectResponse $correctResponse=null)
+    {
+        $this->correctResponse = $correctResponse;
+        return $this;
+    }
+
+    /**
+     * Check if the correctResponse is set
+     *
+     * @return bool
+     */
+    public function hasCorrectResponse()
+    {
+        return !is_null($this->correctResponse);
+    }
+
+    /**
+     * Get the choice sequence
+     *
+     * @return QtiIdentifier
+     */
+    public function getChoiceSequence()
+    {
+        return $this->choiceSequence;
+    }
+
+    /**
+     * Set the choice sequence
+     *
+     * @param QtiIdentifier $choiceSequence
+     * @return $this
+     */
+    public function setChoiceSequence(QtiIdentifier $choiceSequence=null)
+    {
+        $this->choiceSequence = $choiceSequence;
+        return $this;
+    }
+
+    /**
+     * Check if the choice sequence is set
+     *
+     * @return bool
+     */
+    public function hasChoiceSequence()
+    {
+        return !is_null($this->choiceSequence);
+    }
+
+}

--- a/src/qtism/data/results/ResultTemplateVariable.php
+++ b/src/qtism/data/results/ResultTemplateVariable.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\QtiComponentCollection;
+use qtism\data\state\ValueCollection;
+
+/**
+ * Class ResultTemplateVariable
+ *
+ * The Item result information related to a 'Template Variable'.
+ *
+ * @package qtism\data\results
+ */
+class ResultTemplateVariable extends ItemVariable
+{
+    /**
+     * The value(s) of the template variable.
+     * The order of the values is significant only if the template variable was declared with ordered cardinality.
+     *
+     * Multiplicity [0,*]
+     * @var ValueCollection
+     */
+    protected $values=null;
+
+    /**
+     * ResultTemplateVariable constructor.
+     *
+     * @param QtiIdentifier $identifier
+     * @param $cardinality
+     * @param null $baseType
+     * @param ValueCollection|null $values
+     */
+    public function __construct(QtiIdentifier $identifier, $cardinality, $baseType=null, ValueCollection $values=null)
+    {
+        parent::__construct($identifier, $cardinality, $baseType);
+        $this->setValues($values);
+    }
+
+
+    /**
+     * Returns the QTI class name as per QTI 2.1 specification.
+     *
+     * @return string A QTI class name.
+     */
+    public function getQtiClassName()
+    {
+        return 'templateVariable';
+    }
+
+    /**
+     * Get the direct child components of this one.
+     *
+     * @return QtiComponentCollection A collection of QtiComponent objects.
+     */
+    public function getComponents()
+    {
+        $components = [];
+        if ($this->hasValues()) {
+            $components = $this->getValues()->getArrayCopy();
+        }
+        return new QtiComponentCollection($components);
+    }
+
+    /**
+     * Get the template values
+     *
+     * @return ValueCollection
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
+     * Set the template values
+     *
+     * @param ValueCollection $values
+     * @return $this
+     */
+    public function setValues(ValueCollection $values=null)
+    {
+        $this->values = $values;
+        return $this;
+    }
+
+    /**
+     * Check if the values are set
+     *
+     * @return bool
+     */
+    public function hasValues()
+    {
+        return !is_null($this->values);
+    }
+}

--- a/src/qtism/data/results/SessionIdentifier.php
+++ b/src/qtism/data/results/SessionIdentifier.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiString;
+use qtism\common\datatypes\QtiUri;
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+
+/**
+ * Class SessionIdentifier
+ *
+ * The system that creates the result (for example, the test delivery system) should assign a session identifier
+ * that it can use to identify the session.
+ *
+ * @package qtism\data\results
+ */
+class SessionIdentifier extends QtiComponent
+{
+    /**
+     * A unique identifier of the system which added this identifier to the result.
+     *
+     * Multiplicity [1]
+     * @var QtiUri
+     */
+    protected $sourceID;
+
+    /**
+     * The system that creates the report should add a session identifier.
+     * Subsequent systems that process the results might use their own identifier for the session
+     * and should add this too if the result is exported again for further transport.
+     *
+     * Multiplicity [1]
+     * @var QtiIdentifier
+     */
+    protected $identifier;
+
+    /**
+     * SessionIdentifier constructor.
+     *
+     * XML representation of the session created by the delivery system
+     *
+     * @param QtiUri $sourceID
+     * @param QtiIdentifier $identifier
+     */
+    public function __construct(QtiUri $sourceID, QtiIdentifier $identifier)
+    {
+        $this->setSourceID($sourceID);
+        $this->setIdentifier($identifier);
+    }
+
+    /**
+     * Returns the QTI class name as per QTI 2.1 specification.
+     *
+     * @return string A QTI class name.
+     */
+    public function getQtiClassName()
+    {
+        return 'sessionIdentifier';
+    }
+
+    /**
+     * Get the direct child components of this one.
+     *
+     * @return QtiComponentCollection A collection of QtiComponent objects.
+     */
+    public function getComponents()
+    {
+        return new QtiComponentCollection();
+    }
+
+    /**
+     * Get the source id of the session identifier
+     *
+     * @return QtiUri
+     */
+    public function getSourceID()
+    {
+        return $this->sourceID;
+    }
+
+    /**
+     * Set the source id of the session identifier
+     *
+     * @param QtiUri $sourceID
+     * @return $this
+     */
+    public function setSourceID(QtiUri $sourceID)
+    {
+        $this->sourceID = $sourceID;
+        return $this;
+    }
+
+    /**
+     * Get the identifier of the session identifier
+     *
+     * @return QtiIdentifier
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Set the identifier of the session identifier
+     *
+     * @param QtiIdentifier $identifier
+     * @return $this
+     */
+    public function setIdentifier(QtiIdentifier $identifier)
+    {
+        $this->identifier = $identifier;
+        return $this;
+    }
+
+}

--- a/src/qtism/data/results/SessionIdentifierCollection.php
+++ b/src/qtism/data/results/SessionIdentifierCollection.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use qtism\data\QtiComponentCollection;
+
+class SessionIdentifierCollection extends QtiComponentCollection
+{
+    /**
+     * Check if a given $value is an instance of SessionIdentifier.
+     *
+     * @throws \InvalidArgumentException If the given $value is not an instance of SessionIdentifier.
+     */
+    protected function checkType($value)
+    {
+        if (!$value instanceof SessionIdentifier) {
+            throw new \InvalidArgumentException(sprintf(
+                "SessionIdentifierCollection only accepts to store SessionIdentifier objects, '%s' given.",
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
+    }
+}

--- a/src/qtism/data/results/SessionStatus.php
+++ b/src/qtism/data/results/SessionStatus.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ * @package
+ */
+
+namespace qtism\data\results;
+
+use qtism\common\enums\Enumeration;
+
+class SessionStatus implements Enumeration
+{
+    /**
+     * The value to use when the item variables represent the values at the end of an attempt after response processing has taken place.
+     * In other words, after the outcome values have been updated to reflect the values of the response variables.
+     */
+    const STATUS_FINAL = 0;
+
+    /**
+     * The value to use for sessions in the initial state, as described above. This value can only be used to describe sessions
+     * for which the response variable numAttempts is 0. The values of the variables are set according to the rules
+     * defined in the appropriate declarations (see responseDeclaration, outcomeDeclaration and templateDeclaration).
+     */
+    const STATUS_INITIAL = 1;
+
+    /**
+     * The value to use when the item variables represent the values of the response variables after submission but before response processing has taken place.
+     * Again, the outcomes are those assigned at the end of the previous attempt as they are awaiting response processing.
+     */
+    const STATUS_PENDING_RESPONSE_PROCESSING = 2;
+
+    /**
+     * The value to use when the item variables represent a snapshot of the current values during an attempt
+     * (in other words, while interacting or suspended). The values of the response variables represent work in progress
+     * that has not yet been submitted for response processing by the candidate.
+     * The values of the outcome variables represent the values assigned during response processing at the end of the previous attempt or,
+     * in the case of the first attempt, the default values given in the variable declarations.
+     */
+    const STATUS_PENDING_SUBMISSON = 3;
+
+    /**
+     * Get the array representation of SessionStatuses
+     *
+     * @return array
+     */
+    public static function asArray()
+    {
+        return array(
+            self::STATUS_FINAL,
+            self::STATUS_INITIAL,
+            self::STATUS_PENDING_RESPONSE_PROCESSING,
+            self::STATUS_PENDING_SUBMISSON
+        );
+    }
+
+    /**
+     * Find a constant with string name
+     * Return false if does not match
+     *
+     * @param false|int $name
+     * @return bool|int
+     */
+    public static function getConstantByName($name)
+    {
+        switch ($name) {
+
+            case 'final':
+                return self::STATUS_FINAL;
+            break;
+
+            case 'initial':
+                return self::STATUS_INITIAL;
+            break;
+
+            case 'pendingResponseProcessing':
+                return self::STATUS_PENDING_RESPONSE_PROCESSING;
+            break;
+
+            case 'pendingSubmission':
+                return self::STATUS_PENDING_SUBMISSON;
+            break;
+
+            default:
+                return false;
+            break;
+        }
+    }
+
+    /**
+     * Find a human name associated to constant
+     * Return false if does not match
+     *
+     * @param false|int $constant
+     * @return bool|int
+     */
+    public static function getNameByConstant($constant)
+    {
+        switch ($constant) {
+
+            case self::STATUS_FINAL:
+                return 'final';
+                break;
+
+            case self::STATUS_INITIAL:
+                return 'initial';
+                break;
+
+            case self::STATUS_PENDING_RESPONSE_PROCESSING:
+                return 'pendingResponseProcessing';
+                break;
+
+            case self::STATUS_PENDING_SUBMISSON:
+                return 'pendingSubmission';
+                break;
+
+            default:
+                return false;
+                break;
+        }
+    }
+
+}

--- a/src/qtism/data/results/TestResult.php
+++ b/src/qtism/data/results/TestResult.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use DateTime;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+
+
+/**
+ * Class TestResult
+ *
+ * The container for the Test result. When a test result is given the following item results must relate only to items
+ * that were selected for presentation as part of the corresponding test session.
+ * Furthermore, all items selected for presentation should be reported with a corresponding itemResult.
+ *
+ * @package qtism\data\results
+ */
+class TestResult extends QtiComponent
+{
+    /**
+     * The identifier of the test for which this is a result.
+     *
+     * Multiplicity [1]
+     * @var QtiIdentifier
+     */
+    protected $identifier;
+
+    /**
+     * The date stamp of when this result was recorded.
+     *
+     * Multiplicity [1]
+     * @var DateTime
+     */
+    protected $datestamp;
+
+    /**
+     * The values of the test outcomes and any durations that were tracked during the test.
+     * Note that durations are reported as built-in test-level response variables with name duration.
+     * The duration of individual test parts or sections being distinguished by prefixing them
+     * with the associated identifier as described in Assessment Test, Section and Item Information Model.
+     * This is an abstract attribute and so a child named 'itemVariable' will not appear in an instance.
+     *
+     * Multiplicity [0,*]
+     * @var ItemVariable
+     */
+    protected $itemVariables=null;
+
+    /**
+     * TestResult constructor.
+     *
+     * @param string $identifier The identifier of TestResult
+     * @param DateTime $datestamp The timestamp when testResult has been registered
+     * @param ItemVariableCollection|null $itemVariables All variables
+     */
+    public function __construct($identifier, DateTime $datestamp, ItemVariableCollection $itemVariables=null)
+    {
+        $this->setIdentifier($identifier);
+        $this->setDatestamp($datestamp);
+        $this->setItemVariables($itemVariables);
+    }
+
+    /**
+     * Returns the QTI class name as per QTI 2.1 specification.
+     *
+     * @return string A QTI class name.
+     */
+    public function getQtiClassName()
+    {
+        return 'testResult';
+    }
+
+    /**
+     * Get the direct child components of this one.
+     *
+     * @return QtiComponentCollection A collection of QtiComponent objects.
+     */
+    public function getComponents()
+    {
+        if ($this->hasItemVariables()) {
+            $components = $this->getItemVariables()->toArray();
+        } else {
+            $components = [];
+        }
+        return new QtiComponentCollection($components);
+    }
+
+    /**
+     * Get the Qti identifier of testResult
+     *
+     * @return QtiIdentifier
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Set the identifier to testResult component
+     *
+     * @param QtiIdentifier $identifier
+     * @return $this
+     */
+    public function setIdentifier(QtiIdentifier $identifier)
+    {
+        $this->identifier = $identifier;
+        return $this;
+    }
+
+    /**
+     * The date stamp of when this result was recorded.
+     *
+     * @return DateTime
+     */
+    public function getDatestamp()
+    {
+        return $this->datestamp;
+    }
+
+    /**
+     * Set the datestamp that must be a Datetime object
+     *
+     * @param DateTime $datestamp
+     * @return $this
+     */
+    public function setDatestamp(DateTime $datestamp)
+    {
+        $this->datestamp = $datestamp;
+        return $this;
+    }
+
+    /**
+     * Get all test variables. Can be outcome, response, candidate or tempalte variable
+     *
+     * @return mixed
+     */
+    public function getItemVariables()
+    {
+        return $this->itemVariables;
+    }
+
+    /**
+     * Set all test variables
+     *
+     * @param ItemVariableCollection $itemVariables
+     * @return $this
+     */
+    public function setItemVariables(ItemVariableCollection $itemVariables=null)
+    {
+        $this->itemVariables = $itemVariables;
+        return $this;
+    }
+
+    /**
+     * Check if the test result has item variables
+     *
+     * @return bool
+     */
+    public function hasItemVariables()
+    {
+        return !is_null($this->itemVariables);
+    }
+
+}

--- a/src/qtism/data/results/TestResultCollection.php
+++ b/src/qtism/data/results/TestResultCollection.php
@@ -1,9 +1,23 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: siwane
- * Date: 21/06/18
- * Time: 14:58
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
  */
 
 namespace qtism\data\result;

--- a/src/qtism/data/results/TestResultCollection.php
+++ b/src/qtism/data/results/TestResultCollection.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: siwane
+ * Date: 21/06/18
+ * Time: 14:58
+ */
+
+namespace qtism\data\result;
+
+
+use qtism\data\QtiComponentCollection;
+
+class TestResultCollection extends QtiComponentCollection
+{
+    /**
+     * Check if a given $value is an instance of ItemResult.
+     *
+     * @throws InvalidArgumentException If the given $value is not an instance of ItemResult.
+     */
+    protected function checkType($value)
+    {
+        if (!$value instanceof TestResult) {
+            $msg = "TestResultCollection only accepts to store TestResult objects, '" . gettype($value) . "' given.";
+            throw new \InvalidArgumentException($msg);
+        }
+    }
+}

--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -104,6 +104,8 @@ class Utils
                 }
             } else if ($rootNs === 'http://www.imsglobal.org/xsd/imsqti_result_v2p1') {
                 $version = '2.1.0';
+            } else if ($rootNs === 'http://www.imsglobal.org/xsd/imsqti_result_v2p1') {
+                $version = '2.2.0';
             }
         }
         

--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -102,6 +102,8 @@ class Utils
                 if ($nsLocation === 'http://www.imsglobal.org/xsd/qti/aqtiv1p0/imsaqti_itemv1p0_v1p0.xsd') {
                     $version = '3.0.0';
                 }
+            } else if ($rootNs === 'http://www.imsglobal.org/xsd/imsqti_result_v2p1') {
+                $version = '2.1.0';
             }
         }
         

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -533,7 +533,12 @@ class XmlDocument extends QtiDocument
                 $xsdLocation = 'http://www.imsglobal.org/xsd/imsqti_v2p0.xsd';
                 $xmlns = "http://www.imsglobal.org/xsd/imsqti_v2p0";
                 break;
-            
+
+            case '2.1.0':
+                $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd';
+                $xmlns = "http://www.imsglobal.org/xsd/imsqti_v2p1";
+                break;
+
             case '2.1.1':
                 $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1p1.xsd';
                 $xmlns = "http://www.imsglobal.org/xsd/imsqti_v2p1";

--- a/src/qtism/data/storage/xml/XmlResultDocument.php
+++ b/src/qtism/data/storage/xml/XmlResultDocument.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml;
+
+use DOMElement;
+
+/**
+ * Class XmlResultDocument
+ * @package qtism\data\storage\xml
+ */
+class XmlResultDocument extends XmlDocument
+{
+    /**
+     * Validate DomDocument against associated xsd
+     *
+     * Add DomDocument to XmlUtils to fetch xsd by document namespace
+     *
+     * @param string $filename
+     * @throws XmlStorageException
+     */
+    public function schemaValidate($filename = '')
+    {
+        parent::schemaValidate(dirname(__FILE__) . '/schemes/qtiv2p1/imsqti_result_v2p1.xsd');
+    }
+
+    /**
+     * Decorate the root DomElement
+     *
+     * Add Result namespace regarding version
+     *
+     * @param DOMElement $rootElement
+     * @throws \LogicException if the version is not supported by QTI result
+     */
+    protected function decorateRootElement(DOMElement $rootElement)
+    {
+        $version = trim($this->getVersion());
+        switch ($version) {
+            case '2.1.0':
+            case '2.1.1':
+                $qtiSuffix = 'result_v2p1';
+                $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_result_v2p1.xsd';
+                break;
+
+            case '2.2.0':
+            case '2.2.1':
+                $qtiSuffix = 'result_v2p2';
+                $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_result_v2p2.xsd';
+                break;
+
+            default:
+                throw new \LogicException('Result xml is not supported for QTI version "' . $version . '"');
+        }
+
+        $rootElement->setAttribute('xmlns', "http://www.imsglobal.org/xsd/imsqti_${qtiSuffix}");
+        $rootElement->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $rootElement->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', "http://www.imsglobal.org/xsd/imsqti_${qtiSuffix} ${xsdLocation}");
+    }
+}

--- a/src/qtism/data/storage/xml/marshalling/AssessmentResultMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/AssessmentResultMarshaller.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\data\QtiComponent;
+use qtism\data\results\AssessmentResult;
+use qtism\data\results\ItemResultCollection;
+
+/**
+ * Class AssessmentResultMarshaller
+ *
+ * The marshaller to manage serialization between QTI component and DOM Element
+ * 
+ * @package qtism\data\storage\xml\marshalling
+ */
+class AssessmentResultMarshaller extends Marshaller
+{
+    /**
+     * Marshall a QtiComponent object into its QTI-XML equivalent.
+     *
+     * @param QtiComponent|AssessmentResult $component A QtiComponent object to marshall.
+     * @return DOMElement A DOMElement object.
+     * @throws MarshallingException
+     */
+    protected function marshall(QtiComponent $component)
+    {
+        $element = self::getDOMCradle()->createElement($this->getExpectedQtiClassName());
+
+        $context = $component->getContext();
+        $element->appendChild($this->getMarshallerFactory()->createMarshaller($context)->marshall($context));
+
+        if ($component->hasTestResult()) {
+            $testResult = $component->getTestResult();
+            $element->appendChild($this->getMarshallerFactory()->createMarshaller($testResult)->marshall($testResult));
+        }
+
+        if ($component->hasItemResults()) {
+            foreach ($component->getItemResults() as $itemResult) {
+                $element->appendChild($this->getMarshallerFactory()->createMarshaller($itemResult)->marshall($itemResult));
+            }
+        }
+
+        return $element;
+    }
+
+    /**
+     * Unmarshall a DOMElement object corresponding to a QTI sessionIdentifier element.
+     *
+     * @param DOMElement $element A DOMElement object.
+     * @return QtiComponent A QtiComponent object.
+     * @throws UnmarshallingException
+     */
+    protected function unmarshall(DOMElement $element)
+    {
+        try {
+            $contextElements = self::getChildElementsByTagName($element, 'context');
+            $contextElement = array_shift($contextElements);
+            $context = $this->getMarshallerFactory()->createMarshaller($contextElement)->unmarshall($contextElement);
+        } catch (\InvalidArgumentException $e) {
+            $msg = "An 'assessmentResult' element must contain one 'context' element, none given.";
+            throw new UnmarshallingException($msg, $element, $e);
+        }
+
+        $assessmentResult = new AssessmentResult($context);
+
+        try {
+            $testResultElements = $element->getElementsByTagName('testResult');
+            if ($testResultElements->length > 0) {
+                $testResultElement = $testResultElements->item(0);
+                $assessmentResult->setTestResult($this->getMarshallerFactory()->createMarshaller($testResultElement)->unmarshall($testResultElement));
+            }
+
+            $itemResultElements = $element->getElementsByTagName('itemResult');
+            if ($itemResultElements->length > 0) {
+                $itemResults = [];
+                foreach($itemResultElements as $itemResultElement) {
+                    $itemResults[] = $this->getMarshallerFactory()
+                        ->createMarshaller($itemResultElement)
+                        ->unmarshall($itemResultElement);
+                }
+                $assessmentResult->setItemResults(new ItemResultCollection($itemResults));
+            }
+        } catch (\InvalidArgumentException $e) {
+            throw new UnmarshallingException('Error has occurred during unmarshalling of AssessmentResult element : ' . $e->getMessage(), $element, $e);
+        }
+
+        return $assessmentResult;
+    }
+
+    /**
+     * Get the class name/tag name of the QtiComponent/DOMElement which can be handled
+     * by the Marshaller's implementation.
+     *
+     * Return an empty string if the marshaller implementation does not expect a particular
+     * QTI class name.
+     *
+     * @return string A QTI class name or an empty string.
+     */
+    public function getExpectedQtiClassName()
+    {
+        return 'assessmentResult';
+    }
+}

--- a/src/qtism/data/storage/xml/marshalling/CandidateResponseMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/CandidateResponseMarshaller.php
@@ -1,4 +1,24 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
 
 namespace qtism\data\storage\xml\marshalling;
 

--- a/src/qtism/data/storage/xml/marshalling/CandidateResponseMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/CandidateResponseMarshaller.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\data\QtiComponent;
+use qtism\data\results\CandidateResponse;
+use qtism\data\state\Value;
+use qtism\data\state\ValueCollection;
+
+class CandidateResponseMarshaller extends Marshaller
+{
+    protected function marshall(QtiComponent $component)
+    {
+        $element = self::getDOMCradle()->createElement($this->getExpectedQtiClassName());
+
+        if ($component->hasValues()) {
+            /** @var Value $value */
+            foreach ($component->getValues() as $value) {
+                $valueElement= $this->getMarshallerFactory()
+                    ->createMarshaller($value)
+                    ->marshall($value);
+                $element->appendChild($valueElement);
+            }
+        }
+
+        return $element;
+    }
+
+    protected function unmarshall(DOMElement $element)
+    {
+       $valuesElements = self::getChildElementsByTagName($element, 'value');
+        if (!empty($valuesElements)) {
+            $values = [];
+            foreach ($valuesElements as $valuesElement) {
+                $values[] = $this->getMarshallerFactory()
+                    ->createMarshaller($valuesElement)
+                    ->unmarshall($valuesElement);
+            }
+            $valueCollection = new ValueCollection($values);
+        } else {
+            $valueCollection = null;
+        }
+
+        return new CandidateResponse($valueCollection);
+    }
+
+    public function getExpectedQtiClassName()
+    {
+         return 'candidateResponse';
+    }
+
+
+}

--- a/src/qtism/data/storage/xml/marshalling/ContextMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ContextMarshaller.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\QtiComponent;
+use qtism\data\results\Context;
+use qtism\data\results\SessionIdentifierCollection;
+
+/**
+ * Class ContextMarshaller
+ *
+ * The marshaller to manage serialization between QTI component and DOM Element
+ * 
+ * @package qtism\data\storage\xml\marshalling
+ */
+class ContextMarshaller extends Marshaller
+{
+    /**
+     * Marshall a QtiComponent object into its QTI-XML equivalent.
+     *
+     * @param QtiComponent $component A QtiComponent object to marshall.
+     * @return DOMElement A DOMElement object.
+     * @throws MarshallingException If an error occurs during the marshalling process.
+     */
+    protected function marshall(QtiComponent $component)
+    {
+        $element = self::getDOMCradle()->createElement($this->getExpectedQtiClassName());
+
+        if ($component->hasSourcedId()) {
+            $element->setAttribute('sourcedId', $component->getSourcedId());
+        }
+
+        if ($component->hasSessionIdentifiers()) {
+            foreach ($component->getSessionIdentifiers() as $sessionIdentifier) {
+                $sessionIdentifierElement = $this->getMarshallerFactory()
+                    ->createMarshaller($sessionIdentifier)
+                    ->marshall($sessionIdentifier);
+                $element->appendChild($sessionIdentifierElement);
+            }
+        }
+
+        return $element;
+    }
+
+    /**
+     * Unmarshall a DOMElement object corresponding to a QTI context element.
+     *
+     * @param DOMElement $element A DOMElement object.
+     * @return QtiComponent A QtiComponent object.
+     */
+    protected function unmarshall(DOMElement $element)
+    {
+        $sourcedId = $element->hasAttribute('sourcedId')
+            ? new QtiIdentifier($element->getAttribute('sourcedId'))
+            : null;
+
+        $sessionIdentifierElements = self::getChildElementsByTagName($element, 'sessionIdentifier');
+        if (!empty($sessionIdentifierElements)) {
+            $sessionIdentifiers = [];
+            foreach ($sessionIdentifierElements as $sessionIdentifierElement) {
+                $sessionIdentifiers[] = $this->getMarshallerFactory()
+                    ->createMarshaller($sessionIdentifierElement)
+                    ->unmarshall($sessionIdentifierElement);
+            }
+            $sessionIdentifierCollection = new SessionIdentifierCollection($sessionIdentifiers);
+        } else {
+            $sessionIdentifierCollection = null;
+        }
+
+        return new Context($sourcedId, $sessionIdentifierCollection);
+    }
+
+    /**
+     * Get the class name/tag name of the QtiComponent/DOMElement which can be handled
+     * by the Marshaller's implementation.
+     *
+     * Return an empty string if the marshaller implementation does not expect a particular
+     * QTI class name.
+     *
+     * @return string A QTI class name or an empty string.
+     */
+    public function getExpectedQtiClassName()
+    {
+        return 'context';
+    }
+}

--- a/src/qtism/data/storage/xml/marshalling/ItemResultMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ItemResultMarshaller.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use DateTime;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiInteger;
+use qtism\common\datatypes\QtiString;
+use qtism\data\QtiComponent;
+use qtism\data\results\ItemResult;
+use qtism\data\results\ItemVariableCollection;
+use qtism\data\results\SessionStatus;
+
+/**
+ * Class ItemResultMarshaller
+ *
+ * The marshaller to manage serialization between QTI component and DOM Element
+ *
+ * @package qtism\data\storage\xml\marshalling
+ */
+class ItemResultMarshaller extends Marshaller
+{
+    /**
+     * Marshall a QtiComponent object into its QTI-XML equivalent.
+     *
+     * @param QtiComponent|ItemResult $component A QtiComponent object to marshall.
+     * @return DOMElement A DOMElement object.
+     * @throws MarshallingException
+     */
+    protected function marshall(QtiComponent $component)
+    {
+        $element = self::getDOMCradle()->createElement($this->getExpectedQtiClassName());
+        $element->setAttribute('identifier', $component->getIdentifier());
+        $element->setAttribute('datestamp', $component->getDatestamp()->format(DateTime::ISO8601));
+        $element->setAttribute('sessionStatus', SessionStatus::getNameByConstant($component->getSessionStatus()));
+
+        if ($component->hasSequenceIndex()) {
+            $element->setAttribute('sequenceIndex', $component->getSequenceIndex());
+        }
+
+        if ($component->hasCandidateComment()) {
+            $candidateCommentElement = self::getDOMCradle()->createElement('candidateComment');
+            $candidateCommentElement->textContent = $component->getCandidateComment();
+            $element->appendChild($candidateCommentElement);
+        }
+
+        if ($component->hasItemVariables()) {
+            foreach ($component->getItemVariables() as $variable) {
+                $element->appendChild($this->getMarshallerFactory()->createMarshaller($variable)->marshall($variable));
+            }
+        }
+
+        return $element;
+    }
+
+    /**
+     * Unmarshall a DOMElement object corresponding to a QTI sessionIdentifier element.
+     *
+     * @param DOMElement $element A DOMElement object.
+     * @return QtiComponent A QtiComponent object.
+     * @throws UnmarshallingException
+     */
+    protected function unmarshall(DOMElement $element)
+    {
+        if (!$element->hasAttribute('identifier')) {
+            throw new UnmarshallingException('ItemResult element must have identifier attribute', $element);
+        }
+
+        if (!$element->hasAttribute('datestamp')) {
+            throw new UnmarshallingException('ItemResult element must have datestamp attribute', $element);
+        }
+
+        if (!$element->hasAttribute('sessionStatus')) {
+            throw new UnmarshallingException('ItemResult element must have sessionStatus attribute', $element);
+        }
+
+        $identifier = new QtiIdentifier($element->getAttribute('identifier'));
+        $datestamp = new DateTime($element->getAttribute('datestamp'));
+        $sessionStatus = SessionStatus::getConstantByName($element->getAttribute('sessionStatus'));
+
+        $variableElements = array_merge(
+            self::getChildElementsByTagName($element, 'responseVariable'),
+            self::getChildElementsByTagName($element, 'outcomeVariable'),
+            self::getChildElementsByTagName($element, 'templateVariable')
+        );
+
+        if (!empty($variableElements)) {
+            $variables = [];
+            foreach ($variableElements as $variableElement) {
+                $variables[] = $this->getMarshallerFactory()
+                    ->createMarshaller($variableElement)
+                    ->unmarshall($variableElement);
+            }
+            $variableCollection = new ItemVariableCollection($variables);
+        } else {
+            $variableCollection = null;
+        }
+
+        $candidateCommentElements = self::getChildElementsByTagName($element, 'candidateComment');
+        if (!empty($candidateCommentElements)) {
+            $candidateCommentElement = array_shift($candidateCommentElements);
+            $candidateComment = new QtiString($candidateCommentElement->textContent);
+        } else {
+            $candidateComment = null;
+        }
+
+        $sequenceIndex = $element->hasAttribute('sequenceIndex')
+            ? new QtiInteger(intval($element->getAttribute('sequenceIndex')))
+            : null;
+
+        return new ItemResult($identifier, $datestamp, $sessionStatus, $variableCollection, $candidateComment, $sequenceIndex);
+    }
+
+    /**
+     * Get the class name/tag name of the QtiComponent/DOMElement which can be handled
+     * by the Marshaller's implementation.
+     *
+     * Return an empty string if the marshaller implementation does not expect a particular
+     * QTI class name.
+     *
+     * @return string A QTI class name or an empty string.
+     */
+    public function getExpectedQtiClassName()
+    {
+        return 'itemResult';
+    }
+
+}

--- a/src/qtism/data/storage/xml/marshalling/MarshallerFactory.php
+++ b/src/qtism/data/storage/xml/marshalling/MarshallerFactory.php
@@ -292,16 +292,15 @@ abstract class MarshallerFactory
         $this->addMappingEntry('hotspotChoice', 'qtism\\data\\storage\\xml\\marshalling\\HotspotMarshaller');
         $this->addMappingEntry('associableHotspot', 'qtism\\data\\storage\\xml\\marshalling\\HotspotMarshaller');
         $this->addMappingEntry('include', 'qtism\\data\\storage\\xml\\marshalling\\XIncludeMarshaller');
-    }
-
-    /**
-	 * Set the associative array which represents the current QTI class <-> Marshaller class mapping.
-	 *
-	 * @param array $mapping An associative array where keys are QTI class names and values are fully qualified PHP class names.
-	 */
-    protected function setMapping(array &$mapping)
-    {
-        $this->mapping = $mapping;
+        $this->addMappingEntry('assessmentResult', 'qtism\\data\\storage\\xml\\marshalling\\AssessmentResultMarshaller');
+        $this->addMappingEntry('context', 'qtism\\data\\storage\\xml\\marshalling\\ContextMarshaller');
+        $this->addMappingEntry('sessionIdentifier', 'qtism\\data\\storage\\xml\\marshalling\\SessionIdentifierMarshaller');
+        $this->addMappingEntry('testResult', 'qtism\\data\\storage\\xml\\marshalling\\TestResultMarshaller');
+        $this->addMappingEntry('itemResult', 'qtism\\data\\storage\\xml\\marshalling\\ItemResultMarshaller');
+        $this->addMappingEntry('responseVariable', 'qtism\\data\\storage\\xml\\marshalling\\ResponseVariableMarshaller');
+        $this->addMappingEntry('candidateResponse', 'qtism\\data\\storage\\xml\\marshalling\\CandidateResponseMarshaller');
+        $this->addMappingEntry('templateVariable', 'qtism\\data\\storage\\xml\\marshalling\\TemplateVariableMarshaller');
+        $this->addMappingEntry('outcomeVariable', 'qtism\\data\\storage\\xml\\marshalling\\OutcomeVariableMarshaller');
     }
 
     /**

--- a/src/qtism/data/storage/xml/marshalling/OutcomeVariableMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/OutcomeVariableMarshaller.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\common\datatypes\QtiFloat;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiString;
+use qtism\common\datatypes\QtiUri;
+use qtism\common\enums\BaseType;
+use qtism\common\enums\Cardinality;
+use qtism\data\QtiComponent;
+use qtism\data\results\ResultOutcomeVariable;
+use qtism\data\state\ValueCollection;
+use qtism\data\View;
+
+/**
+ * Class OutcomeVariableMarshaller
+ *
+ * The marshaller to manage serialization between QTI component and DOM Element
+ *
+ * @package qtism\data\storage\xml\marshalling
+ */
+class OutcomeVariableMarshaller extends Marshaller
+{
+    /**
+     * Marshall a QtiComponent object into its QTI-XML equivalent.
+     *
+     * @param QtiComponent|ResultOutcomeVariable $component A QtiComponent object to marshall.
+     * @return DOMElement A DOMElement object.
+     * @throws MarshallingException
+     */
+    protected function marshall(QtiComponent $component)
+    {
+        $element = self::getDOMCradle()->createElement($this->getExpectedQtiClassName());
+        $element->setAttribute('identifier', $component->getIdentifier());
+        $element->setAttribute('cardinality', Cardinality::getNameByConstant($component->getCardinality()));
+        $element->setAttribute('baseType', BaseType::getNameByConstant($component->getBaseType()));
+
+        if ($component->hasView()) {
+            $element->setAttribute('view', View::getNameByConstant($component->getView()));
+        }
+
+        if ($component->hasInterpretation()) {
+            $element->setAttribute('interpretation', $component->getInterpretation());
+        }
+
+        if ($component->hasLongInterpretation()) {
+            $element->setAttribute('longInterpretation', $component->getLongInterpretation());
+        }
+
+        if ($component->hasNormalMinimum()) {
+            $element->setAttribute('normalMinimum', $component->getNormalMinimum());
+        }
+
+        if ($component->hasNormalMaximum()) {
+            $element->setAttribute('normalMaximum', $component->getNormalMaximum());
+        }
+
+        if ($component->hasMasteryValue()) {
+            $element->setAttribute('masteryValue', $component->getMasteryValue());
+        }
+
+        if ($component->hasValues()) {
+            foreach ($component->getValues() as $value) {
+                $marshaller = $this->getMarshallerFactory()->createMarshaller($value);
+                $element->appendChild($marshaller->marshall($value));
+            }
+        }
+
+        return $element;
+    }
+
+    /**
+     * Unmarshall a DOMElement object corresponding to a QTI sessionIdentifier element.
+     *
+     * @param DOMElement $element A DOMElement object.
+     * @return QtiComponent A QtiComponent object.
+     * @throws UnmarshallingException
+     */
+    protected function unmarshall(DOMElement $element)
+    {
+        if (!$element->hasAttribute('identifier')) {
+            throw new UnmarshallingException('OutcomeVariable element must have identifier attribute', $element);
+        }
+
+        if (!$element->hasAttribute('cardinality')) {
+            throw new UnmarshallingException('OutcomeVariable element must have cardinality attribute', $element);
+        }
+
+        $identifier = new QtiIdentifier($element->getAttribute('identifier'));
+        $cardinality = Cardinality::getConstantByName($element->getAttribute('cardinality'));
+
+        $component = new ResultOutcomeVariable($identifier, $cardinality);
+        if($element->hasAttribute('baseType')) {
+            $component->setBaseType(BaseType::getConstantByName($element->getAttribute('baseType')));
+        }
+
+        if ($element->hasAttribute('view')) {
+            $component->setView(View::getConstantByName($element->getAttribute('view')));
+        }
+
+        if ($element->hasAttribute('interpretation')) {
+            $component->setInterpretation(new QtiString($element->getAttribute('interpretation')));
+        }
+
+        if ($element->hasAttribute('longInterpretation')) {
+            $component->setLongInterpretation(new QtiUri($element->getAttribute('longInterpretation')));
+        }
+
+        if ($element->hasAttribute('normalMinimum')) {
+            $component->setNormalMinimum(new QtiFloat(floatval($element->getAttribute('normalMinimum'))));
+        }
+
+        if ($element->hasAttribute('normalMaximum')) {
+            $component->setNormalMaximum(new QtiFloat(floatval($element->getAttribute('normalMaximum'))));
+        }
+
+        if ($element->hasAttribute('masteryValue')) {
+            $component->setMasteryValue(new QtiFloat(floatval($element->getAttribute('masteryValue'))));
+        }
+
+        $valuesElements = self::getChildElementsByTagName($element, 'value');
+        if (!empty($valuesElements)) {
+            $values = [];
+            foreach ($valuesElements as $valuesElement) {
+                $values[] = $this->getMarshallerFactory()
+                    ->createMarshaller($valuesElement)
+                    ->unmarshall($valuesElement);
+            }
+            $component->setValues(new ValueCollection($values));
+        }
+
+        return $component;
+    }
+
+    /**
+     * Get the class name/tag name of the QtiComponent/DOMElement which can be handled
+     * by the Marshaller's implementation.
+     *
+     * Return an empty string if the marshaller implementation does not expect a particular
+     * QTI class name.
+     *
+     * @return string A QTI class name or an empty string.
+     */
+    public function getExpectedQtiClassName()
+    {
+         return 'outcomeVariable';
+    }
+
+}

--- a/src/qtism/data/storage/xml/marshalling/ResponseVariableMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ResponseVariableMarshaller.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\enums\BaseType;
+use qtism\common\enums\Cardinality;
+use qtism\data\QtiComponent;
+use qtism\data\results\ResultResponseVariable;
+
+/**
+ * Class ResponseVariableMarshaller
+ *
+ * The marshaller to manage serialization between QTI component and DOM Element
+ *
+ * @package qtism\data\storage\xml\marshalling
+ */
+class ResponseVariableMarshaller extends Marshaller
+{
+    /**
+     * Marshall a QtiComponent object into its QTI-XML equivalent.
+     *
+     * @param QtiComponent|ResultResponseVariable $component A QtiComponent object to marshall.
+     * @return DOMElement A DOMElement object.
+     * @throws MarshallingException
+     */
+    protected function marshall(QtiComponent $component)
+    {
+        $element = self::getDOMCradle()->createElement($this->getExpectedQtiClassName());
+        $element->setAttribute('identifier', $component->getIdentifier());
+        $element->setAttribute('cardinality', Cardinality::getNameByConstant($component->getCardinality()));
+
+        if ($component->hasBaseType()) {
+            $element->setAttribute('baseType', BaseType::getNameByConstant($component->getBaseType()));
+        }
+
+        if ($component->hasChoiceSequence()) {
+            $element->setAttribute('choiceSequence', $component->getChoiceSequence());
+        }
+
+        if ($component->hasCorrectResponse()) {
+            $correctResponse = $component->getCorrectResponse();
+            $marshaller = $this->getMarshallerFactory()->createMarshaller($correctResponse);
+            $element->appendChild($marshaller->marshall($correctResponse));
+        }
+
+        $candidateResponse = $component->getCandidateResponse();
+        $marshaller = $this->getMarshallerFactory()->createMarshaller($candidateResponse);
+        $element->appendChild($marshaller->marshall($candidateResponse));
+
+        return $element;
+    }
+
+    /**
+     * Unmarshall a DOMElement object corresponding to a QTI sessionIdentifier element.
+     *
+     * @param DOMElement $element A DOMElement object.
+     * @return QtiComponent A QtiComponent object.
+     * @throws UnmarshallingException
+     */
+    protected function unmarshall(DOMElement $element)
+    {
+        if (!$element->hasAttribute('identifier')) {
+            throw new UnmarshallingException('ResponseVariable element must have identifier attribute', $element);
+        }
+
+        if (!$element->hasAttribute('cardinality')) {
+            throw new UnmarshallingException('ResponseVariable element must have cardinality attribute', $element);
+        }
+
+        $candidateResponseElements = self::getChildElementsByTagName($element, 'candidateResponse');
+        if (empty($candidateResponseElements)) {
+            throw new UnmarshallingException('ResponseVariable element must have candidateResponse element', $element);
+        }
+
+        $candidateResponseElement = array_shift($candidateResponseElements);
+        $candidateResponse = $this->getMarshallerFactory()
+            ->createMarshaller($candidateResponseElement)
+            ->unmarshall($candidateResponseElement);
+
+        $identifier = new QtiIdentifier($element->getAttribute('identifier'));
+        $cardinality = Cardinality::getConstantByName($element->getAttribute('cardinality'));
+
+        $baseType = $element->hasAttribute('baseType')
+            ? BaseType::getConstantByName($element->getAttribute('baseType'))
+            : null;
+
+        $choiceSequence = $element->hasAttribute('choiceSequence')
+            ? new QtiIdentifier($element->getAttribute('choiceSequence'))
+            : null;
+
+        $correctResponseElements = self::getChildElementsByTagName($element, 'correctResponse');
+        if (!empty($correctResponseElements)) {
+            $correctResponseElement = array_shift($correctResponseElements);
+            $correctResponse = $this->getMarshallerFactory()
+                ->createMarshaller($correctResponseElement)
+                ->unmarshall($correctResponseElement);
+        } else {
+            $correctResponse = null;
+        }
+
+        return new ResultResponseVariable($identifier, $cardinality, $candidateResponse, $baseType, $correctResponse, $choiceSequence);
+    }
+
+    /**
+     * Get the class name/tag name of the QtiComponent/DOMElement which can be handled
+     * by the Marshaller's implementation.
+     *
+     * Return an empty string if the marshaller implementation does not expect a particular
+     * QTI class name.
+     *
+     * @return string A QTI class name or an empty string.
+     */
+    public function getExpectedQtiClassName()
+    {
+         return 'responseVariable';
+    }
+
+}

--- a/src/qtism/data/storage/xml/marshalling/SessionIdentifierMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/SessionIdentifierMarshaller.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiUri;
+use qtism\data\QtiComponent;
+use qtism\data\results\SessionIdentifier;
+
+/**
+ * Class SessionIdentifierMarshaller
+ *
+ * The marshaller to manage serialization between QTI component and DOM Element
+ *
+ * @package qtism\data\storage\xml\marshalling
+ */
+class SessionIdentifierMarshaller extends Marshaller
+{
+    /**
+     * Marshall a QtiComponent object into its QTI-XML equivalent.
+     *
+     * @param QtiComponent|SessionIdentifier $component A QtiComponent object to marshall.
+     * @return DOMElement A DOMElement object.
+     */
+    protected function marshall(QtiComponent $component)
+    {
+        $element = self::getDOMCradle()->createElement($this->getExpectedQtiClassName());
+        $element->setAttribute('sourceID', $component->getSourceID());
+        $element->setAttribute('identifier', $component->getIdentifier());
+
+        return $element;
+    }
+
+    /**
+     * Unmarshall a DOMElement object corresponding to a QTI sessionIdentifier element.
+     *
+     * @param DOMElement $element A DOMElement object.
+     * @return QtiComponent A QtiComponent object.
+     * @throws UnmarshallingException
+     */
+    protected function unmarshall(DOMElement $element)
+    {
+        if (!$element->hasAttribute('sourceID')) {
+            throw new UnmarshallingException('SessionIdentifier element must have sourceID attribute', $element);
+        }
+        if (!$element->hasAttribute('identifier')) {
+            throw new UnmarshallingException('SessionIdentifier element must have identifier attribute', $element);
+        }
+        return new SessionIdentifier(
+            new QtiUri($element->getAttribute('sourceID')),
+            new QtiIdentifier($element->getAttribute('identifier'))
+        );
+    }
+
+    /**
+     * Get the class name/tag name of the QtiComponent/DOMElement which can be handled
+     * by the Marshaller's implementation.
+     *
+     * Return an empty string if the marshaller implementation does not expect a particular
+     * QTI class name.
+     *
+     * @return string A QTI class name or an empty string.
+     */
+    public function getExpectedQtiClassName()
+    {
+        return 'sessionIdentifier';
+    }
+
+}

--- a/src/qtism/data/storage/xml/marshalling/TemplateVariableMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/TemplateVariableMarshaller.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\enums\BaseType;
+use qtism\common\enums\Cardinality;
+use qtism\data\QtiComponent;
+use qtism\data\results\ResultTemplateVariable;
+use qtism\data\state\Value;
+use qtism\data\state\ValueCollection;
+
+/**
+ * Class TemplateVariableMarshaller
+ *
+ * The marshaller to manage serialization between QTI component and DOM Element
+ *
+ * @package qtism\data\storage\xml\marshalling
+ */
+class TemplateVariableMarshaller extends Marshaller
+{
+    /**
+     * Marshall a QtiComponent object into its QTI-XML equivalent.
+     *
+     * @param QtiComponent|ResultTemplateVariable $component A QtiComponent object to marshall.
+     * @return DOMElement A DOMElement object.
+     * @throws MarshallingException
+     */
+    protected function marshall(QtiComponent $component)
+    {
+        $element = self::getDOMCradle()->createElement($this->getExpectedQtiClassName());
+        $element->setAttribute('identifier', $component->getIdentifier());
+        $element->setAttribute('cardinality', Cardinality::getNameByConstant($component->getCardinality()));
+
+        if ($component->hasBaseType()) {
+            $element->setAttribute('baseType', BaseType::getNameByConstant($component->getBaseType()));
+        }
+
+        if ($component->hasValues()) {
+            /** @var Value $value */
+            foreach ($component->getValues() as $value) {
+                $valueElement= $this->getMarshallerFactory()
+                    ->createMarshaller($value)
+                    ->marshall($value);
+                $element->appendChild($valueElement);
+            }
+        }
+
+        return $element;
+    }
+
+    /**
+     * Unmarshall a DOMElement object corresponding to a QTI sessionIdentifier element.
+     *
+     * @param DOMElement $element A DOMElement object.
+     * @return QtiComponent A QtiComponent object.
+     * @throws UnmarshallingException
+     */
+    protected function unmarshall(DOMElement $element)
+    {
+        if (!$element->hasAttribute('identifier')) {
+            throw new UnmarshallingException('TemplateVariable element must have identifier attribute', $element);
+        }
+
+        if (!$element->hasAttribute('cardinality')) {
+            throw new UnmarshallingException('TemplateVariable element must have cardinality attribute', $element);
+        }
+
+        $identifier = new QtiIdentifier($element->getAttribute('identifier'));
+        $cardinality = Cardinality::getConstantByName($element->getAttribute('cardinality'));
+
+        $baseType = $element->hasAttribute('baseType')
+            ? BaseType::getConstantByName($element->getAttribute('baseType'))
+            : null;
+
+        $valuesElements = self::getChildElementsByTagName($element, 'value');
+        if (!empty($valuesElements)) {
+            $values = [];
+            foreach ($valuesElements as $valuesElement) {
+                $values[] = $this->getMarshallerFactory()
+                    ->createMarshaller($valuesElement)
+                    ->unmarshall($valuesElement);
+            }
+            $valueCollection = new ValueCollection($values);
+        } else {
+            $valueCollection = null;
+        }
+
+        return new ResultTemplateVariable($identifier, $cardinality, $baseType, $valueCollection);
+    }
+
+    /**
+     * Get the class name/tag name of the QtiComponent/DOMElement which can be handled
+     * by the Marshaller's implementation.
+     *
+     * Return an empty string if the marshaller implementation does not expect a particular
+     * QTI class name.
+     *
+     * @return string A QTI class name or an empty string.
+     */
+    public function getExpectedQtiClassName()
+    {
+         return 'templateVariable';
+    }
+
+}

--- a/src/qtism/data/storage/xml/marshalling/TestResultMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/TestResultMarshaller.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use DateTime;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\QtiComponent;
+use qtism\data\results\ItemVariableCollection;
+use qtism\data\results\TestResult;
+
+/**
+ * Class TestResultMarshaller
+ *
+ * The marshaller to manage serialization between QTI component and DOM Element
+ *
+ * @package qtism\data\storage\xml\marshalling
+ */
+class TestResultMarshaller extends Marshaller
+{
+    /**
+     * Marshall a QtiComponent object into its QTI-XML equivalent.
+     *
+     * @param QtiComponent|TestResult $component A QtiComponent object to marshall.
+     * @return DOMElement A DOMElement object.
+     * @throws MarshallingException
+     */
+    protected function marshall(QtiComponent $component)
+    {
+        $element = self::getDOMCradle()->createElement($this->getExpectedQtiClassName());
+
+        $element->setAttribute('identifier', $component->getIdentifier());
+
+        $datestamp = $component->getDatestamp()->format(DateTime::ISO8601);
+        $element->setAttribute('datestamp', $datestamp);
+
+        if ($component->hasItemVariables()) {
+            foreach ($component->getItemVariables() as $variable) {
+                $element->appendChild($this->getMarshallerFactory()
+                    ->createMarshaller($variable)
+                    ->marshall($variable));
+            }
+        }
+
+        return $element;
+    }
+
+    /**
+     * Unmarshall a DOMElement object corresponding to a QTI sessionIdentifier element.
+     *
+     * @param DOMElement $element A DOMElement object.
+     * @return QtiComponent A QtiComponent object.
+     * @throws UnmarshallingException
+     */
+    protected function unmarshall(DOMElement $element)
+    {
+        if (!$element->hasAttribute('identifier')) {
+            throw new UnmarshallingException('TestResult element must have identifier attribute', $element);
+        }
+
+        if (!$element->hasAttribute('datestamp')) {
+            throw new UnmarshallingException('TestResult element must have datestamp attribute', $element);
+        }
+
+        $identifier = new QtiIdentifier($element->getAttribute('identifier'));
+        $datestamp = new DateTime($element->getAttribute('datestamp'));
+
+        $variableElements = array_merge(
+            self::getChildElementsByTagName($element, 'responseVariable'),
+            self::getChildElementsByTagName($element, 'outcomeVariable'),
+            self::getChildElementsByTagName($element, 'templateVariable')
+        );
+
+        if (!empty($variableElements)) {
+            $variables = [];
+            foreach ($variableElements as $variableElement) {
+                $variables[] = $this->getMarshallerFactory()
+                    ->createMarshaller($variableElement)
+                    ->unmarshall($variableElement);
+            }
+            $variableCollection = new ItemVariableCollection($variables);
+        } else {
+            $variableCollection = null;
+        }
+
+        return new TestResult($identifier, $datestamp, $variableCollection);
+    }
+
+    /**
+     * Get the class name/tag name of the QtiComponent/DOMElement which can be handled
+     * by the Marshaller's implementation.
+     *
+     * Return an empty string if the marshaller implementation does not expect a particular
+     * QTI class name.
+     *
+     * @return string A QTI class name or an empty string.
+     */
+    public function getExpectedQtiClassName()
+    {
+        return 'testResult';
+    }
+
+}

--- a/src/qtism/data/storage/xml/marshalling/ValueMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ValueMarshaller.php
@@ -130,7 +130,7 @@ class ValueMarshaller extends Marshaller
                 $object = new Value(Utils::stringToDatatype(trim($element->nodeValue), $baseTypeCst), $baseTypeCst);
                 $object->setPartOfRecord(true);
             } else {
-                $msg = "The 'baseType' attribute value ('${value}') is not a valid QTI baseType in element '" . $element->localName . "'.";
+                $msg = "The 'baseType' attribute value ('${baseType}') is not a valid QTI baseType in element '" . $element->localName . "'.";
                 throw new UnmarshallingException($msg, $element);
             }
         } else {

--- a/src/qtism/data/storage/xml/schemes/qtiv2p2/imsqti_result_v2p2.xsd
+++ b/src/qtism/data/storage/xml/schemes/qtiv2p2/imsqti_result_v2p2.xsd
@@ -1,0 +1,580 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<xs:schema xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p2"
+           targetNamespace="http://www.imsglobal.org/xsd/imsqti_result_v2p2"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           version="IMS QTI RESULT 2.2.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:annotation>
+        <xs:documentation>
+            XSD Data File Information
+            =========================
+            Author:         Colin Smythe (IMS Global, UK) and Mark McKell (IMS Global, USA)
+            Date:           1st September, 2015
+            Version:        2.2
+            Status:         Final Release
+            Description:    This is the Platform Specific Model of the Assessment Result object in the IMS QTIv2.2 Specification Information Model. It is this representation that is used to produce the XSD binding for the AssessmentResult IMS QTI v2.2.
+
+            History:        This version supercedes the full IMS QTI v2.1 specification.
+
+            License:        IPR and Distribution Notices
+
+            This machine readable file is derived from IMS Global specification IMS Question and Test Interoperability (QTI) Version 2.2
+            found at http://www.imsglobal.org/question and the original IMS Global schema binding or code base
+            http://www.imsglobal.org/question.
+
+            Recipients of this document are requested to submit, with their comments, notification of any relevant
+            patent claims or other intellectual property rights of which they may be aware that might be infringed by
+            any implementation of the specification set forth in this document, and to provide supporting documentation.
+
+            IMS takes no position regarding the validity or scope of any intellectual property or other rights that might
+            be claimed to pertain to the implementation or use of the technology described in this document or the extent
+            to which any license under such rights might or might not be available; neither does it represent that it has
+            made any effort to identify any such rights. Information on IMS procedures with respect to rights in IMS
+            specifications can be found at the IMS Global Intellectual Property Rights web page: http://www.imsglobal.org/ipr/imsipr_policyFinal.pdf.
+
+            Copyright (c) IMS Global Learning Consortium 1999-2015. All Rights Reserved.
+
+            Use of this specification to develop products or services is governed by the license with IMS found on the IMS website: http://www.imsglobal.org/license.html.
+
+            Permission is granted to all parties to use excerpts from this document as needed in producing requests for proposals.
+
+            The limited permissions granted above are perpetual and will not be revoked by IMS or its successors or assigns.
+
+            THIS SPECIFICATION IS BEING OFFERED WITHOUT ANY WARRANTY WHATSOEVER, AND IN PARTICULAR, ANY WARRANTY OF NONINFRINGEMENT IS
+            EXPRESSLY DISCLAIMED. ANY USE OF THIS SPECIFICATION SHALL BE MADE ENTIRELY AT THE IMPLEMENTERS OWN RISK, AND NEITHER THE CONSORTIUM
+            NOR ANY OF ITS MEMBERS OR SUBMITTERS, SHALL HAVE ANY LIABILITY WHATSOEVER TO ANY IMPLEMENTER OR THIRD PARTY FOR ANY DAMAGES OF
+            ANY NATURE WHATSOEVER, DIRECTLY OR INDIRECTLY, ARISING FROM THE USE OF THIS SPECIFICATION.
+
+            Source UML File Information
+            ===========================
+            The source file information must be supplied as an XMI file (without diagram layout information).
+            The supported UML authoring tools are:
+            (a) Poseidon - v6 (and later)
+            (b) Papyrus - v0.10.2 (and later)
+
+            Source XSLT File Information
+            ============================
+            XSL Generator:    Specificationv1p0_GenerationToolv1.xsl
+            XSLT Processor:   Saxon-PE-9.5.0.2
+            Release:          1.0
+            Date:             31st July, 2014
+            Autogen Engineer: Colin Smythe (IMS Global, UK)
+            Autogen Date:     2015-12-14
+
+            IMS Global Auto-generation Binding Tool-kit (I-BAT)
+            ===================================================
+            This file was auto-generated using the IMS Global Binding Auto-generation Tool-kit (I-BAT).  While every
+            attempt has been made to ensure that this tool auto-generates the files correctly, users should be aware
+            that this is an experimental tool.  Permission is given to make use of this tool.  IMS Global makes no
+            claim on the materials created by third party users of this tool.  Details on how to use this tool
+            are contained in the IMS Global "I-BAT" documentation available at the IMS Global web-site:
+            http://www.imsglobal.org.
+
+            Tool Copyright:  2012-2015  (c) IMS Global Learning Consortium Inc.  All Rights Reserved.
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- Generate Global Attributes (non-assigned) ******************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global Attributes *********************************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Global List Types *********************************************************************** -->
+
+    <xs:simpleType name="IdentifierList.Type">
+        <xs:restriction base="xs:NCName" />
+    </xs:simpleType>
+
+    <xs:simpleType name="View.Type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="author" />
+            <xs:enumeration value="candidate" />
+            <xs:enumeration value="proctor" />
+            <xs:enumeration value="scorer" />
+            <xs:enumeration value="testConstructor" />
+            <xs:enumeration value="tutor" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Namespaced extension Group  ************************************************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate Special DataTypes  ********************************************************************** -->
+
+    <xs:complexType name="EmptyPrimitiveType.Type">
+        <xs:complexContent>
+            <xs:restriction base="xs:anyType" />
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the enumerated simpleType declarations ************************************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Parameter) ***************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Derived) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Union) ********************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the simpleType elements based on IMS data-types (Complex) ******************************* -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon simpleType ************************************ -->
+
+    <xs:simpleType name="DateTime.Type">
+        <xs:restriction base="xs:dateTime">
+            <xs:pattern value="[0-9]{4}.*" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="Identifier.Type">
+        <xs:restriction base="xs:NCName" />
+    </xs:simpleType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived data-type elements based upon derived simpleType **************************** -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the ComplexTypes ************************************************************************ -->
+
+    <xs:complexType name="AssessmentResult.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                This is the root class to contain the assessment result data. An Assessment Result is used
+                to report the results of a candidate's interaction with a test and/or one or more items a-
+                ttempted. Information about the test is optional, in some systems it may be possible to i-
+                nteract with items that are not organized into a test at all. For example, items that are
+                organized with learning resources and presented individually in a formative context.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="context" type="Context.Type" minOccurs="1" maxOccurs="1" />
+            <xs:element name="testResult" type="TestResult.Type" minOccurs="0" maxOccurs="1" />
+            <xs:element name="itemResult" type="ItemResult.Type" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="CandidateResponse.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The response given by the candidate.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="value" type="Value.Type" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Context.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                This is the context for the 'assessmentResult'. It provides the corresponding set of iden-
+                tifiers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="sessionIdentifier" type="SessionIdentifier.Type" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="sourcedId" use="optional" type="Identifier.Type" />
+    </xs:complexType>
+
+    <xs:complexType name="CorrectResponse.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The correct response may be output as part of the report if desired. Systems are not limi-
+                ted to reporting correct responses declared in responseDeclarations. For example, a corre-
+                ct response may be set by a templateRule or may simply have been suppressed from the decl-
+                aration passed to the delivery engine e.g. for security.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="value" type="Value.Type" minOccurs="1" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="interpretation" use="optional" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="ItemResult.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The result of an item session is reported with an itemResult. A report may contain multip-
+                le results for the same instance of an item representing multiple attempts, progression t-
+                hrough an adaptive item or even more detailed tracking. In these cases, each item result
+                must have a different datestamp.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="responseVariable" type="ResponseVariable.Type" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="templateVariable" type="TemplateVariable.Type" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="outcomeVariable" type="OutcomeVariable.Type" minOccurs="1" maxOccurs="1"/>
+            </xs:choice>
+            <xs:element name="candidateComment" type="xs:string" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="identifier" use="required" type="xs:normalizedString" />
+        <xs:attribute name="sequenceIndex" use="optional" type="xs:integer" />
+        <xs:attribute name="datestamp" use="required" type="DateTime.Type" />
+        <xs:attribute name="sessionStatus" use="required">
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation source="documentation">
+                        The session status is used to keep track of the status of the item variables in an item s-
+                        ession.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="final" />
+                    <xs:enumeration value="initial" />
+                    <xs:enumeration value="pendingResponseProcessing" />
+                    <xs:enumeration value="pendingSubmission" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="OutcomeVariable.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The Item result information related to an 'Outcome Variable'.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="value" type="Value.Type" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="identifier" use="required" type="Identifier.Type" />
+        <xs:attribute name="cardinality" use="required">
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation source="documentation">
+                        An expression or itemVariable can either be single-valued or multi-valued. A multi-valued
+                        expression (or variable) is called a container. A container contains a list of values, th-
+                        is list may be empty in which case it is treated as NULL. All the values in a multiple or
+                        ordered container are drawn from the same value set, however, containers may contain mult-
+                        iple occurrences of the same value. In other words, [A,B,B,C] is an acceptable value for a
+                        container. A container with cardinality multiple and value [A,B,C] is equivalent to a sim-
+                        ilar one with value [C,B,A] whereas these two values would be considered distinct for con-
+                        tainers with cardinality ordered. When used as the value of a response variable this dist-
+                        inction is typified by the difference between selecting choices in a multi-response multi-
+                        -choice task and ranking choices in an order objects task. In the language of [ISO 11404]
+                        a container with multiple cardinality is a "bag-type", a container with ordered cardinali-
+                        ty is a "sequence-type" and a container with record cardinality is a "record-type". The r-
+                        ecord container type is a special container that contains a set of independent values each
+                        identified by its own identifier and having its own base-type. This specification does not
+                        make use of the record type directly however it is provided to enable customInteractions
+                        to manipulate more complex responses and customOperators to return more complex values, in
+                        addition to the use for detailed information about numeric responses described in the str-
+                        ingInteraction abstract class.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="multiple" />
+                    <xs:enumeration value="ordered" />
+                    <xs:enumeration value="record" />
+                    <xs:enumeration value="single" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="baseType" use="optional">
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation source="documentation">
+                        A base-type is simply a description of a set of atomic values (atomic to this specificati-
+                        on). Note that several of the baseTypes used to define the runtime data model have identi-
+                        cal definitions to those of the basic data types used to define the values for attributes
+                        in the specification itself. The use of an enumeration to define the set of baseTypes used
+                        in the runtime model, as opposed to the use of classes with similar names, is designed to
+                        help distinguish between these two distinct levels of modelling.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="boolean" />
+                    <xs:enumeration value="directedPair" />
+                    <xs:enumeration value="duration" />
+                    <xs:enumeration value="file" />
+                    <xs:enumeration value="float" />
+                    <xs:enumeration value="identifier" />
+                    <xs:enumeration value="integer" />
+                    <xs:enumeration value="pair" />
+                    <xs:enumeration value="point" />
+                    <xs:enumeration value="string" />
+                    <xs:enumeration value="uri" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="view" use="optional">
+            <xs:simpleType>
+                <xs:list itemType="View.Type" />
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="interpretation" use="optional" type="xs:string" />
+        <xs:attribute name="longInterpretation" use="optional" type="xs:anyURI" />
+        <xs:attribute name="normalMaximum" use="optional" type="xs:double" />
+        <xs:attribute name="normalMinimum" use="optional" type="xs:double" />
+        <xs:attribute name="masteryValue" use="optional" type="xs:double" />
+    </xs:complexType>
+
+    <xs:complexType name="ResponseVariable.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The Item result information related to a 'Response Variable'.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="correctResponse" type="CorrectResponse.Type" minOccurs="0" maxOccurs="1" />
+            <xs:element name="candidateResponse" type="CandidateResponse.Type" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="identifier" use="required" type="Identifier.Type" />
+        <xs:attribute name="cardinality" use="required">
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation source="documentation">
+                        An expression or itemVariable can either be single-valued or multi-valued. A multi-valued
+                        expression (or variable) is called a container. A container contains a list of values, th-
+                        is list may be empty in which case it is treated as NULL. All the values in a multiple or
+                        ordered container are drawn from the same value set, however, containers may contain mult-
+                        iple occurrences of the same value. In other words, [A,B,B,C] is an acceptable value for a
+                        container. A container with cardinality multiple and value [A,B,C] is equivalent to a sim-
+                        ilar one with value [C,B,A] whereas these two values would be considered distinct for con-
+                        tainers with cardinality ordered. When used as the value of a response variable this dist-
+                        inction is typified by the difference between selecting choices in a multi-response multi-
+                        -choice task and ranking choices in an order objects task. In the language of [ISO 11404]
+                        a container with multiple cardinality is a "bag-type", a container with ordered cardinali-
+                        ty is a "sequence-type" and a container with record cardinality is a "record-type". The r-
+                        ecord container type is a special container that contains a set of independent values each
+                        identified by its own identifier and having its own base-type. This specification does not
+                        make use of the record type directly however it is provided to enable customInteractions
+                        to manipulate more complex responses and customOperators to return more complex values, in
+                        addition to the use for detailed information about numeric responses described in the str-
+                        ingInteraction abstract class.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="multiple" />
+                    <xs:enumeration value="ordered" />
+                    <xs:enumeration value="record" />
+                    <xs:enumeration value="single" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="baseType" use="optional">
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation source="documentation">
+                        A base-type is simply a description of a set of atomic values (atomic to this specificati-
+                        on). Note that several of the baseTypes used to define the runtime data model have identi-
+                        cal definitions to those of the basic data types used to define the values for attributes
+                        in the specification itself. The use of an enumeration to define the set of baseTypes used
+                        in the runtime model, as opposed to the use of classes with similar names, is designed to
+                        help distinguish between these two distinct levels of modelling.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="boolean" />
+                    <xs:enumeration value="directedPair" />
+                    <xs:enumeration value="duration" />
+                    <xs:enumeration value="file" />
+                    <xs:enumeration value="float" />
+                    <xs:enumeration value="identifier" />
+                    <xs:enumeration value="integer" />
+                    <xs:enumeration value="pair" />
+                    <xs:enumeration value="point" />
+                    <xs:enumeration value="string" />
+                    <xs:enumeration value="uri" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="choiceSequence" use="optional">
+            <xs:simpleType>
+                <xs:list itemType="IdentifierList.Type" />
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="TemplateVariable.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The Item result information related to a 'Template Variable'.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="value" type="Value.Type" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="identifier" use="required" type="Identifier.Type" />
+        <xs:attribute name="cardinality" use="required">
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation source="documentation">
+                        An expression or itemVariable can either be single-valued or multi-valued. A multi-valued
+                        expression (or variable) is called a container. A container contains a list of values, th-
+                        is list may be empty in which case it is treated as NULL. All the values in a multiple or
+                        ordered container are drawn from the same value set, however, containers may contain mult-
+                        iple occurrences of the same value. In other words, [A,B,B,C] is an acceptable value for a
+                        container. A container with cardinality multiple and value [A,B,C] is equivalent to a sim-
+                        ilar one with value [C,B,A] whereas these two values would be considered distinct for con-
+                        tainers with cardinality ordered. When used as the value of a response variable this dist-
+                        inction is typified by the difference between selecting choices in a multi-response multi-
+                        -choice task and ranking choices in an order objects task. In the language of [ISO 11404]
+                        a container with multiple cardinality is a "bag-type", a container with ordered cardinali-
+                        ty is a "sequence-type" and a container with record cardinality is a "record-type". The r-
+                        ecord container type is a special container that contains a set of independent values each
+                        identified by its own identifier and having its own base-type. This specification does not
+                        make use of the record type directly however it is provided to enable customInteractions
+                        to manipulate more complex responses and customOperators to return more complex values, in
+                        addition to the use for detailed information about numeric responses described in the str-
+                        ingInteraction abstract class.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="multiple" />
+                    <xs:enumeration value="ordered" />
+                    <xs:enumeration value="record" />
+                    <xs:enumeration value="single" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="baseType" use="optional">
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation source="documentation">
+                        A base-type is simply a description of a set of atomic values (atomic to this specificati-
+                        on). Note that several of the baseTypes used to define the runtime data model have identi-
+                        cal definitions to those of the basic data types used to define the values for attributes
+                        in the specification itself. The use of an enumeration to define the set of baseTypes used
+                        in the runtime model, as opposed to the use of classes with similar names, is designed to
+                        help distinguish between these two distinct levels of modelling.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="boolean" />
+                    <xs:enumeration value="directedPair" />
+                    <xs:enumeration value="duration" />
+                    <xs:enumeration value="file" />
+                    <xs:enumeration value="float" />
+                    <xs:enumeration value="identifier" />
+                    <xs:enumeration value="integer" />
+                    <xs:enumeration value="pair" />
+                    <xs:enumeration value="point" />
+                    <xs:enumeration value="string" />
+                    <xs:enumeration value="uri" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="TestResult.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The container for the Test result. When a test result is given the following item results
+                must relate only to items that were selected for presentation as part of the corresponding
+                test session. Furthermore, all items selected for presentation should be reported with a
+                corresponding itemResult.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="responseVariable" type="ResponseVariable.Type" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="templateVariable" type="TemplateVariable.Type" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="outcomeVariable" type="OutcomeVariable.Type" minOccurs="1" maxOccurs="1"/>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="identifier" use="required" type="xs:normalizedString" />
+        <xs:attribute name="datestamp" use="required" type="DateTime.Type" />
+    </xs:complexType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Generate the derived ComplexTypes **************************************************************** -->
+
+    <xs:complexType name="SessionIdentifier.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                The system that creates the result (for example, the test delivery system) should assign a
+                session identifier that it can use to identify the session.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="EmptyPrimitiveType.Type">
+                <xs:attribute name="sourceID" use="required" type="xs:anyURI" />
+                <xs:attribute name="identifier" use="required" type="xs:normalizedString" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="Value.Type" abstract="false" mixed="false">
+        <xs:annotation>
+            <xs:documentation source="documentation">
+                A class that can represent a single value of any baseType in variable declarations and re-
+                sult reports. The base-type is defined by the baseType attribute of the declaration except
+                in the case of variables with record cardinality.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:normalizedString">
+                <xs:attribute name="fieldIdentifier" use="optional" type="Identifier.Type" />
+                <xs:attribute name="baseType" use="optional">
+                    <xs:simpleType>
+                        <xs:annotation>
+                            <xs:documentation source="documentation">
+                                A base-type is simply a description of a set of atomic values (atomic to this specificati-
+                                on). Note that several of the baseTypes used to define the runtime data model have identi-
+                                cal definitions to those of the basic data types used to define the values for attributes
+                                in the specification itself. The use of an enumeration to define the set of baseTypes used
+                                in the runtime model, as opposed to the use of classes with similar names, is designed to
+                                help distinguish between these two distinct levels of modelling.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="boolean" />
+                            <xs:enumeration value="directedPair" />
+                            <xs:enumeration value="duration" />
+                            <xs:enumeration value="file" />
+                            <xs:enumeration value="float" />
+                            <xs:enumeration value="identifier" />
+                            <xs:enumeration value="integer" />
+                            <xs:enumeration value="pair" />
+                            <xs:enumeration value="point" />
+                            <xs:enumeration value="string" />
+                            <xs:enumeration value="uri" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Complex) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the elements (Derived) ************************************************************ -->
+
+    <!-- ================================================================================================== -->
+
+    <!-- Declaration of the root element(s) *************************************************************** -->
+
+    <xs:element name="assessmentResult" type="AssessmentResult.Type" />
+
+    <!-- ================================================================================================== -->
+
+</xs:schema>

--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -523,14 +523,16 @@ abstract class Variable
     {
         $values = new ValueCollection();
 
-        if ($this->getCardinality() === Cardinality::SINGLE) {
-            $values[] = new Value($this->getValue() . '');
-        } elseif ($this->getValue() !== null && ($this->getCardinality() === Cardinality::MULTIPLE || $this->getCardinality() === Cardinality::ORDERED)) {
-            foreach ($this->getValue() as $v) {
-                $values[] = new Value($this->getValue() . '');
+        if ($this->getValue() !== null) {
+            if ($this->getCardinality() === Cardinality::SINGLE) {
+                $values[] = new Value(\qtism\data\storage\Utils::stringToDatatype($this->getValue() . '', $this->getBaseType()));
+            } elseif ($this->getValue() !== null && ($this->getCardinality() === Cardinality::MULTIPLE || $this->getCardinality() === Cardinality::ORDERED)) {
+                foreach ($this->getValue() as $v) {
+                    $values[] = new Value(\qtism\data\storage\Utils::stringToDatatype($v->getValue() . '', $this->getBaseType()));
+                }
             }
         }
-
+        
         return $values;
     }
 

--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -26,6 +26,7 @@ namespace qtism\runtime\common;
 use qtism\common\collections\Container;
 use qtism\common\datatypes\QtiDatatype;
 use qtism\data\expressions\operators\IsNull;
+use qtism\data\state\Value;
 use qtism\data\state\ValueCollection;
 use qtism\data\state\VariableDeclaration;
 use qtism\common\enums\Cardinality;
@@ -509,6 +510,28 @@ abstract class Variable
     public function isString()
     {
         return (!$this->isNull() && $this->getBaseType() === BaseType::STRING);
+    }
+
+    /**
+     * Get Data Model Values
+     *
+     * Get the representation of the variable's value in terms of value QTI elements.
+     *
+     * @return ValueCollection
+     */
+    public function getDataModelValues()
+    {
+        $values = new ValueCollection();
+
+        if ($this->getCardinality() === Cardinality::SINGLE) {
+            $values[] = new Value($this->getValue() . '');
+        } elseif ($this->getValue() !== null && ($this->getCardinality() === Cardinality::MULTIPLE || $this->getCardinality() === Cardinality::ORDERED)) {
+            foreach ($this->getValue() as $v) {
+                $values[] = new Value($this->getValue() . '');
+            }
+        }
+
+        return $values;
     }
 
     /**

--- a/src/qtism/runtime/results/AbstractResultBuilder.php
+++ b/src/qtism/runtime/results/AbstractResultBuilder.php
@@ -30,7 +30,14 @@ use qtism\data\results\ResultResponseVariable;
 use qtism\runtime\common\OutcomeVariable;
 use qtism\runtime\common\ResponseVariable;
 use qtism\runtime\common\State;
+use qtism\runtime\common\VariableCollection;
 
+/**
+ * Class AbstractResultBuilder
+ *
+ * This abstract class aims at providing a base class for QTI Results
+ * building from AssessmentItemSession and AssessmentTestSession objects.
+ */
 abstract class AbstractResultBuilder
 {
     /**
@@ -38,11 +45,25 @@ abstract class AbstractResultBuilder
      */
     protected $state;
 
+    /**
+     * AbstractResultBuilder constructor.
+     *
+     * Create a new AbstractResultBuilder based object.
+     *
+     * @param State $state
+     */
     public function __construct(State $state)
     {
         $this->state = $state;
     }
 
+    /**
+     * Build Variables
+     *
+     * Build the ItemVariable objects contained in the target State object.
+     *
+     * @return ItemVariableCollection
+     */
     protected function buildVariables() {
         $itemVariables = new ItemVariableCollection();
 
@@ -80,7 +101,19 @@ abstract class AbstractResultBuilder
         return $itemVariables;
     }
 
+    /**
+     * Get All Variables
+     *
+     * Get all the variables to be serialized as ItemVariable objects.
+     *
+     * @return VariableCollection
+     */
     abstract protected function getAllVariables();
 
+    /**
+     * Trigger the build.
+     *
+     * @return mixed
+     */
     abstract public function buildResult();
 }

--- a/src/qtism/runtime/results/AbstractResultBuilder.php
+++ b/src/qtism/runtime/results/AbstractResultBuilder.php
@@ -1,4 +1,24 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Bogaerts Jérôme, <jerome@taotesting.com>
+ * @license GPLv2
+ */
 
 namespace qtism\runtime\results;
 

--- a/src/qtism/runtime/results/AbstractResultBuilder.php
+++ b/src/qtism/runtime/results/AbstractResultBuilder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace qtism\runtime\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\results\CandidateResponse;
+use qtism\data\results\ItemVariableCollection;
+use qtism\data\results\ResultOutcomeVariable;
+use qtism\data\results\ResultResponseVariable;
+use qtism\runtime\common\OutcomeVariable;
+use qtism\runtime\common\ResponseVariable;
+use qtism\runtime\common\State;
+
+abstract class AbstractResultBuilder
+{
+    /**
+     * @var State
+     */
+    protected $state;
+
+    public function __construct(State $state)
+    {
+        $this->state = $state;
+    }
+
+    protected function buildVariables() {
+        $itemVariables = new ItemVariableCollection();
+
+        foreach ($this->getAllVariables() as $variable) {
+
+            if ($variable instanceof ResponseVariable) {
+                $var = new ResultResponseVariable(
+                    new QtiIdentifier($variable->getIdentifier()),
+                    $variable->getCardinality(),
+                    new CandidateResponse($variable->getDataModelValues())
+                );
+
+                if ($variable->getBaseType() !== -1) {
+                    $var->setBaseType($variable->getBaseType());
+                }
+
+                $itemVariables[] = $var;
+
+            } elseif ($variable instanceof OutcomeVariable) {
+                $var = new ResultOutcomeVariable(
+                    new QtiIdentifier($variable->getIdentifier()),
+                    $variable->getCardinality()
+                );
+
+                if ($variable->getBaseType() !== -1) {
+                    $var->setBaseType($variable->getBaseType());
+                }
+
+                $var->setValues($variable->getDataModelValues());
+
+                $itemVariables[] = $var;
+            }
+        }
+
+        return $itemVariables;
+    }
+
+    abstract protected function getAllVariables();
+
+    abstract public function buildResult();
+}

--- a/src/qtism/runtime/results/AssessmentResultBuilder.php
+++ b/src/qtism/runtime/results/AssessmentResultBuilder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace qtism\runtime\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\AssessmentItemRef;
+use qtism\data\results\AssessmentResult;
+use qtism\data\results\Context;
+use qtism\data\results\ItemResultCollection;
+use qtism\data\results\TestResult;
+use qtism\runtime\tests\AssessmentItemSession;
+use qtism\runtime\tests\AssessmentTestSession;
+
+class AssessmentResultBuilder extends AbstractResultBuilder
+{
+
+    public function buildResult()
+    {
+        /** @var AssessmentTestSession $state */
+        $state = $this->state;
+
+        $assessmentContext = new Context();
+        $assessmentResult = new AssessmentResult($assessmentContext);
+
+        $testResult = new TestResult(
+            new QtiIdentifier($state->getSessionId()),
+            new \DateTime()
+        );
+
+        $testResult->setItemVariables($this->buildVariables());
+        $assessmentResult->setTestResult($testResult);
+
+        $itemResults = new ItemResultCollection();
+
+        /** @var AssessmentItemRef $assessmentItemRef */
+        foreach ($state->getRoute()->getAssessmentItemRefs() as $assessmentItemRef) {
+            $assessmentItemSessions = $state->getAssessmentItemSessions($assessmentItemRef->getIdentifier());
+
+            /** @var AssessmentItemSession $assessmentItemSession */
+            foreach ($assessmentItemSessions as $assessmentItemSession) {
+                $itemResultBuilder = new ItemResultBuilder($assessmentItemSession);
+                $itemResults[] = $itemResultBuilder->buildResult();
+            }
+        }
+
+        $assessmentResult->setItemResults($itemResults);
+
+        return $assessmentResult;
+    }
+
+    protected function getAllVariables()
+    {
+        return $this->state->getAllVariables();
+    }
+}

--- a/src/qtism/runtime/results/AssessmentResultBuilder.php
+++ b/src/qtism/runtime/results/AssessmentResultBuilder.php
@@ -1,4 +1,24 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Bogaerts Jérôme, <jerome@taotesting.com>
+ * @license GPLv2
+ */
 
 namespace qtism\runtime\results;
 

--- a/src/qtism/runtime/results/AssessmentResultBuilder.php
+++ b/src/qtism/runtime/results/AssessmentResultBuilder.php
@@ -31,9 +31,20 @@ use qtism\data\results\TestResult;
 use qtism\runtime\tests\AssessmentItemSession;
 use qtism\runtime\tests\AssessmentTestSession;
 
+/**
+ * Class AssessmentResultBuilder
+ *
+ * This class aims at building QTI AssessmentResult objects from a given
+ * AssessmentTestSession object.
+ */
 class AssessmentResultBuilder extends AbstractResultBuilder
 {
 
+    /**
+     * Build Result
+     *
+     * @return AssessmentResult
+     */
     public function buildResult()
     {
         /** @var AssessmentTestSession $state */
@@ -68,6 +79,13 @@ class AssessmentResultBuilder extends AbstractResultBuilder
         return $assessmentResult;
     }
 
+    /**
+     * Get the variables
+     *
+     * Get the variables representing the intrinsic state of the AssessmentTestSession.
+     *
+     * @return \qtism\runtime\common\VariableCollection
+     */
     protected function getAllVariables()
     {
         return $this->state->getAllVariables();

--- a/src/qtism/runtime/results/ItemResultBuilder.php
+++ b/src/qtism/runtime/results/ItemResultBuilder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace qtism\runtime\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\results\ItemResult;
+use qtism\data\results\SessionStatus;
+use qtism\runtime\tests\AssessmentItemSession;
+
+class ItemResultBuilder extends AbstractResultBuilder
+{
+    public function buildResult()
+    {
+        /** @var AssessmentItemSession $state */
+        $state = $this->state;
+
+        $itemResultIdentifier = new QtiIdentifier(
+            $state->getAssessmentItem()->getIdentifier()
+        );
+
+        $itemResult = new ItemResult(
+            $itemResultIdentifier,
+            new \DateTime(),
+            SessionStatus::STATUS_FINAL
+        );
+
+        $itemResult->setItemVariables($this->buildVariables());
+
+        return $itemResult;
+    }
+
+    protected function getAllVariables()
+    {
+        return $this->state->getAllVariables();
+    }
+}

--- a/src/qtism/runtime/results/ItemResultBuilder.php
+++ b/src/qtism/runtime/results/ItemResultBuilder.php
@@ -1,4 +1,24 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Bogaerts Jérôme, <jerome@taotesting.com>
+ * @license GPLv2
+ */
 
 namespace qtism\runtime\results;
 

--- a/src/qtism/runtime/results/ItemResultBuilder.php
+++ b/src/qtism/runtime/results/ItemResultBuilder.php
@@ -27,8 +27,19 @@ use qtism\data\results\ItemResult;
 use qtism\data\results\SessionStatus;
 use qtism\runtime\tests\AssessmentItemSession;
 
+/**
+ * Class ItemResultBuilder
+ *
+ * This class aims at building ItemResult objects from
+ * AssessmentItemSession objects.
+ */
 class ItemResultBuilder extends AbstractResultBuilder
 {
+    /**
+     * Build ItemResult
+     *
+     * @return ItemResult
+     */
     public function buildResult()
     {
         /** @var AssessmentItemSession $state */
@@ -49,6 +60,13 @@ class ItemResultBuilder extends AbstractResultBuilder
         return $itemResult;
     }
 
+    /**
+     * Get all variables
+     *
+     * Get all the variables held by the AssessmentItemSession.
+     *
+     * @return \qtism\runtime\common\VariableCollection
+     */
     protected function getAllVariables()
     {
         return $this->state->getAllVariables();

--- a/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
@@ -1,4 +1,24 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Bogaerts Jérôme, <jerome@taotesting.com>
+ * @license GPLv2
+ */
 
 namespace qtismtest\data\storage\xml;
 

--- a/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
@@ -76,4 +76,19 @@ class XmlResultDocumentTest extends QtiSmTestCase
         $xmlDoc = new XmlResultDocument();
         $xmlDoc->load(self::samplesDir() . 'results/simple-assessment-result-missing-data.xml', true);
     }
+
+    public function testSaveToString()
+    {
+        $xmlDoc = new XmlResultDocument();
+        $xmlDoc->load(self::samplesDir() . 'results/simple-assessment-result.xml', true);
+
+        $str = $xmlDoc->saveToString(false);
+        $expected = '<assessmentResult xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_result_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_result_v2p1.xsd"><context sourcedId="fixture-sourcedId"><sessionIdentifier sourceID="http://sessionIdentifier1-sourceID" identifier="sessionIdentifier1-id"/><sessionIdentifier sourceID="http://sessionIdentifier2-sourceID" identifier="sessionIdentifier2-id"/></context><testResult identifier="fixture-test-identifier" datestamp="2018-06-27T09:41:45+0000"><responseVariable identifier="response-identifier" cardinality="single"><correctResponse><value>fixture-test-value1</value><value>fixture-test-value2</value></correctResponse><candidateResponse><value fieldIdentifier="test-id-1">fixture-test-value1</value><value fieldIdentifier="test-id-2">fixture-test-value2</value><value fieldIdentifier="test-id-3">fixture-test-value3</value></candidateResponse></responseVariable><templateVariable identifier="response-identifier" cardinality="single"><value>test1</value><value>test2</value></templateVariable></testResult><itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45+0000" sessionStatus="final" sequenceIndex="2"><candidateComment>comment-fixture</candidateComment><responseVariable identifier="fixture-identifier" cardinality="single" baseType="string" choiceSequence="value-id-1"><correctResponse><value>fixture-value1</value><value>fixture-value2</value></correctResponse><candidateResponse><value fieldIdentifier="value-id-1">fixture-value1</value><value fieldIdentifier="value-id-2">fixture-value2</value><value fieldIdentifier="value-id-3">fixture-value3</value></candidateResponse></responseVariable><outcomeVariable identifier="fixture-identifier" cardinality="single" baseType="string" view="candidate" interpretation="fixture-interpretation" longInterpretation="http://fixture-interpretation" normalMinimum="2" normalMaximum="3" masteryValue="4"><value>fixture-value1</value><value>fixture-value2</value><value>fixture-value3</value></outcomeVariable><templateVariable identifier="fixture-identifier" cardinality="single" baseType="string"><value>fixture-value1</value><value>fixture-value2</value><value>fixture-value3</value></templateVariable></itemResult><itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45+0000" sessionStatus="final" sequenceIndex="2"><responseVariable identifier="fixture-identifier" cardinality="single" baseType="string" choiceSequence="value-id-1"><correctResponse><value>fixture-value1</value><value>fixture-value2</value></correctResponse><candidateResponse><value fieldIdentifier="value-id-1">fixture-value1</value><value fieldIdentifier="value-id-2">fixture-value2</value><value fieldIdentifier="value-id-3">fixture-value3</value></candidateResponse></responseVariable><outcomeVariable identifier="fixture-identifier" cardinality="single" baseType="string" view="candidate" interpretation="fixture-interpretation" longInterpretation="http://fixture-interpretation" normalMinimum="2" normalMaximum="3" masteryValue="4"><value>fixture-value1</value><value>fixture-value2</value><value>fixture-value3</value></outcomeVariable></itemResult></assessmentResult>';
+        $expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" . $expected . "\n";
+
+        $this->assertEquals(
+            $expected,
+            $str
+        );
+    }
 }

--- a/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace qtismtest\data\storage\xml;
+
+use qtism\data\results\AssessmentResult;
+use qtism\data\results\Context;
+use qtism\data\results\SessionIdentifier;
+use qtism\data\results\SessionIdentifierCollection;
+use qtism\data\storage\xml\XmlResultDocument;
+use qtismtest\QtiSmTestCase;
+
+class XmlResultDocumentTest extends QtiSmTestCase
+{
+    public function testLoad()
+    {
+        $xmlDoc = new XmlResultDocument();
+        $xmlDoc->load(self::samplesDir() . 'results/simple-assessment-result.xml', true);
+
+        $this->assertEquals('2.1.0', $xmlDoc->getVersion());
+
+        /** @var AssessmentResult $assessmentResult */
+        $assessmentResult = $xmlDoc->getDocumentComponent();
+        $this->assertInstanceOf(AssessmentResult::class, $assessmentResult);
+
+        $context = $assessmentResult->getContext();
+        $this->assertInstanceOf(Context::class, $context);
+
+        $sessionIdentifiers = $context->getSessionIdentifiers();
+        $this->assertInstanceOf(SessionIdentifierCollection::class, $sessionIdentifiers);
+
+        /** @var SessionIdentifier $sessionIdentifier1 */
+        $sessionIdentifier1 = $sessionIdentifiers[0];
+        $this->assertEquals('sessionIdentifier1-id', $sessionIdentifier1->getIdentifier());
+        $this->assertEquals('http://sessionIdentifier1-sourceID', $sessionIdentifier1->getSourceID());
+
+        /** @var SessionIdentifier $sessionIdentifier2 */
+        $sessionIdentifier2 = $sessionIdentifiers[1];
+        $this->assertEquals('sessionIdentifier2-id', $sessionIdentifier2->getIdentifier());
+        $this->assertEquals('http://sessionIdentifier2-sourceID', $sessionIdentifier2->getSourceID());
+
+        $testResult = $assessmentResult->getTestResult();
+        $this->assertEquals('fixture-test-identifier', $testResult->getIdentifier());
+        $this->assertInstanceOf(\DateTime::class, $testResult->getDatestamp());
+
+        $this->assertCount(2, $testResult->getItemVariables());
+
+    }
+}

--- a/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
@@ -7,6 +7,7 @@ use qtism\data\results\Context;
 use qtism\data\results\SessionIdentifier;
 use qtism\data\results\SessionIdentifierCollection;
 use qtism\data\storage\xml\XmlResultDocument;
+use qtism\data\storage\xml\XmlStorageException;
 use qtismtest\QtiSmTestCase;
 
 class XmlResultDocumentTest extends QtiSmTestCase
@@ -43,6 +44,16 @@ class XmlResultDocumentTest extends QtiSmTestCase
         $this->assertInstanceOf(\DateTime::class, $testResult->getDatestamp());
 
         $this->assertCount(2, $testResult->getItemVariables());
+    }
 
+    public function testLoadMissingData()
+    {
+        $this->setExpectedException(
+            XmlStorageException::class,
+            'The document could not be validated with XML Schema'
+        );
+
+        $xmlDoc = new XmlResultDocument();
+        $xmlDoc->load(self::samplesDir() . 'results/simple-assessment-result-missing-data.xml', true);
     }
 }

--- a/test/qtismtest/data/storage/xml/marshalling/AssessmentResultMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/AssessmentResultMarshallerTest.php
@@ -1,0 +1,354 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use DateTime;
+use qtism\data\results\AssessmentResult;
+use qtism\data\results\Context;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiUri;
+use qtism\data\results\SessionIdentifier;
+use qtism\data\results\SessionIdentifierCollection;
+use qtism\data\results\TestResult;
+use qtism\data\state\Value;
+use qtism\data\state\ValueCollection;
+use qtism\data\results\ItemResultCollection;
+use qtism\data\results\ResultResponseVariable;
+use qtism\data\results\ResultTemplateVariable;
+use qtism\data\results\ResultOutcomeVariable;
+use qtism\data\results\ItemResult;
+use qtism\data\results\CandidateResponse;
+use qtism\data\results\ItemVariableCollection;
+use qtismtest\QtiSmTestCase;
+
+class AssessmentResultMarshallerTest extends QtiSmTestCase
+{
+    public function testValidMinimalXml()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <assessmentResult xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p2">
+                <context />
+            </assessmentResult>
+        ';
+
+        /** @var AssessmentResult $assessmentResult */
+        $assessmentResult = $this->createComponentFromXml($xml);
+        $this->assertInstanceOf(AssessmentResult::class, $assessmentResult);
+
+        $context = $assessmentResult->getContext();
+        $this->assertFalse($context->hasSourcedId());
+        $this->assertFalse($context->hasSessionIdentifiers());
+
+        $this->assertFalse($assessmentResult->hasTestResult());
+        $this->assertEquals(null, $assessmentResult->getTestResult());
+        $this->assertFalse($assessmentResult->hasItemResults());
+        $this->assertEquals(null, $assessmentResult->getItemResults());
+    }
+
+    public function testUnmarshall()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <assessmentResult xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p2">
+                <context sourcedId="fixture-sourcedId">
+                    <sessionIdentifier sourceID="http://sessionIdentifier1-sourceID" identifier="sessionIdentifier1-id"/>
+                    <sessionIdentifier sourceID="http://sessionIdentifier2-sourceID" identifier="sessionIdentifier2-id"/>
+                </context>
+                <testResult identifier="fixture-test-identifier" datestamp="2018-06-27T09:41:45.529">
+                    <responseVariable identifier="response-identifier" cardinality="single">
+                        <correctResponse>
+                            <value>fixture-test-value1</value>
+                            <value>fixture-test-value2</value>
+                        </correctResponse>
+                        <candidateResponse>
+                            <value fieldIdentifier="test-id-1">fixture-test-value1</value>
+                            <value fieldIdentifier="test-id-2">fixture-test-value2</value>
+                            <value fieldIdentifier="test-id-3">fixture-test-value3</value>
+                        </candidateResponse>
+                    </responseVariable>
+                    <templateVariable identifier="response-identifier" cardinality="single">
+                        <value>test1</value>
+                        <value>test2</value>
+                    </templateVariable>
+                </testResult>
+                <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529" sessionStatus="final" sequenceIndex="2">
+                    <responseVariable cardinality="single" identifier="fixture-identifier" baseType="string" choiceSequence="value-id-1">
+                        <correctResponse>
+                            <value>fixture-value1</value>
+                            <value>fixture-value2</value>
+                        </correctResponse>
+                        <candidateResponse>
+                            <value fieldIdentifier="value-id-1">fixture-value1</value>
+                            <value fieldIdentifier="value-id-2">fixture-value2</value>
+                            <value fieldIdentifier="value-id-3">fixture-value3</value>
+                        </candidateResponse>
+                    </responseVariable>
+                    <templateVariable cardinality="single" identifier="fixture-identifier" baseType="string">
+                        <value>fixture-value1</value>
+                        <value>fixture-value2</value>
+                        <value>fixture-value3</value>
+                    </templateVariable>
+                    <outcomeVariable 
+                        cardinality="single" 
+                        identifier="fixture-identifier" 
+                        baseType="string" 
+                        view="candidate"
+                        interpretation="fixture-interpretation"
+                        longInterpretation="http://fixture-interpretation"
+                        normalMinimum="2"
+                        normalMaximum="3"
+                        masteryValue="4"
+                        >
+                        <value>fixture-value1</value>
+                        <value>fixture-value2</value>
+                        <value>fixture-value3</value>
+                    </outcomeVariable>
+                    <candidateComment>comment-fixture</candidateComment>
+                </itemResult>
+                <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529" sessionStatus="final" sequenceIndex="2">
+                    <responseVariable cardinality="single" identifier="fixture-identifier" baseType="string" choiceSequence="value-id-1">
+                        <correctResponse>
+                            <value>fixture-value1</value>
+                            <value>fixture-value2</value>
+                        </correctResponse>
+                        <candidateResponse>
+                            <value fieldIdentifier="value-id-1">fixture-value1</value>
+                            <value fieldIdentifier="value-id-2">fixture-value2</value>
+                            <value fieldIdentifier="value-id-3">fixture-value3</value>
+                        </candidateResponse>
+                    </responseVariable>
+                    <outcomeVariable 
+                        cardinality="single" 
+                        identifier="fixture-identifier" 
+                        baseType="string" 
+                        view="candidate"
+                        interpretation="fixture-interpretation"
+                        longInterpretation="http://fixture-interpretation"
+                        normalMinimum="2"
+                        normalMaximum="3"
+                        masteryValue="4"
+                        >
+                        <value>fixture-value1</value>
+                        <value>fixture-value2</value>
+                        <value>fixture-value3</value>
+                    </outcomeVariable>
+                </itemResult>
+            </assessmentResult>
+        ';
+        
+        /** @var AssessmentResult $assessmentResult */
+        $assessmentResult = $this->createComponentFromXml($xml);
+        $this->assertInstanceOf(AssessmentResult::class, $assessmentResult);
+
+        $context = $assessmentResult->getContext();
+        $this->assertEquals('fixture-sourcedId', $context->getSourcedId());
+        $this->assertEquals(2, $context->getSessionIdentifiers()->count());
+
+        $this->assertTrue($assessmentResult->hasTestResult());
+        $this->assertEquals(2, $assessmentResult->getTestResult()->getItemVariables()->count());
+
+        $this->assertTrue($assessmentResult->hasItemResults());
+        $this->assertEquals(2, $assessmentResult->getItemResults()->count());
+        $this->assertEquals(3, $assessmentResult->getItemResults()[0]->getItemVariables()->count());
+        $this->assertTrue($assessmentResult->getItemResults()[0]->hasCandidateComment());
+        $this->assertEquals(2, $assessmentResult->getItemResults()[1]->getItemVariables()->count());
+        $this->assertFalse($assessmentResult->getItemResults()[1]->hasCandidateComment());
+
+
+        $assessmentResult = $this->createComponentFromXml($xml);
+        $this->assertInstanceOf(AssessmentResult::class, $assessmentResult);
+    }
+
+    public function testUnmarshallWithoutTestResult()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <assessmentResult xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p2">
+                <context />
+                <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529" sessionStatus="final" sequenceIndex="2">
+                    <responseVariable cardinality="single" identifier="fixture-identifier" baseType="string" choiceSequence="value-id-1">
+                        <correctResponse>
+                            <value>fixture-value1</value>
+                            <value>fixture-value2</value>
+                        </correctResponse>
+                        <candidateResponse>
+                            <value fieldIdentifier="value-id-1">fixture-value1</value>
+                            <value fieldIdentifier="value-id-2">fixture-value2</value>
+                            <value fieldIdentifier="value-id-3">fixture-value3</value>
+                        </candidateResponse>
+                    </responseVariable>
+                </itemResult>
+                <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529" sessionStatus="final" sequenceIndex="2">
+                    <responseVariable cardinality="single" identifier="fixture-identifier" baseType="string" choiceSequence="value-id-1">
+                        <correctResponse>
+                            <value>fixture-value1</value>
+                            <value>fixture-value2</value>
+                        </correctResponse>
+                        <candidateResponse>
+                            <value fieldIdentifier="value-id-1">fixture-value1</value>
+                            <value fieldIdentifier="value-id-2">fixture-value2</value>
+                            <value fieldIdentifier="value-id-3">fixture-value3</value>
+                        </candidateResponse>
+                    </responseVariable>
+                </itemResult>
+            </assessmentResult>
+        ';
+
+        /** @var AssessmentResult $assessmentResult */
+        $assessmentResult = $this->createComponentFromXml($xml);
+        $this->assertInstanceOf(AssessmentResult::class, $assessmentResult);
+
+        $this->assertFalse($assessmentResult->hasTestResult());
+
+        $this->assertTrue($assessmentResult->hasItemResults());
+        $this->assertEquals(2, $assessmentResult->getItemResults()->count());
+
+        $assessmentResult = $this->createComponentFromXml($xml);
+        $this->assertInstanceOf(AssessmentResult::class, $assessmentResult);
+    }
+
+    public function testMarshall()
+    {
+        $component = new AssessmentResult(
+            new Context(
+                new QtiIdentifier('fixture-sourcedId'),
+                new SessionIdentifierCollection(array(
+                    new SessionIdentifier(
+                        new QtiUri('http://sessionIdentifier1-sourceID'), new QtiIdentifier('sessionIdentifier1-id')
+                    ),
+                    new SessionIdentifier(
+                        new QtiUri('http://sessionIdentifier2-sourceID'), new QtiIdentifier('sessionIdentifier2-id')
+                    )
+                ))
+            ),
+            new TestResult(
+                new QtiIdentifier('fixture-identifier'),
+                new DateTime('2018-06-27T09:41:45.529'),
+                new ItemVariableCollection(array(
+                    new ResultResponseVariable(
+                        new QtiIdentifier('response-identifier'),
+                        0,
+                        new CandidateResponse(new ValueCollection(array(
+                            new Value('fixture-test-value1')
+                        )))
+                    ),
+                    new ResultTemplateVariable(
+                        new QtiIdentifier('fixture-identifier'),
+                        0,
+                        4,
+                        new ValueCollection(array(
+                            new Value('fixture-test-value1'),
+                            new Value('fixture-test-value2')
+                        ))
+                    )
+                ))
+            ),
+            new ItemResultCollection(array(
+                new ItemResult(
+                    new QtiIdentifier('fixture-identifier'),
+                    new DateTime('2018-06-27T09:41:45.529'),
+                    1,
+                    new ItemVariableCollection(array(
+                        new ResultResponseVariable(
+                            new QtiIdentifier('response-identifier'),
+                            0,
+                            new CandidateResponse(new ValueCollection(array(
+                                new Value('fixture-test-value1')
+                            )))
+                        ),
+                        new ResultTemplateVariable(
+                            new QtiIdentifier('response-identifier'),
+                            0,
+                            4,
+                            new ValueCollection(array(
+                                    new Value('fixture-test-value1'),
+                                    new Value('fixture-test-value2')
+                                )
+                            )),
+                        new ResultOutcomeVariable(
+                            new QtiIdentifier('response-identifier'),
+                            0,
+                            4,
+                            new ValueCollection(array(
+                                    new Value('fixture-test-value1'),
+                                    new Value('fixture-test-value2')
+                                )
+                            ))
+                    ))
+                ),
+                new ItemResult(
+                    new QtiIdentifier('fixture-identifier'),
+                    new DateTime('2018-06-27T09:41:45.529'),
+                    1,
+                    new ItemVariableCollection(array(
+                        new ResultResponseVariable(
+                            new QtiIdentifier('response-identifier'),
+                            0,
+                            new CandidateResponse(new ValueCollection(array(
+                                new Value('fixture-test-value1')
+                            )))
+                        ),
+                        new ResultOutcomeVariable(
+                            new QtiIdentifier('response-identifier'),
+                            0,
+                            4,
+                            new ValueCollection(array(
+                                    new Value('fixture-test-value1'),
+                                    new Value('fixture-test-value2')
+                                )
+                            ))
+                    ))
+                )
+            ))
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $this->assertEquals(1, $element->getElementsByTagName('context')->length);
+        $this->assertEquals(1, $element->getElementsByTagName('testResult')->length);
+        $this->assertEquals(2, $element->getElementsByTagName('itemResult')->length);
+    }
+
+    public function testUnmarshallMinimal()
+    {
+        $component = new AssessmentResult(
+            new Context()
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $this->assertEquals(1, $element->getElementsByTagName('context')->length);
+        $this->assertEquals(0, $element->getElementsByTagName('testResult')->length);
+        $this->assertEquals(0, $element->getElementsByTagName('itemResult')->length);
+    }
+
+}

--- a/test/qtismtest/data/storage/xml/marshalling/CandidateResponseMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/CandidateResponseMarshallerTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\data\results\CandidateResponse;
+use qtism\data\state\ValueCollection;
+use qtism\data\state\Value;
+use qtismtest\QtiSmTestCase;
+
+class CandidateResponseMarshallerTest extends QtiSmTestCase
+{
+    public function testUnmarshall()
+    {
+        /** @var CandidateResponse $candidateResponse */
+        $candidateResponse = $this->createComponentFromXml('
+            <candidateResponse>
+                <value>fixture1</value>
+                <value>fixture2</value>
+            </candidateResponse>
+        ');
+
+        $this->assertInstanceOf(CandidateResponse::class, $candidateResponse);
+
+        $this->assertTrue($candidateResponse->hasValues());
+        $this->assertInstanceOf(ValueCollection::class, $candidateResponse->getValues());
+        $this->assertEquals(2, $candidateResponse->getValues()->count());
+    }
+
+    public function testUnmarshallMinimal()
+    {
+        /** @var CandidateResponse $candidateResponse */
+        $candidateResponse = $this->createComponentFromXml('
+            <candidateResponse />
+        ');
+
+        $this->assertInstanceOf(CandidateResponse::class, $candidateResponse);
+
+        $this->assertFalse($candidateResponse->hasValues());
+        $this->assertNull($candidateResponse->getValues());
+    }
+
+    public function testMarshall()
+    {
+        $component = new CandidateResponse(
+            new ValueCollection(array(
+                new Value('fixture1'),
+                new Value('fixture2'),
+            ))
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $this->assertEquals(2, $element->getElementsByTagName('value')->length);
+        /** @var DOMElement $node */
+        foreach ($element->childNodes as $node) {
+            $this->assertEquals('value', $node->nodeName);
+        }
+    }
+
+    public function testMarshallMinimal()
+    {
+        $component = new CandidateResponse();
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+        $this->assertFalse($element->hasAttributes());
+        $this->assertFalse($element->hasChildNodes());
+    }
+
+    public function testGetExpectedQtiClassName()
+    {
+        $component = new CandidateResponse();
+        $marshaller = $this->getMarshallerFactory()->createMarshaller($component);
+        $this->assertEquals($component->getQtiClassName(), $marshaller->getExpectedQtiClassName());
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/ContextMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ContextMarshallerTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\data\results\Context;
+use qtism\data\results\SessionIdentifierCollection;
+use qtism\data\results\SessionIdentifier;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiUri;
+use qtismtest\QtiSmTestCase;
+
+class ContextMarshallerTest extends QtiSmTestCase
+{
+    public function testUnmarshall()
+    {
+        /** @var Context $context */
+        $context = $this->createComponentFromXml('
+            <context sourcedId="fixture-sourcedId">
+                <sessionIdentifier sourceID="sessionIdentifier1-sourceID" identifier="sessionIdentifier1-id"/>
+                <sessionIdentifier sourceID="sessionIdentifier2-sourceID" identifier="sessionIdentifier2-id"/>
+            </context>
+        ');
+
+        $this->assertInstanceOf(Context::class, $context);
+
+        $this->assertInstanceOf(QtiIdentifier::class, $context->getSourcedId());
+        $this->assertTrue($context->hasSourcedId());
+        $this->assertEquals('fixture-sourcedId', $context->getSourcedId()->getValue());
+        $this->assertEquals('fixture-sourcedId', $context->getSourcedId());
+
+        $this->assertTrue($context->hasSessionIdentifiers());
+        $this->assertInstanceOf(SessionIdentifierCollection::class, $context->getSessionIdentifiers());
+        $this->assertEquals(2, $context->getSessionIdentifiers()->count());
+    }
+
+    public function testUnmarshallMinimal()
+    {
+        /** @var Context $context */
+        $context = $this->createComponentFromXml('
+            <context />
+        ');
+
+        $this->assertInstanceOf(Context::class, $context);
+
+        $this->assertFalse($context->hasSourcedId());
+        $this->assertNull($context->getSourcedId());
+
+        $this->assertFalse($context->hasSessionIdentifiers());
+        $this->assertNull($context->getSessionIdentifiers());
+    }
+
+    public function testMarshall()
+    {
+        $sourcedId = 'fixture-sourcedId';
+
+        $component = new Context(
+            new QtiIdentifier($sourcedId),
+            new SessionIdentifierCollection(array(
+                new SessionIdentifier(new QtiUri('sessionIdentifier1-sourceID'), new QtiIdentifier('sessionIdentifier1-id')),
+                new SessionIdentifier(new QtiUri('sessionIdentifier2-sourceID'), new QtiIdentifier('sessionIdentifier2-id')),
+            ))
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+        $this->assertEquals($sourcedId, $element->getAttribute('sourcedId'));
+
+        $this->assertEquals(2, $element->getElementsByTagName('sessionIdentifier')->length);
+        /** @var DOMElement $node */
+        foreach ($element->childNodes as $node) {
+            $this->assertEquals('sessionIdentifier', $node->nodeName);
+        }
+    }
+
+    public function testMarshallMinimal()
+    {
+        $component = new Context();
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+        $this->assertFalse($element->hasAttributes());
+        $this->assertFalse($element->hasChildNodes());
+    }
+
+    public function testGetExpectedQtiClassName()
+    {
+        $component = new Context();
+        $marshaller = $this->getMarshallerFactory()->createMarshaller($component);
+        $this->assertEquals($component->getQtiClassName(), $marshaller->getExpectedQtiClassName());
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/ItemResultMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ItemResultMarshallerTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use DateTime;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\results\ResultTemplateVariable;
+use qtism\data\results\ResultResponseVariable;
+use qtism\data\results\ItemResult;
+use qtism\data\results\ItemVariableCollection;
+use qtism\data\results\SessionStatus;
+use qtism\common\datatypes\QtiString;
+use qtism\common\datatypes\QtiInteger;
+use qtism\data\results\CandidateResponse;
+use qtismtest\QtiSmTestCase;
+
+class ItemResultMarshallerTest extends QtiSmTestCase
+{
+    public function testUnmarshall()
+    {
+        /** @var ItemResult $itemResult */
+        $itemResult = $this->createComponentFromXml('
+            <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529" sessionStatus="final" sequenceIndex="2">
+                <responseVariable identifier="response-identifier" cardinality="single">
+                    <candidateResponse>test</candidateResponse>
+                </responseVariable>
+                <templateVariable identifier="response-identifier" cardinality="single">
+                    <value>test1</value>
+                    <value>test2</value>
+                </templateVariable>
+                <candidateComment>comment-fixture</candidateComment>
+            </itemResult>
+        ');
+
+        $this->assertInstanceOf(ItemResult::class, $itemResult);
+
+        $this->assertEquals('fixture-identifier', $itemResult->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $itemResult->getIdentifier());
+
+        $this->assertInstanceOf(DateTime::class, $itemResult->getDatestamp());
+
+        $this->assertEquals('final', SessionStatus::getNameByConstant($itemResult->getSessionStatus()));
+
+        $this->assertTrue($itemResult->hasSequenceIndex());
+        $this->assertEquals(2, $itemResult->getSequenceIndex()->getValue());
+
+        $this->assertTrue($itemResult->hasCandidateComment());
+        $this->assertEquals('comment-fixture', $itemResult->getCandidateComment());
+
+        $this->assertTrue($itemResult->hasItemVariables());
+        $this->assertInstanceOf(ItemVariableCollection::class, $itemResult->getItemVariables());
+        $this->assertEquals(2, $itemResult->getItemVariables()->count());
+    }
+
+    public function testUnmarshallMinimal()
+    {
+        /** @var ItemResult $itemResult */
+        $itemResult = $this->createComponentFromXml('
+            <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529" sessionStatus="initial" />
+        ');
+
+        $this->assertInstanceOf(ItemResult::class, $itemResult);
+
+        $this->assertEquals('fixture-identifier', $itemResult->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $itemResult->getIdentifier());
+
+        $this->assertInstanceOf(DateTime::class, $itemResult->getDatestamp());
+
+        $this->assertEquals('initial', SessionStatus::getNameByConstant($itemResult->getSessionStatus()));
+
+        $this->assertFalse($itemResult->hasSequenceIndex());
+        $this->assertNull($itemResult->getSequenceIndex());
+        $this->assertFalse($itemResult->hasCandidateComment());
+        $this->assertNull($itemResult->getCandidateComment());
+        $this->assertFalse($itemResult->hasItemVariables());
+        $this->assertNull($itemResult->getItemVariables());
+    }
+
+    public function testMarshall()
+    {
+        $component = new ItemResult(
+            new QtiIdentifier('fixture-identifier'),
+            new DateTime('2018-06-27T09:41:45.529'),
+            1,
+            new ItemVariableCollection(array(
+                new ResultResponseVariable(
+                    new QtiIdentifier('response-identifier'), 0, new CandidateResponse()
+                ),
+                new ResultTemplateVariable(
+                    new QtiIdentifier('response-identifier'), 0
+                )
+            )),
+            new QtiString('candidate-comment'),
+            new QtiInteger(1)
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $this->assertEquals('fixture-identifier', $element->getAttribute('identifier'));
+        $this->assertTrue($element->hasAttribute('datestamp'));
+        $this->assertEquals('initial', $element->getAttribute('sessionStatus'));
+        $this->assertEquals(1, $element->getAttribute('sequenceIndex'));
+
+        $this->assertEquals(1,$element->getElementsByTagName('responseVariable')->length);
+        $this->assertEquals(1,$element->getElementsByTagName('templateVariable')->length);
+    }
+
+    public function testMarshallMinimal()
+    {
+        $component = new ItemResult(
+            new QtiIdentifier('fixture-identifier'),
+            new DateTime('2018-06-27T09:41:45.529'),
+            1
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $attributes = [];
+        for ($i=0; $i<2; $i++) {
+            $attributes[] = $element->attributes->item($i)->name;
+        }
+        $this->assertEmpty(array_diff($attributes, array('identifier', 'datestamp', 'sessionStatus')));
+
+        $this->assertFalse($element->hasChildNodes());
+    }
+
+    public function testGetExpectedQtiClassName()
+    {
+        $component = new ItemResult(
+            new QtiIdentifier('fixture-identifier'),
+            new DateTime('2018-06-27T09:41:45.529'),
+            1
+        );
+        $marshaller = $this->getMarshallerFactory()->createMarshaller($component);
+        $this->assertEquals($component->getQtiClassName(), $marshaller->getExpectedQtiClassName());
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/OutcomeVariableMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/OutcomeVariableMarshallerTest.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\common\enums\Cardinality;
+use qtism\common\enums\BaseType;
+use qtism\data\state\ValueCollection;
+use qtism\data\results\ResultOutcomeVariable;
+use qtism\data\View;
+use qtism\common\datatypes\QtiString;
+use qtism\common\datatypes\QtiUri;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiFloat;
+use qtism\data\state\Value;
+use qtismtest\QtiSmTestCase;
+
+class OutcomeVariableMarshallerTest extends QtiSmTestCase
+{
+    public function testUnmarshall()
+    {
+        /** @var ResultOutcomeVariable $resultOutcomeVariable */
+        $resultOutcomeVariable = $this->createComponentFromXml('
+            <outcomeVariable 
+                cardinality="single" 
+                identifier="fixture-identifier" 
+                baseType="string" 
+                view="candidate"
+                interpretation="fixture-interpretation"
+                longInterpretation="http://fixture-interpretation"
+                normalMinimum="2"
+                normalMaximum="3"
+                masteryValue="4"
+            >
+                <value>fixture-value1</value>
+                <value>fixture-value2</value>
+                <value>fixture-value3</value>
+            </outcomeVariable>
+        ');
+
+        $this->assertInstanceOf(ResultOutcomeVariable::class, $resultOutcomeVariable);
+
+        $this->assertEquals('fixture-identifier', $resultOutcomeVariable->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $resultOutcomeVariable->getIdentifier());
+
+        $this->assertEquals(Cardinality::getConstantByName('single'), $resultOutcomeVariable->getCardinality());
+
+        $this->assertTrue($resultOutcomeVariable->hasBaseType());
+        $this->assertEquals(BaseType::getConstantByName('string'), $resultOutcomeVariable->getBaseType());
+
+        $this->assertTrue($resultOutcomeVariable->hasView());
+        $this->assertEquals(View::getConstantByName('candidate'), $resultOutcomeVariable->getView());
+
+        $this->assertTrue($resultOutcomeVariable->hasInterpretation());
+        $this->assertEquals('fixture-interpretation', $resultOutcomeVariable->getInterpretation());
+
+        $this->assertTrue($resultOutcomeVariable->hasLongInterpretation());
+        $this->assertEquals('http://fixture-interpretation', $resultOutcomeVariable->getLongInterpretation()->getValue());
+
+        $this->assertTrue($resultOutcomeVariable->hasNormalMinimum());
+        $this->assertEquals(2, $resultOutcomeVariable->getNormalMinimum()->getValue());
+
+        $this->assertTrue($resultOutcomeVariable->hasNormalMaximum());
+        $this->assertEquals(3, $resultOutcomeVariable->getNormalMaximum()->getValue());
+
+        $this->assertTrue($resultOutcomeVariable->hasMasteryValue());
+        $this->assertEquals(4, $resultOutcomeVariable->getMasteryValue()->getValue());
+
+        $this->assertTrue($resultOutcomeVariable->hasValues());
+        $this->assertInstanceOf(ValueCollection::class, $resultOutcomeVariable->getValues());
+        $this->assertEquals(3, $resultOutcomeVariable->getValues()->count());
+    }
+
+    public function testUnmarshallMinimal()
+    {
+        /** @var ResultOutcomeVariable $resultOutcomeVariable */
+        $resultOutcomeVariable = $this->createComponentFromXml('
+            <outcomeVariable cardinality="single" identifier="fixture-identifier" />
+        ');
+
+        $this->assertInstanceOf(ResultOutcomeVariable::class, $resultOutcomeVariable);
+
+        $this->assertEquals('fixture-identifier', $resultOutcomeVariable->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $resultOutcomeVariable->getIdentifier());
+
+        $this->assertEquals(Cardinality::getConstantByName('single'), $resultOutcomeVariable->getCardinality());
+
+        $this->assertFalse($resultOutcomeVariable->hasBaseType());
+        $this->assertNull($resultOutcomeVariable->getBaseType());
+
+        $this->assertFalse($resultOutcomeVariable->hasView());
+        $this->assertNull($resultOutcomeVariable->getView());
+
+        $this->assertFalse($resultOutcomeVariable->hasInterpretation());
+        $this->assertNull($resultOutcomeVariable->getInterpretation());
+
+        $this->assertFalse($resultOutcomeVariable->hasLongInterpretation());
+        $this->assertNull($resultOutcomeVariable->getLongInterpretation());
+
+        $this->assertFalse($resultOutcomeVariable->hasNormalMinimum());
+        $this->assertNull($resultOutcomeVariable->getNormalMinimum());
+
+        $this->assertFalse($resultOutcomeVariable->hasNormalMaximum());
+        $this->assertNull($resultOutcomeVariable->getNormalMaximum());
+
+        $this->assertFalse($resultOutcomeVariable->hasMasteryValue());
+        $this->assertNull($resultOutcomeVariable->getMasteryValue());
+
+        $this->assertFalse($resultOutcomeVariable->hasValues());
+        $this->assertNull($resultOutcomeVariable->getValues());
+    }
+
+
+    public function testMarshall()
+    {
+        $component = new ResultOutcomeVariable(
+            new QtiIdentifier('fixture-identifier'),
+            0,
+            4,
+            new ValueCollection(array(
+                new Value('fixture-value1'),
+                new Value('fixture-value2'),
+            )),
+            1,
+            new QtiString('fixture-interpretation'),
+            new QtiUri('http://long-interpretation'),
+            new QtiFloat(2.0),
+            new QtiFloat(3.0),
+            new QtiFloat(4.0)
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $this->assertEquals('fixture-identifier', $element->getAttribute('identifier'));
+        $this->assertEquals('single', $element->getAttribute('cardinality'));
+        $this->assertEquals('string', $element->getAttribute('baseType'));
+
+        $this->assertEquals(2,$element->getElementsByTagName('value')->length);
+    }
+
+    public function testMarshallMinimal()
+    {
+        $component = new ResultOutcomeVariable(
+            new QtiIdentifier('fixture-identifier'),
+            0
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $attributes = [];
+        for ($i=0; $i<2; $i++) {
+            $attributes[] = $element->attributes->item($i)->name;
+        }
+        $this->assertEmpty(array_diff($attributes, array('identifier', 'cardinality')));
+
+        $this->assertEquals(0,$element->getElementsByTagName('value')->length);
+    }
+
+    public function testGetExpectedQtiClassName()
+    {
+        $component = new ResultOutcomeVariable(
+            new QtiIdentifier('fixture-identifier'),
+            0
+        );
+        $marshaller = $this->getMarshallerFactory()->createMarshaller($component);
+        $this->assertEquals($component->getQtiClassName(), $marshaller->getExpectedQtiClassName());
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/ResponseVariableMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ResponseVariableMarshallerTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\data\results\ResultResponseVariable;
+use qtism\data\results\CandidateResponse;
+use qtism\common\enums\Cardinality;
+use qtism\common\enums\BaseType;
+use qtism\data\state\CorrectResponse;
+use qtism\data\state\Value;
+use qtism\data\state\ValueCollection;
+use qtism\common\datatypes\QtiIdentifier;
+use qtismtest\QtiSmTestCase;
+
+class ResponseVariableMarshallerTest extends QtiSmTestCase
+{
+    public function testUnmarshall()
+    {
+        /** @var ResultResponseVariable $resultResponseVariable */
+        $resultResponseVariable = $this->createComponentFromXml('
+            <responseVariable cardinality="single" identifier="fixture-identifier" baseType="string" choiceSequence="value-id-1">
+                <correctResponse>
+                    <value>fixture-value1</value>
+                    <value>fixture-value2</value>
+                </correctResponse>
+                <candidateResponse>
+                    <value fieldIdentifier="value-id-1">fixture-value1</value>
+                    <value fieldIdentifier="value-id-2">fixture-value2</value>
+                    <value fieldIdentifier="value-id-3">fixture-value3</value>
+                </candidateResponse>
+            </responseVariable>
+        ');
+
+        $this->assertInstanceOf(ResultResponseVariable::class, $resultResponseVariable);
+
+        $this->assertEquals('fixture-identifier', $resultResponseVariable->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $resultResponseVariable->getIdentifier());
+
+        $this->assertEquals(Cardinality::getConstantByName('single'), $resultResponseVariable->getCardinality());
+
+        $this->assertInstanceOf(CandidateResponse::class, $resultResponseVariable->getCandidateResponse());
+        $this->assertEquals(3, $resultResponseVariable->getCandidateResponse()->getValues()->count());
+
+        $this->assertTrue($resultResponseVariable->hasBaseType());
+        $this->assertEquals(BaseType::getConstantByName('string'), $resultResponseVariable->getBaseType());
+
+        $this->assertTrue($resultResponseVariable->hasCorrectResponse());
+        $this->assertInstanceOf(CorrectResponse::class, $resultResponseVariable->getCorrectResponse());
+        $this->assertEquals(2, $resultResponseVariable->getCorrectResponse()->getValues()->count());
+
+        $this->assertTrue($resultResponseVariable->hasChoiceSequence());
+        $this->assertEquals('value-id-1', $resultResponseVariable->getChoiceSequence()->getValue());
+    }
+
+    public function testUnmarshallMinimal()
+    {
+        /** @var ResultResponseVariable $resultResponseVariable */
+        $resultResponseVariable = $this->createComponentFromXml('
+            <responseVariable cardinality="single" identifier="fixture-identifier">
+                <candidateResponse>
+                    <value>fixture-value1</value>
+                    <value>fixture-value2</value>
+                    <value>fixture-value3</value>
+                </candidateResponse>
+            </responseVariable>
+        ');
+
+        $this->assertInstanceOf(ResultResponseVariable::class, $resultResponseVariable);
+
+        $this->assertEquals('fixture-identifier', $resultResponseVariable->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $resultResponseVariable->getIdentifier());
+
+        $this->assertEquals(Cardinality::getConstantByName('single'), $resultResponseVariable->getCardinality());
+
+        $this->assertInstanceOf(CandidateResponse::class, $resultResponseVariable->getCandidateResponse());
+        $this->assertEquals(3, $resultResponseVariable->getCandidateResponse()->getValues()->count());
+
+        $this->assertFalse($resultResponseVariable->hasBaseType());
+        $this->assertNull($resultResponseVariable->getBaseType());
+
+        $this->assertFalse($resultResponseVariable->hasCorrectResponse());
+        $this->assertNull($resultResponseVariable->getCorrectResponse());
+
+        $this->assertFalse($resultResponseVariable->hasChoiceSequence());
+        $this->assertNull($resultResponseVariable->getChoiceSequence());
+    }
+
+    public function testMarshall()
+    {
+        $component = new ResultResponseVariable(
+            new QtiIdentifier('fixture-identifier'),
+            0,
+            new CandidateResponse(new ValueCollection(array(
+                new Value('fixture-value1'),
+                new Value('fixture-value2'),
+            ))),
+            4,
+            new CorrectResponse(new ValueCollection(array(
+                new Value('fixture-value1'),
+                new Value('fixture-value2'),
+                new Value('fixture-value2'),
+            ))),
+            new QtiIdentifier('value-id-1')
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $this->assertEquals('fixture-identifier', $element->getAttribute('identifier'));
+        $this->assertEquals('single', $element->getAttribute('cardinality'));
+        $this->assertEquals('string', $element->getAttribute('baseType'));
+        $this->assertEquals('value-id-1', $element->getAttribute('choiceSequence'));
+
+        $this->assertEquals(1, $element->getElementsByTagName('candidateResponse')->length);
+        $this->assertEquals(2,$element->getElementsByTagName('candidateResponse')->item(0)->getElementsByTagName('value')->length);
+
+        $this->assertEquals(1, $element->getElementsByTagName('correctResponse')->length);
+        $this->assertEquals(3,$element->getElementsByTagName('correctResponse')->item(0)->getElementsByTagName('value')->length);
+    }
+
+    public function testMarshallMinimal()
+    {
+        $component = new ResultResponseVariable(
+            new QtiIdentifier('fixture-identifier'),
+            0,
+            new CandidateResponse(new ValueCollection(array(
+                new Value('fixture-value1'),
+                new Value('fixture-value2'),
+            )))
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $attributes = [];
+        for ($i=0; $i<2; $i++) {
+            $attributes[] = $element->attributes->item($i)->name;
+        }
+        $this->assertEmpty(array_diff($attributes, array('identifier', 'cardinality')));
+
+        $this->assertEquals(1,$element->getElementsByTagName('candidateResponse')->length);
+        $this->assertEquals(2,$element->getElementsByTagName('candidateResponse')->item(0)->getElementsByTagName('value')->length);
+
+        $this->assertEquals(0,$element->getElementsByTagName('correctResponse')->length);
+    }
+
+    public function testGetExpectedQtiClassName()
+    {
+        $component = new ResultResponseVariable(
+            new QtiIdentifier('fixture-identifier'),
+            0,
+            new CandidateResponse()
+        );
+        $marshaller = $this->getMarshallerFactory()->createMarshaller($component);
+        $this->assertEquals($component->getQtiClassName(), $marshaller->getExpectedQtiClassName());
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/SessionIdentifierMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/SessionIdentifierMarshallerTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\data\results\SessionIdentifier;
+use qtism\common\datatypes\QtiUri;
+use qtism\common\datatypes\QtiIdentifier;
+use qtismtest\QtiSmTestCase;
+
+class SessionIdentifierMarshallerTest extends QtiSmTestCase
+{
+	public function testUnmarshall()
+    {
+        /** @var SessionIdentifier $sessionIdentifier */
+        $sessionIdentifier = $this->createComponentFromXml(
+            '<sessionIdentifier sourceID="fixture-sourceID" identifier="fixture-id"/>'
+        );
+
+        $this->assertInstanceOf(SessionIdentifier::class, $sessionIdentifier);
+
+        $this->assertInstanceOf(QtiUri::class, $sessionIdentifier->getSourceID());
+        $this->assertEquals('fixture-sourceID', $sessionIdentifier->getSourceID()->getValue());
+        $this->assertEquals('fixture-sourceID', $sessionIdentifier->getSourceID());
+
+        $this->assertInstanceOf(QtiIdentifier::class, $sessionIdentifier->getIdentifier());
+        $this->assertEquals('fixture-id', $sessionIdentifier->getIdentifier()->getValue());
+        $this->assertEquals('fixture-id', $sessionIdentifier->getIdentifier());
+	}
+	
+	public function testMarshall()
+    {
+        $sourceID = 'fixture-sourceID';
+        $id = 'fixture-id';
+        $component = new SessionIdentifier(new QtiUri($sourceID), new QtiIdentifier($id));
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+        $this->assertEquals($sourceID, $element->getAttribute('sourceID'));
+        $this->assertEquals($id, $element->getAttribute('identifier'));
+	}
+
+    public function testGetExpectedQtiClassName()
+    {
+        $sourceID = 'fixture-sourceID';
+        $id = 'fixture-id';
+        $component = new SessionIdentifier(new QtiUri($sourceID), new QtiIdentifier($id));
+
+        $marshaller = $this->getMarshallerFactory()->createMarshaller($component);
+        $this->assertEquals($component->getQtiClassName(), $marshaller->getExpectedQtiClassName());
+    }
+
+    /**
+     * @expectedException \qtism\data\storage\xml\marshalling\UnmarshallingException
+     */
+    public function testWrongSessionIdentifierIdentifier()
+    {
+        $xml = '<sessionIdentifier identifier="fixture-id"/>';
+        $element = QtiSmTestCase::createDOMElement($xml);
+        $this->getMarshallerFactory()->createMarshaller($element)->unmarshall($element);
+    }
+
+    /**
+     * @expectedException \qtism\data\storage\xml\marshalling\UnmarshallingException
+     */
+    public function testWrongSessionIdentifierSourceID()
+    {
+        $xml = '<sessionIdentifier sourceID="fixture-sourceID"/>';
+        $element = QtiSmTestCase::createDOMElement($xml);
+        $this->getMarshallerFactory()->createMarshaller($element)->unmarshall($element);
+    }
+
+    /**
+     * @expectedException \qtism\data\storage\xml\marshalling\UnmarshallingException
+     */
+    public function testEmptySessionIdentifier()
+    {
+        $xml = '<sessionIdentifier/>';
+        $element = QtiSmTestCase::createDOMElement($xml);
+        $this->getMarshallerFactory()->createMarshaller($element)->unmarshall($element);
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/TemplateVariableMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/TemplateVariableMarshallerTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\common\enums\Cardinality;
+use qtism\common\enums\BaseType;
+use qtism\data\state\Value;
+use qtism\data\state\ValueCollection;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\results\ResultTemplateVariable;
+use qtismtest\QtiSmTestCase;
+
+class TemplateVariableMarshallerTest extends QtiSmTestCase
+{
+    public function testUnmarshall()
+    {
+        /** @var ResultTemplateVariable $resultTemplateVariable */
+        $resultTemplateVariable = $this->createComponentFromXml('
+            <templateVariable cardinality="single" identifier="fixture-identifier" baseType="string">
+                <value>fixture-value1</value>
+                <value>fixture-value2</value>
+                <value>fixture-value3</value>
+            </templateVariable>
+        ');
+
+        $this->assertInstanceOf(ResultTemplateVariable::class, $resultTemplateVariable);
+
+        $this->assertEquals('fixture-identifier', $resultTemplateVariable->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $resultTemplateVariable->getIdentifier());
+
+        $this->assertEquals(Cardinality::getConstantByName('single'), $resultTemplateVariable->getCardinality());
+
+        $this->assertTrue($resultTemplateVariable->hasBaseType());
+        $this->assertEquals(BaseType::getConstantByName('string'), $resultTemplateVariable->getBaseType());
+
+        $this->assertTrue($resultTemplateVariable->hasValues());
+        $this->assertInstanceOf(ValueCollection::class, $resultTemplateVariable->getValues());
+        $this->assertEquals(3, $resultTemplateVariable->getValues()->count());
+    }
+
+    public function testUnmarshallMinimal()
+    {
+        /** @var ResultTemplateVariable $resultTemplateVariable */
+        $resultTemplateVariable = $this->createComponentFromXml('
+            <templateVariable cardinality="single" identifier="fixture-identifier"/>
+        ');
+
+        $this->assertInstanceOf(ResultTemplateVariable::class, $resultTemplateVariable);
+
+        $this->assertEquals('fixture-identifier', $resultTemplateVariable->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $resultTemplateVariable->getIdentifier());
+
+        $this->assertEquals(Cardinality::getConstantByName('single'), $resultTemplateVariable->getCardinality());
+
+        $this->assertFalse($resultTemplateVariable->hasBaseType());
+        $this->assertNull($resultTemplateVariable->getBaseType());
+
+        $this->assertFalse($resultTemplateVariable->hasValues());
+        $this->assertNull($resultTemplateVariable->getValues());
+    }
+
+    public function testMarshall()
+    {
+        $component = new ResultTemplateVariable(
+            new QtiIdentifier('fixture-identifier'),
+            0,
+            4,
+            new ValueCollection(array(
+                new Value('fixture-value1'),
+                new Value('fixture-value2'),
+            ))
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $this->assertEquals('fixture-identifier', $element->getAttribute('identifier'));
+        $this->assertEquals('single', $element->getAttribute('cardinality'));
+        $this->assertEquals('string', $element->getAttribute('baseType'));
+
+        $this->assertEquals(2,$element->getElementsByTagName('value')->length);
+    }
+
+    public function testMarshallMinimal()
+    {
+        $component = new ResultTemplateVariable(
+            new QtiIdentifier('fixture-identifier'),
+            0
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $attributes = [];
+        for ($i=0; $i<2; $i++) {
+            $attributes[] = $element->attributes->item($i)->name;
+        }
+        $this->assertEmpty(array_diff($attributes, array('identifier', 'cardinality')));
+
+        $this->assertEquals(0,$element->getElementsByTagName('value')->length);
+    }
+
+    public function testGetExpectedQtiClassName()
+    {
+        $component = new ResultTemplateVariable(
+            new QtiIdentifier('fixture-identifier'),
+            0
+        );
+        $marshaller = $this->getMarshallerFactory()->createMarshaller($component);
+        $this->assertEquals($component->getQtiClassName(), $marshaller->getExpectedQtiClassName());
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/TestResultMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/TestResultMarshallerTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Moyon Camille, <camille@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use DateTime;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\data\results\ResultTemplateVariable;
+use qtism\data\results\ResultResponseVariable;
+use qtism\data\results\ItemVariableCollection;
+use qtism\data\results\CandidateResponse;
+use qtism\data\results\TestResult;
+use qtismtest\QtiSmTestCase;
+
+class TestResultMarshallerTest extends QtiSmTestCase
+{
+    public function testUnmarshall()
+    {
+        /** @var TestResult $testResult */
+        $testResult = $this->createComponentFromXml('
+            <testResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529">
+                <responseVariable identifier="response-identifier" cardinality="single">
+                    <candidateResponse>test</candidateResponse>
+                </responseVariable>
+                <templateVariable identifier="response-identifier" cardinality="single">
+                    <value>test1</value>
+                    <value>test2</value>
+                </templateVariable>
+            </testResult>
+        ');
+
+        $this->assertInstanceOf(TestResult::class, $testResult);
+
+        $this->assertEquals('fixture-identifier', $testResult->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $testResult->getIdentifier());
+
+        $this->assertInstanceOf(DateTime::class, $testResult->getDatestamp());
+
+        $this->assertTrue($testResult->hasItemVariables());
+        $this->assertInstanceOf(ItemVariableCollection::class, $testResult->getItemVariables());
+        $this->assertEquals(2, $testResult->getItemVariables()->count());
+    }
+
+    public function testUnmarshallMinimal()
+    {
+        /** @var TestResult $testResult */
+        $testResult = $this->createComponentFromXml('
+            <testResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529" />
+        ');
+
+        $this->assertInstanceOf(TestResult::class, $testResult);
+
+        $this->assertEquals('fixture-identifier', $testResult->getIdentifier()->getValue());
+        $this->assertEquals('fixture-identifier', $testResult->getIdentifier());
+
+        $this->assertInstanceOf(DateTime::class, $testResult->getDatestamp());
+
+        $this->assertFalse($testResult->hasItemVariables());
+        $this->assertNull($testResult->getItemVariables());
+    }
+
+    public function testMarshall()
+    {
+        $component = new TestResult(
+            new QtiIdentifier('fixture-identifier'),
+            new DateTime('2018-06-27T09:41:45.529'),
+            new ItemVariableCollection(array(
+                new ResultResponseVariable(
+                    new QtiIdentifier('response-identifier'), 0, new CandidateResponse()
+                ),
+                new ResultTemplateVariable(
+                    new QtiIdentifier('response-identifier'), 0
+                )
+            ))
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $this->assertEquals('fixture-identifier', $element->getAttribute('identifier'));
+        $this->assertTrue($element->hasAttribute('datestamp'));
+
+        $this->assertEquals(1,$element->getElementsByTagName('responseVariable')->length);
+        $this->assertEquals(1,$element->getElementsByTagName('templateVariable')->length);
+    }
+
+    public function testMarshallMinimal()
+    {
+        $component = new TestResult(
+            new QtiIdentifier('fixture-identifier'),
+            new DateTime('2018-06-27T09:41:45.529')
+        );
+
+        /** @var DOMElement $element */
+        $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
+
+        $this->assertInstanceOf(\DOMElement::class, $element);
+
+        $this->assertEquals($component->getQtiClassName(), $element->nodeName);
+
+        $attributes = [];
+        for ($i=0; $i<2; $i++) {
+            $attributes[] = $element->attributes->item($i)->name;
+        }
+        $this->assertEmpty(array_diff($attributes, array('identifier', 'datestamp')));
+
+        $this->assertFalse($element->hasChildNodes());
+    }
+
+    public function testGetExpectedQtiClassName()
+    {
+        $component = new TestResult(
+            new QtiIdentifier('fixture-identifier'),
+            new DateTime('2018-06-27T09:41:45.529')
+        );
+        $marshaller = $this->getMarshallerFactory()->createMarshaller($component);
+        $this->assertEquals($component->getQtiClassName(), $marshaller->getExpectedQtiClassName());
+    }
+}

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace qtismtest\runtime\common;
 
+use qtism\common\datatypes\QtiFloat;
 use qtism\common\datatypes\QtiInteger;
 
 use qtismtest\QtiSmTestCase;
@@ -96,7 +97,22 @@ class ResponseVariableTest extends QtiSmTestCase {
 	    $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::INTEGER, new QtiInteger(25));
 	    $this->assertFalse($responseVariable->isCorrect());
 	}
-	
+
+	public function testGetDataModelValuesSingleCardinality()
+    {
+        $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::INTEGER, new QtiInteger(10));
+        $values = $responseVariable->getDataModelValues();
+
+        $this->assertCount(1, $values);
+        $this->assertSame(10, $values[0]->getValue());
+
+        $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::FLOAT, new QtiFloat(10.1));
+        $values = $responseVariable->getDataModelValues();
+
+        $this->assertCount(1, $values);
+        $this->assertSame(10.1, $values[0]->getValue());
+    }
+
 	public function testClone() {
 	    // value, default value and correct response must be independent after cloning.
 	    $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::INTEGER, new QtiInteger(25));

--- a/test/qtismtest/runtime/results/AssessmentResultBuilderTest.php
+++ b/test/qtismtest/runtime/results/AssessmentResultBuilderTest.php
@@ -1,4 +1,24 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Bogaerts Jérôme, <jerome@taotesting.com>
+ * @license GPLv2
+ */
 
 namespace qtismtest\runtime\results;
 

--- a/test/qtismtest/runtime/results/AssessmentResultBuilderTest.php
+++ b/test/qtismtest/runtime/results/AssessmentResultBuilderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace qtismtest\runtime\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\enums\BaseType;
+use qtism\common\enums\Cardinality;
+use qtism\data\results\AssessmentResult;
+use qtism\data\results\TestResult;
+use qtism\runtime\common\ResponseVariable;
+use qtism\runtime\common\State;
+use qtism\runtime\results\AssessmentResultBuilder;
+use qtismtest\QtiSmAssessmentTestSessionTestCase;
+
+class AssessmentResultBuilderTest extends QtiSmAssessmentTestSessionTestCase
+{
+    public function testBasic()
+    {
+        $session = self::instantiate(self::samplesDir() . 'custom/runtime/linear_5_items.xml');
+        $session->beginTestSession();
+
+        $session->beginAttempt();
+        $session->endAttempt(
+            new State([
+                new ResponseVariable(
+                    'RESPONSE',
+                    Cardinality::SINGLE,
+                    BaseType::IDENTIFIER,
+                    new QtiIdentifier('ChoiceA')
+                )
+            ])
+        );
+
+        $assessmentResultBuilder = new AssessmentResultBuilder($session);
+        $assessmentResult = $assessmentResultBuilder->buildResult();
+
+        $this->assertInstanceOf(AssessmentResult::class, $assessmentResult);
+
+        $testResult = $assessmentResult->getTestResult();
+        $this->assertInstanceOf(TestResult::class, $testResult);
+        $this->assertCount(0, $testResult->getItemVariables());
+
+        $itemResults = $assessmentResult->getItemResults();
+        $this->assertCount(5, $itemResults);
+    }
+}

--- a/test/qtismtest/runtime/results/ItemResultBuilderTest.php
+++ b/test/qtismtest/runtime/results/ItemResultBuilderTest.php
@@ -1,4 +1,24 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Bogaerts Jérôme, <jerome@taotesting.com>
+ * @license GPLv2
+ */
 
 namespace qtismtest\runtime\results;
 

--- a/test/qtismtest/runtime/results/ItemResultBuilderTest.php
+++ b/test/qtismtest/runtime/results/ItemResultBuilderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace qtismtest\runtime\results;
+
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\enums\BaseType;
+use qtism\common\enums\Cardinality;
+use qtism\data\results\ItemResult;
+use qtism\data\results\ResultOutcomeVariable;
+use qtism\data\results\ResultResponseVariable;
+use qtism\data\results\SessionStatus;
+use qtism\runtime\common\ResponseVariable;
+use qtism\runtime\common\State;
+use qtism\runtime\results\ItemResultBuilder;
+use qtismtest\QtiSmAssessmentItemTestCase;
+
+class ItemResultBuilderTest extends QtiSmAssessmentItemTestCase
+{
+    public function testBasic()
+    {
+        $itemSession = self::instantiateBasicAssessmentItemSession();
+        $itemSession->beginAttempt();
+        $itemSession->endAttempt(
+            new State([
+                new ResponseVariable(
+                    'RESPONSE',
+                    Cardinality::SINGLE,
+                    BaseType::IDENTIFIER,
+                    new QtiIdentifier('ChoiceB')
+                )
+            ])
+        );
+
+        $itemResultBuilder = new ItemResultBuilder($itemSession);
+        $itemResult = $itemResultBuilder->buildResult();
+
+        $this->assertInstanceOf(ItemResult::class, $itemResult);
+        $this->assertEquals('Q01', $itemResult->getIdentifier());
+        $this->assertInstanceOf(\DateTime::class, $itemResult->getDatestamp());
+        $this->assertEquals(SessionStatus::STATUS_FINAL, $itemResult->getSessionStatus());
+
+        $variables = $itemResult->getItemVariables();
+        $this->assertCount(5, $variables);
+
+        $this->assertInstanceOf(ResultResponseVariable::class, $variables[0]);
+        $this->assertEquals('numAttempts', $variables[0]->getIdentifier());
+
+        $this->assertInstanceOf(ResultResponseVariable::class, $variables[1]);
+        $this->assertEquals('duration', $variables[1]->getIdentifier());
+
+        $this->assertInstanceOf(ResultOutcomeVariable::class, $variables[2]);
+        $this->assertEquals('completionStatus', $variables[2]->getIdentifier());
+
+        $this->assertInstanceOf(ResultOutcomeVariable::class, $variables[3]);
+        $this->assertEquals('SCORE', $variables[3]->getIdentifier());
+
+        $this->assertInstanceOf(ResultResponseVariable::class, $variables[4]);
+        $this->assertEquals('RESPONSE', $variables[4]->getIdentifier());
+    }
+}

--- a/test/samples/results/simple-assessment-result-missing-data.xml
+++ b/test/samples/results/simple-assessment-result-missing-data.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentResult xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_result_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_result_v2p1.xsd">
+</assessmentResult>

--- a/test/samples/results/simple-assessment-result.xml
+++ b/test/samples/results/simple-assessment-result.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentResult xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_result_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_result_v2p1.xsd">
+  <context sourcedId="fixture-sourcedId">
+    <sessionIdentifier sourceID="http://sessionIdentifier1-sourceID" identifier="sessionIdentifier1-id"/>
+    <sessionIdentifier sourceID="http://sessionIdentifier2-sourceID" identifier="sessionIdentifier2-id"/>
+  </context>
+  <testResult identifier="fixture-test-identifier" datestamp="2018-06-27T09:41:45.529">
+    <responseVariable identifier="response-identifier" cardinality="single">
+      <correctResponse>
+        <value>fixture-test-value1</value>
+        <value>fixture-test-value2</value>
+      </correctResponse>
+      <candidateResponse>
+        <value fieldIdentifier="test-id-1">fixture-test-value1</value>
+        <value fieldIdentifier="test-id-2">fixture-test-value2</value>
+        <value fieldIdentifier="test-id-3">fixture-test-value3</value>
+      </candidateResponse>
+    </responseVariable>
+    <templateVariable identifier="response-identifier" cardinality="single">
+      <value>test1</value>
+      <value>test2</value>
+    </templateVariable>
+  </testResult>
+  <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529" sessionStatus="final" sequenceIndex="2">
+    <responseVariable cardinality="single" identifier="fixture-identifier" baseType="string" choiceSequence="value-id-1">
+      <correctResponse>
+        <value>fixture-value1</value>
+        <value>fixture-value2</value>
+      </correctResponse>
+      <candidateResponse>
+        <value fieldIdentifier="value-id-1">fixture-value1</value>
+        <value fieldIdentifier="value-id-2">fixture-value2</value>
+        <value fieldIdentifier="value-id-3">fixture-value3</value>
+      </candidateResponse>
+    </responseVariable>
+    <templateVariable cardinality="single" identifier="fixture-identifier" baseType="string">
+      <value>fixture-value1</value>
+      <value>fixture-value2</value>
+      <value>fixture-value3</value>
+    </templateVariable>
+    <outcomeVariable cardinality="single" identifier="fixture-identifier" baseType="string" view="candidate" interpretation="fixture-interpretation" longInterpretation="http://fixture-interpretation" normalMinimum="2" normalMaximum="3" masteryValue="4">
+      <value>fixture-value1</value>
+      <value>fixture-value2</value>
+      <value>fixture-value3</value>
+     </outcomeVariable>
+     <candidateComment>comment-fixture</candidateComment>
+  </itemResult>
+  <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45.529" sessionStatus="final" sequenceIndex="2">
+    <responseVariable cardinality="single" identifier="fixture-identifier" baseType="string" choiceSequence="value-id-1">
+      <correctResponse>
+        <value>fixture-value1</value>
+        <value>fixture-value2</value>
+      </correctResponse>
+      <candidateResponse>
+        <value fieldIdentifier="value-id-1">fixture-value1</value>
+        <value fieldIdentifier="value-id-2">fixture-value2</value>
+        <value fieldIdentifier="value-id-3">fixture-value3</value>
+      </candidateResponse>
+    </responseVariable>
+    <outcomeVariable cardinality="single" identifier="fixture-identifier" baseType="string" view="candidate" interpretation="fixture-interpretation" longInterpretation="http://fixture-interpretation" normalMinimum="2" normalMaximum="3" masteryValue="4">
+      <value>fixture-value1</value>
+      <value>fixture-value2</value>
+      <value>fixture-value3</value>
+    </outcomeVariable>
+  </itemResult>
+</assessmentResult>


### PR DESCRIPTION
This Pull Request aims at providing support for producing QTI Results via the `AssessmentResultBuilder` (from `AssessmentTestSession` objects) and `ItemResultBuilder` (from `AssessmentItemSession` objects) classes. They can be serialized/unserialized using the new `XmlResultDocument` document class.