### PR TITLE
Skpping should be allowed for any item having no resps. decl.

### DIFF
--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -1361,7 +1361,7 @@ class AssessmentItemSession extends State
      */
     private function checkAllowSkipping(State $responses)
     {
-        // In case they are no response variable at all, the item is "skippable" as there is no possibility to provide an answer.
+        // In case there are no response variable at all, the item is "skippable" as there is no possibility to provide an answer.
         if ($this->getSubmissionMode() === SubmissionMode::INDIVIDUAL && $this->getItemSessionControl()->doesAllowSkipping() === false && count($this->getResponseVariables(false)) > 0) {
             
             $session = clone $this;

--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -1372,16 +1372,20 @@ class AssessmentItemSession extends State
             }
             
             $state = $session->getResponseVariables(false);
-            
-            // As per QTI Specification, the allowSkipping attribute is consistent with the numberResponded operator.
-            // In other words, the item can be submitted if at least one non-default value for at least one of the 
-            // response variables is provided.
-            if ($state->containsValuesEqualToVariableDefaultOnly() === true) {
-                throw new AssessmentItemSessionException(
-                    "Skipping item '" . $this->getAssessmentItem()->getIdentifier() . "' is not allowed.",
-                    $this,
-                    AssessmentItemSessionException::SKIPPING_FORBIDDEN
-                );
+
+            // In case they are no response variable at all, the item is "skippable" as there is no possibility
+            // to provide an answer.
+            if (count($state) > 0) {
+                // As per QTI Specification, the allowSkipping attribute is consistent with the numberResponded operator.
+                // In other words, the item can be submitted if at least one non-default value for at least one of the
+                // response variables is provided.
+                if ($state->containsValuesEqualToVariableDefaultOnly() === true) {
+                    throw new AssessmentItemSessionException(
+                        "Skipping item '" . $this->getAssessmentItem()->getIdentifier() . "' is not allowed.",
+                        $this,
+                        AssessmentItemSessionException::SKIPPING_FORBIDDEN
+                    );
+                }
             }
         }
     }

