### PR TITLE
Fix/ordered container php72

### DIFF
--- a/src/qtism/runtime/common/OrderedContainer.php
+++ b/src/qtism/runtime/common/OrderedContainer.php
@@ -43,9 +43,8 @@ class OrderedContainer extends MultipleContainer implements QtiDatatype
     public function equals($obj)
     {
         $countA = count($this);
-        $countB = count($obj);
 
-        if (gettype($obj) === 'object' && $obj instanceof self && $countA === $countB) {
+        if (gettype($obj) === 'object' && $obj instanceof self && $countA === count($obj)) {
             for ($i = 0; $i < $countA; $i++) {
                 $objA = $this[$i];
                 $objB = $obj[$i];

--- a/test/qtismtest/runtime/common/OrderedContainerTest.php
+++ b/test/qtismtest/runtime/common/OrderedContainerTest.php
@@ -12,12 +12,14 @@ use qtism\common\datatypes\QtiDirectedPair;
 use qtism\runtime\common\MultipleContainer;
 use qtism\common\enums\BaseType;
 
-class OrderedContainerTest extends QtiSmTestCase {
+class OrderedContainerTest extends QtiSmTestCase
+{
 	
 	/**
 	 * @dataProvider equalsValidProvider
 	 */
-	public function testEqualsValid($containerA, $containerB) {
+	public function testEqualsValid($containerA, $containerB)
+    {
 		$this->assertTrue($containerA->equals($containerB));
 		$this->assertTrue($containerB->equals($containerA));
 	}
@@ -25,19 +27,22 @@ class OrderedContainerTest extends QtiSmTestCase {
 	/**
 	 * @dataProvider equalsInvalidProvider
 	 */
-	public function testEqualsInvalid($containerA, $containerB) {
+	public function testEqualsInvalid($containerA, $containerB)
+    {
 		$this->assertFalse($containerA->equals($containerB));
 		$this->assertFalse($containerB->equals($containerA));
 	}
 	
-	public function testCreationEmpty() {
+	public function testCreationEmpty()
+    {
 		$container = new OrderedContainer(BaseType::INTEGER);
 		$this->assertEquals(0, count($container));
 		$this->assertEquals(BaseType::INTEGER, $container->getBaseType());
 		$this->assertEquals(Cardinality::ORDERED, $container->getCardinality());
 	}
 	
-	public function equalsValidProvider() {
+	public function equalsValidProvider()
+    {
 		return array(
 			array(new OrderedContainer(BaseType::INTEGER), new OrderedContainer(BaseType::INTEGER)),
 			array(new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(20))), new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(20)))),
@@ -46,11 +51,18 @@ class OrderedContainerTest extends QtiSmTestCase {
 		);
 	}
 	
-	public function equalsInvalidProvider() {
+	public function equalsInvalidProvider()
+    {
 		return array(
 			array(new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(20))), new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(30)))),
 			array(new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.taotesting.com'), new QtiUri('http://www.tao.lu'))), new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.tao.lu'), new QtiUri('http://www.taotesting.com')))),
 			array(new OrderedContainer(BaseType::DIRECTED_PAIR, array(new QtiDirectedPair('abc', 'def'))), new OrderedContainer(BaseType::DIRECTED_PAIR, array(new QtiDirectedPair('def', 'abc')))),
 		);
 	}
+
+    public function testEqualsNull()
+    {
+        $container = new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(10)));
+        $this->assertFalse($container->equals(null));
+    }
 }

--- a/test/qtismtest/runtime/common/OrderedContainerTest.php
+++ b/test/qtismtest/runtime/common/OrderedContainerTest.php
@@ -15,8 +15,8 @@ use qtism\common\enums\BaseType;
 class OrderedContainerTest extends QtiSmTestCase
 {
     /**
-     * @dataProvider equalsValidProvider
-     */
+    * @dataProvider equalsValidProvider
+    */
     public function testEqualsValid($containerA, $containerB)
     {
         $this->assertTrue($containerA->equals($containerB));
@@ -24,8 +24,8 @@ class OrderedContainerTest extends QtiSmTestCase
     }
 
     /**
-     * @dataProvider equalsInvalidProvider
-     */
+    * @dataProvider equalsInvalidProvider
+    */
     public function testEqualsInvalid($containerA, $containerB)
     {
         $this->assertFalse($containerA->equals($containerB));

--- a/test/qtismtest/runtime/common/OrderedContainerTest.php
+++ b/test/qtismtest/runtime/common/OrderedContainerTest.php
@@ -14,51 +14,50 @@ use qtism\common\enums\BaseType;
 
 class OrderedContainerTest extends QtiSmTestCase
 {
-	
-	/**
-	 * @dataProvider equalsValidProvider
-	 */
-	public function testEqualsValid($containerA, $containerB)
+    /**
+     * @dataProvider equalsValidProvider
+     */
+    public function testEqualsValid($containerA, $containerB)
     {
-		$this->assertTrue($containerA->equals($containerB));
-		$this->assertTrue($containerB->equals($containerA));
-	}
-	
-	/**
-	 * @dataProvider equalsInvalidProvider
-	 */
-	public function testEqualsInvalid($containerA, $containerB)
+        $this->assertTrue($containerA->equals($containerB));
+        $this->assertTrue($containerB->equals($containerA));
+    }
+
+    /**
+     * @dataProvider equalsInvalidProvider
+     */
+    public function testEqualsInvalid($containerA, $containerB)
     {
-		$this->assertFalse($containerA->equals($containerB));
-		$this->assertFalse($containerB->equals($containerA));
-	}
-	
-	public function testCreationEmpty()
+        $this->assertFalse($containerA->equals($containerB));
+        $this->assertFalse($containerB->equals($containerA));
+    }
+
+    public function testCreationEmpty()
     {
-		$container = new OrderedContainer(BaseType::INTEGER);
-		$this->assertEquals(0, count($container));
-		$this->assertEquals(BaseType::INTEGER, $container->getBaseType());
-		$this->assertEquals(Cardinality::ORDERED, $container->getCardinality());
-	}
-	
-	public function equalsValidProvider()
+        $container = new OrderedContainer(BaseType::INTEGER);
+        $this->assertEquals(0, count($container));
+        $this->assertEquals(BaseType::INTEGER, $container->getBaseType());
+        $this->assertEquals(Cardinality::ORDERED, $container->getCardinality());
+    }
+
+    public function equalsValidProvider()
     {
-		return array(
-			array(new OrderedContainer(BaseType::INTEGER), new OrderedContainer(BaseType::INTEGER)),
-			array(new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(20))), new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(20)))),
-			array(new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.taotesting.com'), new QtiUri('http://www.tao.lu'))), new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.taotesting.com'), new QtiUri('http://www.tao.lu')))),
-			array(new OrderedContainer(BaseType::PAIR, array(new QtiPair('abc', 'def'))), new OrderedContainer(BaseType::PAIR, array(new QtiPair('def', 'abc'))))
-		);
-	}
-	
-	public function equalsInvalidProvider()
+        return array(
+            array(new OrderedContainer(BaseType::INTEGER), new OrderedContainer(BaseType::INTEGER)),
+            array(new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(20))), new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(20)))),
+            array(new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.taotesting.com'), new QtiUri('http://www.tao.lu'))), new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.taotesting.com'), new QtiUri('http://www.tao.lu')))),
+            array(new OrderedContainer(BaseType::PAIR, array(new QtiPair('abc', 'def'))), new OrderedContainer(BaseType::PAIR, array(new QtiPair('def', 'abc'))))
+        );
+    }
+
+    public function equalsInvalidProvider()
     {
-		return array(
-			array(new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(20))), new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(30)))),
-			array(new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.taotesting.com'), new QtiUri('http://www.tao.lu'))), new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.tao.lu'), new QtiUri('http://www.taotesting.com')))),
-			array(new OrderedContainer(BaseType::DIRECTED_PAIR, array(new QtiDirectedPair('abc', 'def'))), new OrderedContainer(BaseType::DIRECTED_PAIR, array(new QtiDirectedPair('def', 'abc')))),
-		);
-	}
+        return array(
+            array(new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(20))), new OrderedContainer(BaseType::INTEGER, array(new QtiInteger(30)))),
+            array(new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.taotesting.com'), new QtiUri('http://www.tao.lu'))), new OrderedContainer(BaseType::URI, array(new QtiUri('http://www.tao.lu'), new QtiUri('http://www.taotesting.com')))),
+            array(new OrderedContainer(BaseType::DIRECTED_PAIR, array(new QtiDirectedPair('abc', 'def'))), new OrderedContainer(BaseType::DIRECTED_PAIR, array(new QtiDirectedPair('def', 'abc')))),
+        );
+    }
 
     public function testEqualsNull()
     {


### PR DESCRIPTION
This PR fixes a `warning` message `PHP Warning:  count(): Parameter must be an array or an object that implements Countable` in OrderedContainer with PHP >= 7.2