### PR TITLE
updating upper case phpunit require-dev for composer 2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"wp-cli/php-cli-tools": "0.10.3"
 	},
 	"require-dev": {
-		"phpunit/PHPUnit": "~5.0",
+		"phpunit/phpunit": "~5.0",
 		"satooshi/php-coveralls": "~v2.0.0"
 	},
 	"bin": [


### PR DESCRIPTION
Fix PHPUnit in require-dev following a warning message from packagist (composer 2 support)