--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -1361,7 +1361,8 @@ class AssessmentItemSession extends State
      */
     private function checkAllowSkipping(State $responses)
     {
-        if ($this->getSubmissionMode() === SubmissionMode::INDIVIDUAL && $this->getItemSessionControl()->doesAllowSkipping() === false) {
+        // In case they are no response variable at all, the item is "skippable" as there is no possibility to provide an answer.
+        if ($this->getSubmissionMode() === SubmissionMode::INDIVIDUAL && $this->getItemSessionControl()->doesAllowSkipping() === false && count($this->getResponseVariables(false)) > 0) {
             
             $session = clone $this;
             
@@ -1373,19 +1374,15 @@ class AssessmentItemSession extends State
             
             $state = $session->getResponseVariables(false);
 
-            // In case they are no response variable at all, the item is "skippable" as there is no possibility
-            // to provide an answer.
-            if (count($state) > 0) {
-                // As per QTI Specification, the allowSkipping attribute is consistent with the numberResponded operator.
-                // In other words, the item can be submitted if at least one non-default value for at least one of the
-                // response variables is provided.
-                if ($state->containsValuesEqualToVariableDefaultOnly() === true) {
-                    throw new AssessmentItemSessionException(
-                        "Skipping item '" . $this->getAssessmentItem()->getIdentifier() . "' is not allowed.",
-                        $this,
-                        AssessmentItemSessionException::SKIPPING_FORBIDDEN
-                    );
-                }
+            // As per QTI Specification, the allowSkipping attribute is consistent with the numberResponded operator.
+            // In other words, the item can be submitted if at least one non-default value for at least one of the
+            // response variables is provided.
+            if ($state->containsValuesEqualToVariableDefaultOnly() === true) {
+                throw new AssessmentItemSessionException(
+                    "Skipping item '" . $this->getAssessmentItem()->getIdentifier() . "' is not allowed.",
+                    $this,
+                    AssessmentItemSessionException::SKIPPING_FORBIDDEN
+                );
             }
         }
     }

--- a/test/qtismtest/runtime/tests/AssessmentTestSessionTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentTestSessionTest.php
@@ -1842,58 +1842,66 @@ class AssessmentTestSessionTest extends QtiSmAssessmentTestSessionTestCase
         $this->assertEquals(AssessmentItemSessionState::SUSPENDED, $session->getAssessmentItemSessions('Q03')[0]->getState());
         
         $session->moveNext();
+
+        // -- Q04.
+        // This is an informational item (No interactions/response declarations)
+        $session->beginAttempt();
+        $session->endAttempt(new State());
+        $session->moveNext();
+        $this->assertEquals(1, $session['Q04.numAttempts']->getValue());
+        $this->assertEquals(AssessmentItemSessionState::SUSPENDED, $session->getAssessmentItemSessions('Q04')[0]->getState());
         
         // !!! ALLOWSKIPPING = TRUE !!!
         
-        // -- Q04.
-        $session->beginAttempt();
-        $session->endAttempt(new State());
-        $this->assertEquals(AssessmentItemSessionState::CLOSED, $session->getAssessmentItemSessions('Q04')[0]->getState());
-        
-        $session->moveNext();
-        
         // -- Q05.
         $session->beginAttempt();
-        $session->endAttempt(new State(array(new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER, new QtiIdentifier('ChoiceA')))));
+        $session->endAttempt(new State());
         $this->assertEquals(AssessmentItemSessionState::CLOSED, $session->getAssessmentItemSessions('Q05')[0]->getState());
         
         $session->moveNext();
         
         // -- Q06.
         $session->beginAttempt();
-        $session->endAttempt(new State(array(new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER), new ResponseVariable('RESPONSE2', Cardinality::SINGLE, BaseType::STRING, new QtiString('')))));
+        $session->endAttempt(new State(array(new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER, new QtiIdentifier('ChoiceA')))));
         $this->assertEquals(AssessmentItemSessionState::CLOSED, $session->getAssessmentItemSessions('Q06')[0]->getState());
+        
+        $session->moveNext();
+        
+        // -- Q07.
+        $session->beginAttempt();
+        $session->endAttempt(new State(array(new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER), new ResponseVariable('RESPONSE2', Cardinality::SINGLE, BaseType::STRING, new QtiString('')))));
+        $this->assertEquals(AssessmentItemSessionState::CLOSED, $session->getAssessmentItemSessions('Q07')[0]->getState());
         
         $session->moveNext();
         
         /// !!! ALLOWSKIPPING = FALSE, But, ignored because the current submission mode is simultaneous !!!
         
-        // -- Q07.
+        // -- Q08.
         $session->beginAttempt();
         $session->endAttempt(new State());
         
         $session->moveNext();
         
-        // -- Q08.
+        // -- Q09.
         $session->beginAttempt();
         $session->endAttempt(new State(array(new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER, new QtiIdentifier('ChoiceA')))));
         
         $session->moveNext();
         
-        // -- Q09.
+        // -- Q10.
         $session->beginAttempt();
         $session->endAttempt(new State(array(new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER), new ResponseVariable('RESPONSE2', Cardinality::SINGLE, BaseType::STRING, new QtiString('')))));
         
-        $this->assertEquals(AssessmentItemSessionState::SUSPENDED, $session->getAssessmentItemSessions('Q07')[0]->getState());
         $this->assertEquals(AssessmentItemSessionState::SUSPENDED, $session->getAssessmentItemSessions('Q08')[0]->getState());
         $this->assertEquals(AssessmentItemSessionState::SUSPENDED, $session->getAssessmentItemSessions('Q09')[0]->getState());
+        $this->assertEquals(AssessmentItemSessionState::SUSPENDED, $session->getAssessmentItemSessions('Q10')[0]->getState());
         
         // Simultaneous submission mode test part ends...
         $session->moveNext();
         
-        $this->assertEquals(AssessmentItemSessionState::CLOSED, $session->getAssessmentItemSessions('Q07')[0]->getState());
         $this->assertEquals(AssessmentItemSessionState::CLOSED, $session->getAssessmentItemSessions('Q08')[0]->getState());
         $this->assertEquals(AssessmentItemSessionState::CLOSED, $session->getAssessmentItemSessions('Q09')[0]->getState());
+        $this->assertEquals(AssessmentItemSessionState::CLOSED, $session->getAssessmentItemSessions('Q10')[0]->getState());
         $this->assertEquals(AssessmentTestSessionState::CLOSED, $session->getState());
     }
     

--- a/test/samples/custom/runtime/skipping/skipping.xml
+++ b/test/samples/custom/runtime/skipping/skipping.xml
@@ -45,20 +45,23 @@
                     </defaultValue>
 				</responseDeclaration>
 			</assessmentItemRef>
+
+			<!-- Item with no interactions, no response declarations (informational item). Should be always skippable -->
+			<assessmentItemRef identifier="Q04" href="Q04.xml" timeDependent="false"/>
 		</assessmentSection>
         
         <!-- S02 is exactly the same as S01, but allowSkipping is true. -->
         <assessmentSection identifier="S02" title="Section2" visible="true">
             <!-- Allow skipping for section S02. -->
             <itemSessionControl allowSkipping="true"/>
-			<assessmentItemRef identifier="Q04" href="./Q04.xml" timeDependent="false">
+			<assessmentItemRef identifier="Q05" href="./Q05.xml" timeDependent="false">
 				<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
 					<correctResponse>
 						<value>ChoiceA</value>
 					</correctResponse>
 				</responseDeclaration>
 			</assessmentItemRef>
-            <assessmentItemRef identifier="Q05" href="./Q05.xml" timeDependent="false">
+            <assessmentItemRef identifier="Q06" href="./Q06.xml" timeDependent="false">
 				<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
 					<correctResponse>
 						<value>ChoiceB</value>
@@ -68,7 +71,7 @@
                     </defaultValue>
 				</responseDeclaration>
 			</assessmentItemRef>
-            <assessmentItemRef identifier="Q06" href="./Q06.xml" timeDependent="false">
+            <assessmentItemRef identifier="Q07" href="./Q07.xml" timeDependent="false">
 				<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
 					<correctResponse>
 						<value>ChoiceB</value>
@@ -91,14 +94,14 @@
         <assessmentSection identifier="S03" title="Section3" visible="true">
             <!-- Do not allow skipping for section S03 (disabled by testPart's simultaneous submission mode). -->
             <itemSessionControl allowSkipping="false"/>
-			<assessmentItemRef identifier="Q07" href="./Q07.xml" timeDependent="false">
+			<assessmentItemRef identifier="Q08" href="./Q08.xml" timeDependent="false">
 				<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
 					<correctResponse>
 						<value>ChoiceA</value>
 					</correctResponse>
 				</responseDeclaration>
 			</assessmentItemRef>
-            <assessmentItemRef identifier="Q08" href="./Q08.xml" timeDependent="false">
+            <assessmentItemRef identifier="Q09" href="./Q09.xml" timeDependent="false">
 				<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
 					<correctResponse>
 						<value>ChoiceB</value>
@@ -108,7 +111,7 @@
                     </defaultValue>
 				</responseDeclaration>
 			</assessmentItemRef>
-            <assessmentItemRef identifier="Q09" href="./Q09.xml" timeDependent="false">
+            <assessmentItemRef identifier="Q10" href="./Q10.xml" timeDependent="false">
 				<responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
 					<correctResponse>
 						<value>ChoiceB</value>


### PR DESCRIPTION
This PR aims at making items without interactions (a.k.a. informational items) always "skippable", as no "non-default" values can be provided as a response to such items.