### PR TITLE
Feature/filesystem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,13 @@
 		"GPL-2.0-only"
 	],
 	"require" : {
-		"php" : ">=5.5",
+		"php" : ">=7.0",
 		"ext-dom": "*",
 		"ext-mbstring": "*",
 		"ext-json": "*",
 		"ext-date": "*",
-		"wp-cli/php-cli-tools": "0.10.3"
+		"wp-cli/php-cli-tools": "0.10.3",
+		"league/flysystem": "^1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~5.0",

--- a/src/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/src/qtism/data/storage/xml/XmlCompactDocument.php
@@ -152,7 +152,7 @@ class XmlCompactDocument extends XmlDocument
     public static function createFromXmlAssessmentTestDocument(XmlDocument $xmlAssessmentTestDocument, FileResolver $resolver = null)
     {
         $compactAssessmentTest = new XmlCompactDocument();
-        $compactAssessmentTest->setFileSystem($xmlAssessmentTestDocument->getFileSystem());
+        $compactAssessmentTest->setFilesystem($xmlAssessmentTestDocument->getFilesystem());
 
         $identifier = $xmlAssessmentTestDocument->getDocumentComponent()->getIdentifier();
         $title = $xmlAssessmentTestDocument->getDocumentComponent()->getTitle();
@@ -287,7 +287,7 @@ class XmlCompactDocument extends XmlDocument
             $href = $resolver->resolve($compactAssessmentItemRef->getHref());
 
             $doc = new XmlDocument();
-            $doc->setFileSystem($sourceDocument->getFileSystem());
+            $doc->setFilesystem($sourceDocument->getFilesystem());
             $doc->load($href);
             
             // Resolve external documents.
@@ -350,7 +350,7 @@ class XmlCompactDocument extends XmlDocument
             $href = $resolver->resolve($assessmentSectionRef->getHref());
 
             $doc = new XmlDocument();
-            $doc->setFileSystem($sourceDocument->getFileSystem());
+            $doc->setFilesystem($sourceDocument->getFilesystem());
             $doc->load($href);
             $doc->xInclude();
 
@@ -405,7 +405,7 @@ class XmlCompactDocument extends XmlDocument
             foreach ($this->explodeRubricBlocks() as $href => $rubricBlock) {
                 try {
                     $doc = new XmlDocument();
-                    $doc->setFileSystem($this->getFileSystem());
+                    $doc->setFilesystem($this->getFilesystem());
                     $doc->setDocumentComponent($rubricBlock);
 
                     $pathinfo = pathinfo($uri);
@@ -444,7 +444,7 @@ class XmlCompactDocument extends XmlDocument
                 
                 // Generate the document.
                 $doc = new XmlDocument();
-                $doc->setFileSystem($this->getFileSystem());
+                $doc->setFilesystem($this->getFilesystem());
                 $doc->setDocumentComponent($testFeedback);
                 
                 try {

--- a/src/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/src/qtism/data/storage/xml/XmlCompactDocument.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Copyright (c) 2013-2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/src/qtism/data/storage/xml/XmlCompactDocument.php
@@ -152,10 +152,7 @@ class XmlCompactDocument extends XmlDocument
     public static function createFromXmlAssessmentTestDocument(XmlDocument $xmlAssessmentTestDocument, FileResolver $resolver = null)
     {
         $compactAssessmentTest = new XmlCompactDocument();
-
-        if (($compactFilesystem = $xmlAssessmentTestDocument->getFileSystem()) !== null) {
-            $compactAssessmentTest->setFileSystem($compactFilesystem);
-        }
+        $compactAssessmentTest->setFileSystem($xmlAssessmentTestDocument->getFileSystem());
 
         $identifier = $xmlAssessmentTestDocument->getDocumentComponent()->getIdentifier();
         $title = $xmlAssessmentTestDocument->getDocumentComponent()->getTitle();
@@ -290,12 +287,7 @@ class XmlCompactDocument extends XmlDocument
             $href = $resolver->resolve($compactAssessmentItemRef->getHref());
 
             $doc = new XmlDocument();
-
-            // In case of the use of a filesystem, reuse it.
-            if (($filesystem = $sourceDocument->getFileSystem()) !== null) {
-                $doc->setFileSystem($filesystem);
-            }
-
+            $doc->setFileSystem($sourceDocument->getFileSystem());
             $doc->load($href);
             
             // Resolve external documents.
@@ -358,11 +350,7 @@ class XmlCompactDocument extends XmlDocument
             $href = $resolver->resolve($assessmentSectionRef->getHref());
 
             $doc = new XmlDocument();
-
-            if (($filesystem = $sourceDocument->getFileSystem()) !== null) {
-                $doc->setFileSystem($filesystem);
-            }
-
+            $doc->setFileSystem($sourceDocument->getFileSystem());
             $doc->load($href);
             $doc->xInclude();
 

--- a/src/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/src/qtism/data/storage/xml/XmlCompactDocument.php
@@ -219,7 +219,7 @@ class XmlCompactDocument extends XmlDocument
                             }
 
                             $resolver->setBasePath($baseUri);
-                            self::resolveAssessmentItemRef($compactRef, $resolver);
+                            self::resolveAssessmentItemRef($xmlAssessmentTestDocument, $compactRef, $resolver);
 
                             $previousParts->replace($component, $compactRef);
                             break;
@@ -235,7 +235,7 @@ class XmlCompactDocument extends XmlDocument
                     
                     $resolver->setBasePath($baseUri);
                     
-                    $assessmentSectionDocument = self::resolveAssessmentSectionRef($component, $resolver);
+                    $assessmentSectionDocument = self::resolveAssessmentSectionRef($xmlAssessmentTestDocument, $component, $resolver);
                     $assessmentSection = $assessmentSectionDocument->getDocumentComponent();
                     $sectionStore[$assessmentSection] = $assessmentSectionDocument;
                     
@@ -279,12 +279,18 @@ class XmlCompactDocument extends XmlDocument
 	 * @param \qtism\data\storage\FileResolver $resolver The Resolver to be used to resolver AssessmentItemRef's href attribute.
 	 * @throws \qtism\data\storage\xml\XmlStorageException If an error occurs (e.g. file not found at URI or unmarshalling issue) during the dereferencing.
 	 */
-    protected static function resolveAssessmentItemRef(ExtendedAssessmentItemRef $compactAssessmentItemRef, FileResolver $resolver)
+    protected static function resolveAssessmentItemRef(XmlDocument $sourceDocument, ExtendedAssessmentItemRef $compactAssessmentItemRef, FileResolver $resolver)
     {
         try {
             $href = $resolver->resolve($compactAssessmentItemRef->getHref());
 
             $doc = new XmlDocument();
+
+            // In case of the use of a filesystem, reuse it.
+            if (($filesystem = $sourceDocument->getFileSystem()) !== null) {
+                $doc->setFileSystem($filesystem);
+            }
+
             $doc->load($href);
             
             // Resolve external documents.
@@ -341,12 +347,17 @@ class XmlCompactDocument extends XmlDocument
 	 * @throws \qtism\data\storage\xml\XmlStorageException If an error occurs while dereferencing the referenced file.
 	 * @return \qtism\data\XmlDocument The AssessmentSection referenced by $assessmentSectionRef as an XmlDocument object.
 	 */
-    protected static function resolveAssessmentSectionRef(AssessmentSectionRef $assessmentSectionRef, FileResolver $resolver)
+    protected static function resolveAssessmentSectionRef(XmlDocument $sourceDocument, AssessmentSectionRef $assessmentSectionRef, FileResolver $resolver)
     {
         try {
             $href = $resolver->resolve($assessmentSectionRef->getHref());
 
             $doc = new XmlDocument();
+
+            if (($filesystem = $sourceDocument->getFileSystem()) !== null) {
+                $doc->setFileSystem($filesystem);
+            }
+
             $doc->load($href);
             $doc->xInclude();
 

--- a/src/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/src/qtism/data/storage/xml/XmlCompactDocument.php
@@ -277,6 +277,7 @@ class XmlCompactDocument extends XmlDocument
 	 * Dereference the file referenced by an assessmentItemRef and add
 	 * outcome/responseDeclarations to the compact one.
 	 *
+     * @param XmlDocument $sourceDocument The source document from where assessmentItemRef must be resolved.
 	 * @param \qtism\data\ExtendedAssessmentItemRef $compactAssessmentItemRef A previously instantiated ExtendedAssessmentItemRef object.
 	 * @param \qtism\data\storage\FileResolver $resolver The Resolver to be used to resolver AssessmentItemRef's href attribute.
 	 * @throws \qtism\data\storage\xml\XmlStorageException If an error occurs (e.g. file not found at URI or unmarshalling issue) during the dereferencing.
@@ -339,10 +340,11 @@ class XmlCompactDocument extends XmlDocument
      * 
      * The xinclude elements in the target assessmentSection file will be resolved at the same time.
 	 *
+     * @param \qtism\data\storage\xml\XmlDocument $sourceDocument The source document from where assessmentItemRef must be resolved.
 	 * @param \qtism\data\AssessmentSectionRef $assessmentSectionRef An AssessmentSectionRef object to dereference.
 	 * @param \qtism\data\storage\FileResolver $resolver The Resolver object to be used to resolve AssessmentSectionRef's href attribute.
 	 * @throws \qtism\data\storage\xml\XmlStorageException If an error occurs while dereferencing the referenced file.
-	 * @return \qtism\data\XmlDocument The AssessmentSection referenced by $assessmentSectionRef as an XmlDocument object.
+	 * @return \qtism\data\storage\xml\XmlDocument The AssessmentSection referenced by $assessmentSectionRef as an XmlDocument object.
 	 */
     protected static function resolveAssessmentSectionRef(XmlDocument $sourceDocument, AssessmentSectionRef $assessmentSectionRef, FileResolver $resolver)
     {
@@ -367,7 +369,7 @@ class XmlCompactDocument extends XmlDocument
 	 * of the default schema.
 	 *
 	 * @param string $filename An optional filename to force the validation against a particular schema.
-	 * @return boolean
+     * @throws XmlStorageException
 	 */
     public function schemaValidate($filename = '')
     {
@@ -383,7 +385,7 @@ class XmlCompactDocument extends XmlDocument
     /**
 	 * Override of XmlDocument.
 	 *
-	 * Specifices the correct XSD schema locations and main namespace
+	 * Specifies the correct XSD schema locations and main namespace
 	 * for the root element of a Compact XML document.
 	 *
 	 * @param \DOMElement $rootElement The root element of a compact XML document.

--- a/src/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/src/qtism/data/storage/xml/XmlCompactDocument.php
@@ -152,6 +152,11 @@ class XmlCompactDocument extends XmlDocument
     public static function createFromXmlAssessmentTestDocument(XmlDocument $xmlAssessmentTestDocument, FileResolver $resolver = null)
     {
         $compactAssessmentTest = new XmlCompactDocument();
+
+        if (($compactFilesystem = $xmlAssessmentTestDocument->getFileSystem()) !== null) {
+            $compactAssessmentTest->setFileSystem($compactFilesystem);
+        }
+
         $identifier = $xmlAssessmentTestDocument->getDocumentComponent()->getIdentifier();
         $title = $xmlAssessmentTestDocument->getDocumentComponent()->getTitle();
 
@@ -412,6 +417,7 @@ class XmlCompactDocument extends XmlDocument
             foreach ($this->explodeRubricBlocks() as $href => $rubricBlock) {
                 try {
                     $doc = new XmlDocument();
+                    $doc->setFileSystem($this->getFileSystem());
                     $doc->setDocumentComponent($rubricBlock);
 
                     $pathinfo = pathinfo($uri);
@@ -450,6 +456,7 @@ class XmlCompactDocument extends XmlDocument
                 
                 // Generate the document.
                 $doc = new XmlDocument();
+                $doc->setFileSystem($this->getFileSystem());
                 $doc->setDocumentComponent($testFeedback);
                 
                 try {

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -67,6 +67,9 @@ class XmlDocument extends QtiDocument
     private $domDocument = null;
 
     /**
+     * The Filesystem implementation in use. Contains null
+     * in case of old fashioned local file system implementation.
+     *
      * @var null|Filesystem
      */
     private $fileSystem = null;
@@ -106,12 +109,29 @@ class XmlDocument extends QtiDocument
         return $this->domDocument;
     }
 
-    public function setFileSystem(Filesystem $filesystem = null)
+    /**
+     * Set the Filesystem implementation.
+     *
+     * Set the Filesystem implementation to be used. As soon as an implementation is set,
+     * all subsequent creations of related XmlDocument objects will use this Filesystem
+     * implementation.
+     *
+     * @param Filesystem|null $filesystem
+     */
+    public function setFilesystem(Filesystem $filesystem = null)
     {
         $this->fileSystem = $filesystem;
     }
 
-    protected function getFileSystem()
+    /**
+     * Get the Filesystem implementation.
+     *
+     * Get the Filesystem implementation currently in use. Returns null
+     * in case of the local file system is in use.
+     *
+     * @return Filesystem|null
+     */
+    protected function getFilesystem()
     {
         return $this->fileSystem;
     }
@@ -123,6 +143,10 @@ class XmlDocument extends QtiDocument
 	 * If the XmlDocument object was previously with a QTI version which does not
 	 * correspond to version in use in the loaded file, the version found into
 	 * the file will supersede the version specified at instantiation time.
+     *
+     * In case of a Filesystem object being injected prior to the call via the XmlDocument::setFilesystem()
+     * method, the data will be loaded through this implementation. Otherwise, it will be loaded from the
+     * local filesystem.
 	 *
 	 * @param string $uri The Uniform Resource Identifier that identifies/locate the file.
 	 * @param boolean $validate Whether or not the file must be validated unsing XML Schema? Default is false.
@@ -130,7 +154,7 @@ class XmlDocument extends QtiDocument
 	 */
     public function load($uri, $validate = false)
     {
-        if (($filesystem = $this->getFileSystem()) === null) {
+        if (($filesystem = $this->getFilesystem()) === null) {
             $this->loadImplementation($uri, $validate, false);
 
             // We now are sure that the URI is valid.
@@ -139,7 +163,7 @@ class XmlDocument extends QtiDocument
             try {
                 $input = $filesystem->read($uri);
                 $this->loadImplementation($input, $validate, true);
-                $this->setFileSystem($filesystem);
+                $this->setFilesystem($filesystem);
 
                 // Build new custom basePath.
                 $this->setUrl($uri);
@@ -274,6 +298,9 @@ class XmlDocument extends QtiDocument
     /**
 	 * Save the Assessment Document at the location described by $uri. Please be carefull
 	 * to provide an AssessmentTest object to save before calling this method.
+     *
+     * In case of a Filesystem object being injected prior to the call, data will be stored on through
+     * this Filesystem implementation. Otherwise, it will be stored on the local filesystem.
 	 *
 	 * @param string $uri The URI describing the location to save the QTI-XML representation of the Assessment Test.
 	 * @param boolean $formatOutput Wether the XML content of the file must be formatted (new lines, indentation) or not.
@@ -281,7 +308,7 @@ class XmlDocument extends QtiDocument
 	 */
     public function save($uri, $formatOutput = true)
     {
-        if (($filesystem = $this->getFileSystem()) === null) {
+        if (($filesystem = $this->getFilesystem()) === null) {
             $this->saveImplementation($uri, $formatOutput);
         } else {
             $error = false;
@@ -308,7 +335,7 @@ class XmlDocument extends QtiDocument
     /**
 	 * Save the Assessment Document as an XML string.
 	 *
-	 * @param boolean $formatOutput Wether the XML content of the file must be formatted (new lines, indentation) or not.
+	 * @param boolean $formatOutput Whether the XML content of the file must be formatted (new lines, indentation) or not.
 	 * @throws \qtism\data\storage\xml\XmlStorageException If an error occurs while transforming the AssessmentTest object to its QTI-XML representation.
      * @return string The XML string.
 	 */
@@ -452,8 +479,8 @@ class XmlDocument extends QtiDocument
                         
                         $doc = new XmlDocument();
 
-                        if (($filesystem = $this->getFileSystem()) !== null) {
-                            $doc->setFileSystem($filesystem);
+                        if (($filesystem = $this->getFilesystem()) !== null) {
+                            $doc->setFilesystem($filesystem);
                         }
 
                         $doc->load($href, $validate);
@@ -505,8 +532,8 @@ class XmlDocument extends QtiDocument
                     
                     $doc = new XmlDocument();
 
-                    if (($filesystem = $this->getFileSystem()) !== null) {
-                        $doc->setFileSystem($filesystem);
+                    if (($filesystem = $this->getFilesystem()) !== null) {
+                        $doc->setFilesystem($filesystem);
                     }
 
                     $doc->load($templateLocation, $validate);
@@ -558,8 +585,8 @@ class XmlDocument extends QtiDocument
                         
                         $doc = new XmlDocument();
 
-                        if (($filesystem = $this->getFileSystem()) !== null) {
-                            $doc->setFileSystem($filesystem);
+                        if (($filesystem = $this->getFilesystem()) !== null) {
+                            $doc->setFilesystem($filesystem);
                         }
 
                         $doc->load($href, $validate);

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -22,6 +22,8 @@
 
 namespace qtism\data\storage\xml;
 
+use League\Flysystem\FileNotFoundException;
+use League\Flysystem\Filesystem;
 use qtism\common\utils\Url;
 use qtism\data\QtiComponentCollection;
 use qtism\data\QtiComponentIterator;
@@ -129,6 +131,28 @@ class XmlDocument extends QtiDocument
     public function loadFromString($string, $validate = false)
     {
         $this->loadImplementation($string, $validate, true);
+    }
+
+    /**
+     * @param Filesystem $filesystem
+     * @param $path
+     * @param bool $validate
+     * @throws XmlStorageException
+     */
+    public function loadFromFileSystem(Filesystem $filesystem, $path, $validate = false)
+    {
+        try {
+            $input = $filesystem->read($path);
+            $this->loadImplementation($input, $validate, true);
+
+        } catch (FileNotFoundException $e) {
+
+            throw new XmlStorageException(
+                "Cannot load QTI file at path '${path}'. It does not exist or is not readable.",
+                XmlStorageException::RESOLUTION,
+                $e
+            );
+        }
     }
 
     /**

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -531,11 +531,7 @@ class XmlDocument extends QtiDocument
                     $templateLocation = Url::rtrim($basePath) . '/' . Url::ltrim($templateLocation);
                     
                     $doc = new XmlDocument();
-
-                    if (($filesystem = $this->getFilesystem()) !== null) {
-                        $doc->setFilesystem($filesystem);
-                    }
-
+                    $doc->setFilesystem($this->getFilesystem());
                     $doc->load($templateLocation, $validate);
                     
                     $newResponseProcessing = $doc->getDocumentComponent();
@@ -584,11 +580,7 @@ class XmlDocument extends QtiDocument
                         $href = Url::rtrim($basePath) . '/' . Url::ltrim($href);
                         
                         $doc = new XmlDocument();
-
-                        if (($filesystem = $this->getFilesystem()) !== null) {
-                            $doc->setFilesystem($filesystem);
-                        }
-
+                        $doc->setFilesystem($this->getFilesystem());
                         $doc->load($href, $validate);
 
                         $sectionRoot = $doc->getDocumentComponent();

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Copyright (c) 2013-2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -67,11 +67,6 @@ class XmlDocument extends QtiDocument
     private $domDocument = null;
 
     /**
-     * @var string
-     */
-    private $customBaseUri = '';
-
-    /**
      * @var null|Filesystem
      */
     private $fileSystem = null;
@@ -111,16 +106,6 @@ class XmlDocument extends QtiDocument
         return $this->domDocument;
     }
 
-    protected function setCustomBaseUri($customBaseUri)
-    {
-        $this->customBaseUri = $customBaseUri;
-    }
-
-    protected function getCustomBaseUri()
-    {
-        return $this->customBaseUri;
-    }
-
     public function setFileSystem(Filesystem $filesystem = null)
     {
         $this->fileSystem = $filesystem;
@@ -146,7 +131,6 @@ class XmlDocument extends QtiDocument
     public function load($uri, $validate = false)
     {
         if (($filesystem = $this->getFileSystem()) === null) {
-            $this->setCustomBaseUri('');
             $this->loadImplementation($uri, $validate, false);
 
             // We now are sure that the URI is valid.
@@ -158,7 +142,7 @@ class XmlDocument extends QtiDocument
                 $this->setFileSystem($filesystem);
 
                 // Build new custom basePath.
-                $this->setCustomBaseUri($uri);
+                $this->setUrl($uri);
 
             } catch (FileNotFoundException $e) {
 
@@ -180,30 +164,8 @@ class XmlDocument extends QtiDocument
 	 */
     public function loadFromString($string, $validate = false)
     {
-        $this->setCustomBaseUri('');
+        $this->setUrl('');
         $this->loadImplementation($string, $validate, true);
-    }
-
-    /**
-     * Get the base URI of the document.
-     *
-     * Will return an empty string in case of no document loaded yet.
-     *
-     * @return string
-     */
-    public function getBaseUri()
-    {
-        $baseUri = '';
-
-        if (($customBaseUri = $this->getCustomBaseUri()) !== '') {
-
-            $baseUri = $customBaseUri;
-        } elseif (($document = $this->getDomDocument()) !== null) {
-
-            $baseUri = $document->documentElement->baseURI;
-        }
-
-        return $baseUri;
     }
 
     /**
@@ -450,7 +412,7 @@ class XmlDocument extends QtiDocument
         
         if (($root = $this->getDocumentComponent()) !== null) {
             
-            $baseUri = str_replace('\\', '/', $this->getBaseUri());
+            $baseUri = str_replace('\\', '/', $this->getUrl());
             $pathinfo = pathinfo($baseUri);
             $basePath = $pathinfo['dirname'];
             
@@ -515,7 +477,7 @@ class XmlDocument extends QtiDocument
                 
                 if (Url::isRelative($templateLocation) === true) {
                     
-                    $baseUri = $this->getBaseUri();
+                    $baseUri = $this->getUrl();
                     $pathinfo = pathinfo($baseUri);
                     $basePath = $pathinfo['dirname'];
                     $templateLocation = Url::rtrim($basePath) . '/' . Url::ltrim($templateLocation);
@@ -559,7 +521,7 @@ class XmlDocument extends QtiDocument
     {
         if (($root = $this->getDocumentComponent()) !== null) {
             
-            $baseUri = str_replace('\\', '/', $this->getBaseUri());
+            $baseUri = str_replace('\\', '/', $this->getUrl());
             $pathinfo = pathinfo($baseUri);
             $basePath = $pathinfo['dirname'];
             

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -281,7 +281,28 @@ class XmlDocument extends QtiDocument
 	 */
     public function save($uri, $formatOutput = true)
     {
-        $this->saveImplementation($uri, $formatOutput);
+        if (($filesystem = $this->getFileSystem()) === null) {
+            $this->saveImplementation($uri, $formatOutput);
+        } else {
+            $error = false;
+
+            try {
+                $output = $this->saveImplementation('', $formatOutput);
+                if (!$filesystem->put($uri, $output)) {
+                    $error = true;
+                }
+            } catch (LogicException $e) {
+                // FlySystem throws a LogicException when trying to write outside of the root... catch it!
+                $error = true;
+            }
+
+            if ($error) {
+                throw new XmlStorageException(
+                    "An error occurred while saving QTI-XML file at '${uri}'. Maybe the save location is not reachable?",
+                    XmlStorageException::WRITE
+                );
+            }
+        }
     }
 
     /**

--- a/test/qtismtest/QtiSmTestCase.php
+++ b/test/qtismtest/QtiSmTestCase.php
@@ -1,6 +1,8 @@
 <?php
 namespace qtismtest;
 
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
 use qtism\common\utils\Version;
 use qtism\data\storage\xml\marshalling\Qti20MarshallerFactory;
@@ -14,14 +16,47 @@ use \DateTime;
 use \DateTimeZone;
 
 abstract class QtiSmTestCase extends TestCase {
-	
+
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem = null;
+
 	public function setUp() {
 	    parent::setUp();
+
+	    // Set up File System Local adapter for testing.
+        $adapter = new Local(self::samplesDir());
+        $this->setFileSystem(new Filesystem($adapter));
 	}
 	
 	public function tearDown() {
 	    parent::tearDown();
 	}
+
+    /**
+     * Set File System
+     *
+     * Setup the FileSystem implementation to be used for testing.
+     *
+     * @param Filesystem $filesystem
+     */
+	protected function setFileSystem(Filesystem $filesystem)
+    {
+        $this->fileSystem = $filesystem;
+    }
+
+    /**
+     * Get File System
+     *
+     * Setup the FileSystem implementation to be used for testing.
+     *
+     * @return Filesystem
+     */
+    protected function getFileSystem()
+    {
+        return $this->fileSystem;
+    }
 	
 	public function getMarshallerFactory($version = '2.1') {
 	    if (Version::compare($version, '2.0.0', '==') === true) {

--- a/test/qtismtest/QtiSmTestCase.php
+++ b/test/qtismtest/QtiSmTestCase.php
@@ -22,17 +22,38 @@ abstract class QtiSmTestCase extends TestCase {
      */
     private $fileSystem = null;
 
+    /**
+     * @var Filesystem
+     */
+    private $outputFileSystem = null;
+
 	public function setUp() {
 	    parent::setUp();
 
 	    // Set up File System Local adapter for testing.
         $adapter = new Local(self::samplesDir());
         $this->setFileSystem(new Filesystem($adapter));
+
+        // Set up File System Local adapter for output.
+        $adapter = new Local(sys_get_temp_dir() . '/qsmout');
+        $this->setOutputFileSystem(new Filesystem($adapter));
 	}
 	
 	public function tearDown() {
 	    parent::tearDown();
 	}
+
+    /**
+     * Get File System
+     *
+     * Setup the FileSystem implementation to be used for testing.
+     *
+     * @return Filesystem
+     */
+    protected function getFileSystem()
+    {
+        return $this->fileSystem;
+    }
 
     /**
      * Set File System
@@ -47,15 +68,27 @@ abstract class QtiSmTestCase extends TestCase {
     }
 
     /**
-     * Get File System
+     * Get Output File System
      *
      * Setup the FileSystem implementation to be used for testing.
      *
      * @return Filesystem
      */
-    protected function getFileSystem()
+    protected function getOutputFileSystem()
     {
-        return $this->fileSystem;
+        return $this->outputFileSystem;
+    }
+
+    /**
+     * Set Output File System
+     *
+     * Setup the FileSystem implementation to be used for testing.
+     *
+     * @param Filesystem $filesystem
+     */
+    protected function setOutputFileSystem(Filesystem $filesystem)
+    {
+        $this->outputFileSystem = $filesystem;
     }
 	
 	public function getMarshallerFactory($version = '2.1') {

--- a/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
@@ -118,12 +118,11 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
     {
         $doc = new XmlDocument();
 
-        if ($filesystem === false) {
-            $doc->load($file, true);
-        } else {
-            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        if ($filesystem === true) {
+            $doc->setFileSystem($this->getFileSystem());
         }
 
+        $doc->load($file, true);
         $doc->includeAssessmentSectionRefs();
         
         $root = $doc->getDocumentComponent();
@@ -165,12 +164,11 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
     {
         $doc = new XmlDocument();
 
-        if ($filesystem === false) {
-            $doc->load($file, true);
-        } else {
-            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        if ($filesystem === true) {
+            $doc->setFileSystem($this->getFileSystem());
         }
 
+        $doc->load($file, true);
         $doc->includeAssessmentSectionRefs(true);
 
         $root = $doc->getDocumentComponent();

--- a/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
@@ -119,7 +119,7 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
         $doc = new XmlDocument();
 
         if ($filesystem === true) {
-            $doc->setFileSystem($this->getFileSystem());
+            $doc->setFilesystem($this->getFileSystem());
         }
 
         $doc->load($file, true);
@@ -165,7 +165,7 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
         $doc = new XmlDocument();
 
         if ($filesystem === true) {
-            $doc->setFileSystem($this->getFileSystem());
+            $doc->setFilesystem($this->getFileSystem());
         }
 
         $doc->load($file, true);

--- a/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
@@ -1,14 +1,15 @@
 <?php
 namespace qtismtest\data\storage\xml;
 
+use League\Flysystem\Filesystem;
 use qtismtest\QtiSmTestCase;
 use qtism\data\storage\xml\XmlDocument;
-use qtism\data\AssessmentTest;
 use qtism\data\storage\xml\XmlStorageException;
 
 class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
 	
-	public function testLoad() {
+	public function testLoad()
+    {
 		$uri = dirname(__FILE__) . '/../../../../samples/ims/tests/interaction_mix_sachsen/interaction_mix_sachsen.xml';
 		$doc = new XmlDocument('2.1');
 		$doc->load($uri);
@@ -17,7 +18,8 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
 		$this->assertInstanceOf('qtism\\data\\AssessmentTest', $doc->getDocumentComponent());
 	}
 	
-	public function testLoadFileDoesNotExist() {
+	public function testLoadFileDoesNotExist()
+    {
 		// This file does not exist.
 		$uri = dirname(__FILE__) . '/../../../../samples/invalid/abcd.xml';
 		$doc = new XmlDocument('2.1');
@@ -25,7 +27,8 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
 		$doc->load($uri);
 	}
 	
-	public function testLoadFileMalformed() {
+	public function testLoadFileMalformed()
+    {
 		// This file contains malformed xml markup.
 		$uri = dirname(__FILE__) . '/../../../../samples/invalid/malformed.xml';
 		$doc = new XmlDocument('2.1');
@@ -41,7 +44,8 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
 		}
 	}
 	
-	public function testLoadSimpleItemSessionControlOnTestPart() {
+	public function testLoadSimpleItemSessionControlOnTestPart()
+    {
 	    $doc = new XmlDocument('2.1');
 	    $doc->load(self::samplesDir() . 'custom/simple_itemsessioncontrol_testpart.xml');
 	    $testParts = $doc->getDocumentComponent()->getTestParts();
@@ -50,7 +54,8 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
 	    $this->assertEquals(0, $testParts['testPartId']->getItemSessionControl()->getMaxAttempts());
 	}
 	
-	public function testSaveSimpleItemSessionControlOnTestPart() {
+	public function testSaveSimpleItemSessionControlOnTestPart()
+    {
 	    $doc = new XmlDocument('2.1');
 	    $doc->load(self::samplesDir() . 'custom/simple_itemsessioncontrol_testpart.xml');
 	    $file = tempnam('/tmp', 'qsm');
@@ -66,7 +71,8 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
 	    unlink($file);
 	}
 	
-	public function testFullyQualified() {
+	public function testFullyQualified()
+    {
 		$uri = dirname(__FILE__) . '/../../../../samples/custom/fully_qualified_assessmenttest.xml';
 		$doc = new XmlDocument('2.1');
 		$doc->load($uri);
@@ -76,7 +82,8 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
 		$this->assertInstanceOf('qtism\\data\\AssessmentTest', $doc->getDocumentComponent());
 	}
 	
-	public function testItemSessionControls() {
+	public function testItemSessionControls()
+    {
 	    $doc = new XmlDocument('2.1');
 	    $doc->load(self::samplesDir() . 'custom/runtime/routeitem_itemsessioncontrols.xml');
 	    
@@ -91,7 +98,8 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
 	    $this->assertEquals(4, $p02->getItemSessionControl()->getMaxAttempts());
 	}
     
-    public function testAssessmentSectionRefsInTestParts() {
+    public function testAssessmentSectionRefsInTestParts()
+    {
         $doc = new XmlDocument();
         $doc->load(self::samplesDir() . 'custom/tests/nested_assessment_section_refs/test_definition/test.xml', true);
         
@@ -102,10 +110,20 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
         $this->assertTrue(isset($sectionParts['SR01']));
         $this->assertInstanceOf('qtism\\data\\AssessmentSectionRef', $sectionParts['SR01']);
     }
-    
-    public function testIncludeAssessmentSectionRefsInTestParts() {
+
+    /**
+     * @dataProvider includeAssessmentSectionRefsInTestPartsProvider
+     */
+    public function testIncludeAssessmentSectionRefsInTestParts($file, $filesystem)
+    {
         $doc = new XmlDocument();
-        $doc->load(self::samplesDir() . 'custom/tests/nested_assessment_section_refs/test_definition/test.xml', true);
+
+        if ($filesystem === false) {
+            $doc->load($file, true);
+        } else {
+            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        }
+
         $doc->includeAssessmentSectionRefs();
         
         $root = $doc->getDocumentComponent();
@@ -131,23 +149,38 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
         $this->assertInstanceOf('qtism\\data\\AssessmentItemRef', $assessmentItemRefs['Q03']);
         $this->assertEquals('../sections/../sections/../items/question3.xml', $assessmentItemRefs['Q03']->getHref());
     }
+
+    public function includeAssessmentSectionRefsInTestPartsProvider()
+    {
+        return [
+            [self::samplesDir() . 'custom/tests/nested_assessment_section_refs/test_definition/test.xml', false],
+            ['custom/tests/nested_assessment_section_refs/test_definition/test.xml', true]
+        ];
+    }
     
     /**
      * @dataProvider testIncludeAssessmentSectionRefsMixedProvider
      */
-    public function testIncludeAssessmentSectionRefsMixed($file) {
+    public function testIncludeAssessmentSectionRefsMixed($file, $filesystem)
+    {
         $doc = new XmlDocument();
-        $doc->load($file, true);
+
+        if ($filesystem === false) {
+            $doc->load($file, true);
+        } else {
+            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        }
+
         $doc->includeAssessmentSectionRefs(true);
-        
+
         $root = $doc->getDocumentComponent();
-        
+
         $testParts = $root->getTestParts();
         $this->assertTrue(isset($testParts['T01']));
-        
+
         $this->assertCount(1, $testParts['T01']->getAssessmentSections());
         $this->assertTrue(isset($testParts['T01']->getAssessmentSections()['S00']));
-        
+
         $mainSection = $testParts['T01']->getAssessmentSections()['S00'];
         $sectionParts = $mainSection->getSectionParts();
         $this->assertCount(5, $sectionParts);
@@ -155,32 +188,36 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase {
             array('Q01', 'S01', 'Q03', 'S02', 'Q05'),
             $sectionParts->getKeys()
         );
-        
+
         $this->assertInstanceOf('qtism\\data\\AssessmentItemRef', $sectionParts['Q01']);
         $this->assertInstanceOf('qtism\\data\\AssessmentSection', $sectionParts['S01']);
         $this->assertInstanceOf('qtism\\data\\AssessmentItemRef', $sectionParts['Q03']);
         $this->assertInstanceOf('qtism\\data\\AssessmentSection', $sectionParts['S02']);
         $this->assertInstanceOf('qtism\\data\\AssessmentItemRef', $sectionParts['Q05']);
-        
+
         $section = $sectionParts['S01'];
         $this->assertCount(1, $section->getSectionParts());
         $this->assertTrue(isset($section->getSectionParts()['Q02']));
         $this->assertInstanceOf('qtism\\data\\AssessmentItemRef', $section->getSectionParts()['Q02']);
-        
+
         $section = $sectionParts['S02'];
         $this->assertCount(1, $section->getSectionParts());
         $this->assertTrue(isset($section->getSectionParts()['Q04']));
         $this->assertInstanceOf('qtism\\data\\AssessmentItemRef', $section->getSectionParts()['Q04']);
     }
-    
-    public function testIncludeAssessmentSectionRefsMixedProvider() {
+
+    public function testIncludeAssessmentSectionRefsMixedProvider()
+    {
         return array(
-            array(self::samplesDir() . 'custom/tests/mixed_assessment_section_refs/test_similar_ids.xml'),
-            array(self::samplesDir() . 'custom/tests/mixed_assessment_section_refs/test_different_ids.xml')
+            array(self::samplesDir() . 'custom/tests/mixed_assessment_section_refs/test_similar_ids.xml', false),
+            array(self::samplesDir() . 'custom/tests/mixed_assessment_section_refs/test_different_ids.xml', false),
+            array('custom/tests/mixed_assessment_section_refs/test_similar_ids.xml', true),
+            array('custom/tests/mixed_assessment_section_refs/test_different_ids.xml', true)
         );
     }
 	
-	private static function decorateUri($uri) {
+	private static function decorateUri($uri)
+    {
 		return dirname(__FILE__) . '/../../../../samples/ims/tests/' . $uri;
 	}
 }

--- a/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
@@ -75,11 +75,19 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
 		unlink($file);
 		$this->assertFalse(file_exists($file));
 	}
-	
-	public function testCreateFrom()
+
+    /**
+     * @throws XmlStorageException
+     * @dataProvider createFromProvider
+     */
+	public function testCreateFrom($file, $filesystem)
     {
 		$doc = new XmlDocument('2.1');
-		$file = self::samplesDir() . 'ims/tests/interaction_mix_sachsen/interaction_mix_sachsen.xml';
+
+		if ($filesystem === true) {
+		    $doc->setFileSystem($this->getFileSystem());
+        }
+
 		$doc->load($file);
 		
 		$compactDoc = XmlCompactDocument::createFromXmlAssessmentTestDocument($doc);
@@ -91,14 +99,31 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
 		$compactDoc = new XmlCompactDocument('2.1.0');
 		$compactDoc->load($file);
 		$this->testLoad($compactDoc);
-		unlink($file);
-		$this->assertFalse(file_exists($file));
 	}
-    
-    public function testCreateFromWithUnresolvableAssessmentSectionRef()
+
+	public function createFromProvider()
+    {
+        return [
+            [self::samplesDir() . 'ims/tests/interaction_mix_sachsen/interaction_mix_sachsen.xml', false],
+            ['ims/tests/interaction_mix_sachsen/interaction_mix_sachsen.xml', true]
+        ];
+    }
+
+
+    /**
+     * @param $file
+     * @param $filesystem
+     * @throws XmlStorageException
+     * @dataProvider createFromWithUnresolvableAssessmentSectionRefProvider
+     */
+    public function testCreateFromWithUnresolvableAssessmentSectionRef($file, $filesystem)
     {
 		$doc = new XmlDocument('2.1');
-		$file = self::samplesDir() . 'custom/interaction_mix_saschen_assessmentsectionref/interaction_mix_sachsen3.xml';
+
+		if ($filesystem === true) {
+		    $doc->setFileSystem($this->getFileSystem());
+        }
+
 		$doc->load($file);
 		
         $this->setExpectedException(
@@ -108,6 +133,14 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
         
 		$compactDoc = XmlCompactDocument::createFromXmlAssessmentTestDocument($doc);
 	}
+
+	public function createFromWithUnresolvableAssessmentSectionRefProvider()
+    {
+        return [
+            [self::samplesDir() . 'custom/interaction_mix_saschen_assessmentsectionref/interaction_mix_sachsen3.xml', false],
+            ['custom/interaction_mix_saschen_assessmentsectionref/interaction_mix_sachsen3.xml', true]
+        ];
+    }
 	
 	public function testCreateFromExploded($v = '', $sectionCount = 2)
     {
@@ -176,12 +209,23 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
     {
         $this->testCreateFromExploded('2', 3);
     }
-    
-    public function testCreateFromTestWithShuffledInteractions()
+
+    /**
+     * @param $file
+     * @param $filesystem
+     * @throws XmlStorageException
+     * @dataProvider createFromTestWithShuffledInteractionsProvider
+     */
+    public function testCreateFromTestWithShuffledInteractions($file, $filesystem)
     {
         $doc = new XmlDocument('2.1');
-		$file = self::samplesDir() . 'custom/tests/shufflings.xml';
+
+        if ($filesystem === true) {
+            $doc->setFileSystem($this->getFileSystem());
+        }
+
 		$doc->load($file);
+
 		$compactDoc = XmlCompactDocument::createFromXmlAssessmentTestDocument($doc, new LocalFileResolver());
         $compactTest = $compactDoc->getDocumentComponent();
         
@@ -264,6 +308,14 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
         
         $shufflings = $itemRef->getShufflings();
         $this->assertEquals(0, count($shufflings));
+    }
+
+    public function createFromTestWithShuffledInteractionsProvider()
+    {
+        return [
+            [self::samplesDir() . 'custom/tests/shufflings.xml', false],
+            ['custom/tests/shufflings.xml', true]
+        ];
     }
 	
 	public function testLoadRubricBlockRefs(XmlCompactDocument $doc = null)

--- a/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
@@ -86,18 +86,18 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
         $outputFilesystem = $filesystem ? $this->getOutputFileSystem() : null;
 		$doc = new XmlDocument('2.1');
 
-		$doc->setFileSystem($inputFilesystem);
+		$doc->setFilesystem($inputFilesystem);
 		$doc->load($file);
 		
 		$compactDoc = XmlCompactDocument::createFromXmlAssessmentTestDocument($doc);
 		
 		$file = tempnam('/tmp', 'qsm');
-		$compactDoc->setFileSystem($outputFilesystem);
+		$compactDoc->setFilesystem($outputFilesystem);
 
 		$compactDoc->save($file);
 		
 		$compactDoc = new XmlCompactDocument('2.1.0');
-		$compactDoc->setFileSystem($outputFilesystem);
+		$compactDoc->setFilesystem($outputFilesystem);
 
 		$compactDoc->load($file);
 		$this->testLoad($compactDoc);
@@ -123,7 +123,7 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
 		$doc = new XmlDocument('2.1');
 
 		if ($filesystem === true) {
-		    $doc->setFileSystem($this->getFileSystem());
+		    $doc->setFilesystem($this->getFileSystem());
         }
 
 		$doc->load($file);
@@ -223,7 +223,7 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
         $doc = new XmlDocument('2.1');
 
         if ($filesystem === true) {
-            $doc->setFileSystem($this->getFileSystem());
+            $doc->setFilesystem($this->getFileSystem());
         }
 
 		$doc->load($file);
@@ -332,7 +332,7 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase {
 	        $doc = new XmlCompactDocument();
 
 	        if ($filesystem === true) {
-	            $doc->setFileSystem($this->getFileSystem());
+	            $doc->setFilesystem($this->getFileSystem());
             }
 
 	        $doc->load($src, true);

--- a/test/qtismtest/data/storage/xml/XmlDocumentTemplateLocationTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTemplateLocationTest.php
@@ -17,7 +17,7 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
         $doc = new XmlDocument();
 
         if ($filesystem === true) {
-            $doc->setFileSystem($this->getFileSystem());
+            $doc->setFilesystem($this->getFileSystem());
         }
 
         $doc->load($file, true);
@@ -59,7 +59,7 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
         $doc = new XmlDocument();
 
         if ($filesystem === true) {
-            $doc->setFileSystem($this->getFileSystem());
+            $doc->setFilesystem($this->getFileSystem());
         }
 
         $doc->load($file, true);
@@ -86,7 +86,7 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
         $doc = new XmlDocument();
 
         if ($filesystem === true) {
-           $doc->setFileSystem($this->getFileSystem());
+           $doc->setFilesystem($this->getFileSystem());
         }
 
         $doc->load($file, true);
@@ -113,7 +113,7 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
         $doc = new XmlDocument();
 
         if ($filesystem === true) {
-            $doc->setFileSystem($this->getFileSystem());
+            $doc->setFilesystem($this->getFileSystem());
         }
 
         $doc->load($file, true);

--- a/test/qtismtest/data/storage/xml/XmlDocumentTemplateLocationTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTemplateLocationTest.php
@@ -6,10 +6,22 @@ use qtism\data\storage\xml\XmlDocument;
 use qtism\data\storage\xml\XmlStorageException;
 
 class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
-	
-    public function testCorrectlyFormed() {
+
+    /**
+     * @param $file
+     * @param $filesystem
+     * @throws XmlStorageException
+     * @dataProvider correctlyFormedProvider
+     */
+    public function testCorrectlyFormed($file, $filesystem) {
         $doc = new XmlDocument();
-        $doc->load(self::samplesDir() . 'custom/items/template_location/template_location_item.xml', true);
+
+        if ($filesystem === false) {
+            $doc->load($file, true);
+        } else {
+            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        }
+
          
         $responseProcessings = $doc->getDocumentComponent()->getComponentsByClassName('responseProcessing');
         $this->assertEquals(1, count($responseProcessings));
@@ -21,6 +33,14 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
         $this->assertEquals(1, count($responseProcessings));
         $this->assertEquals('http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct', $responseProcessings[0]->getTemplate());
     }
+
+    public function correctlyFormedProvider()
+    {
+        return [
+            [self::samplesDir() . 'custom/items/template_location/template_location_item.xml', false],
+            ['custom/items/template_location/template_location_item.xml', true]
+        ];
+    }
     
     public function testNotLoaded() {
         $doc = new XmlDocument();
@@ -28,28 +48,86 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
         $this->setExpectedException('\\LogicException', 'Cannot resolve template location before loading any file.');
         $doc->resolveTemplateLocation();
     }
-    
-    public function testWrongTarget() {
+
+    /**
+     * @param $file
+     * @param $filesystem
+     * @throws XmlStorageException
+     * @dataProvider wrongTargetProvider
+     */
+    public function testWrongTarget($file, $filesystem) {
         $doc = new XmlDocument();
-        $doc->load(self::samplesDir() . 'custom/items/template_location/template_location_item_wrong_target.xml', true);
+
+        if ($filesystem === false) {
+            $doc->load($file, true);
+        } else {
+            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        }
         
         $this->setExpectedException('qtism\\data\\storage\\xml\\XmlStorageException');
         $doc->resolveTemplateLocation();
     }
-    
-    public function testInvalidTargetNoValidation() {
+
+    public function wrongTargetProvider()
+    {
+        return [
+            [self::samplesDir() . 'custom/items/template_location/template_location_item_wrong_target.xml', false],
+            ['custom/items/template_location/template_location_item_wrong_target.xml', true]
+        ];
+    }
+
+    /**
+     * @param $file
+     * @param $filesystem
+     * @throws XmlStorageException
+     * @dataProvider invalidTargetNoValidationProvider
+     */
+    public function testInvalidTargetNoValidation($file, $filesystem) {
         $doc = new XmlDocument();
-        $doc->load(self::samplesDir() . 'custom/items/template_location/template_location_item_invalid_target.xml', true);
+
+        if ($filesystem === false) {
+            $doc->load($file, true);
+        } else {
+            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        }
         
         $this->setExpectedException('qtism\\data\\storage\\xml\\XmlStorageException', "'responseProcessingZ' components are not supported in QTI version '2.1.0'.", XmlStorageException::VERSION);
         $doc->resolveTemplateLocation();
     }
-    
-    public function testInvalidTargetValidation() {
+
+    public function invalidTargetNoValidationProvider()
+    {
+        return [
+            [self::samplesDir() . 'custom/items/template_location/template_location_item_invalid_target.xml', false],
+            ['custom/items/template_location/template_location_item_invalid_target.xml', true]
+        ];
+    }
+
+    /**
+     * @param $file
+     * @param $filesystem
+     * @throws XmlStorageException
+     * @dataProvider invalidTargetValidationProvider
+     */
+    public function testInvalidTargetValidation($file, $filesystem) {
         $doc = new XmlDocument();
-        $doc->load(self::samplesDir() . 'custom/items/template_location/template_location_item_invalid_target.xml', true);
+
+        if ($filesystem === false) {
+            $doc->load($file, true);
+        } else {
+            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        }
+
         
         $this->setExpectedException('qtism\\data\\storage\\xml\\XmlStorageException', null, XmlStorageException::XSD_VALIDATION);
         $doc->resolveTemplateLocation(true);
+    }
+
+    public function invalidTargetValidationProvider()
+    {
+        return [
+            [self::samplesDir() . 'custom/items/template_location/template_location_item_invalid_target.xml', false],
+            ['custom/items/template_location/template_location_item_invalid_target.xml', true]
+        ];
     }
 }

--- a/test/qtismtest/data/storage/xml/XmlDocumentTemplateLocationTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTemplateLocationTest.php
@@ -16,11 +16,11 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
     public function testCorrectlyFormed($file, $filesystem) {
         $doc = new XmlDocument();
 
-        if ($filesystem === false) {
-            $doc->load($file, true);
-        } else {
-            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        if ($filesystem === true) {
+            $doc->setFileSystem($this->getFileSystem());
         }
+
+        $doc->load($file, true);
 
          
         $responseProcessings = $doc->getDocumentComponent()->getComponentsByClassName('responseProcessing');
@@ -58,11 +58,11 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
     public function testWrongTarget($file, $filesystem) {
         $doc = new XmlDocument();
 
-        if ($filesystem === false) {
-            $doc->load($file, true);
-        } else {
-            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        if ($filesystem === true) {
+            $doc->setFileSystem($this->getFileSystem());
         }
+
+        $doc->load($file, true);
         
         $this->setExpectedException('qtism\\data\\storage\\xml\\XmlStorageException');
         $doc->resolveTemplateLocation();
@@ -85,11 +85,11 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
     public function testInvalidTargetNoValidation($file, $filesystem) {
         $doc = new XmlDocument();
 
-        if ($filesystem === false) {
-            $doc->load($file, true);
-        } else {
-            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        if ($filesystem === true) {
+           $doc->setFileSystem($this->getFileSystem());
         }
+
+        $doc->load($file, true);
         
         $this->setExpectedException('qtism\\data\\storage\\xml\\XmlStorageException', "'responseProcessingZ' components are not supported in QTI version '2.1.0'.", XmlStorageException::VERSION);
         $doc->resolveTemplateLocation();
@@ -112,12 +112,11 @@ class XmlDocumentTemplateLocationTest extends QtiSmTestCase {
     public function testInvalidTargetValidation($file, $filesystem) {
         $doc = new XmlDocument();
 
-        if ($filesystem === false) {
-            $doc->load($file, true);
-        } else {
-            $doc->loadFromFileSystem($this->getFileSystem(), $file, true);
+        if ($filesystem === true) {
+            $doc->setFileSystem($this->getFileSystem());
         }
 
+        $doc->load($file, true);
         
         $this->setExpectedException('qtism\\data\\storage\\xml\\XmlStorageException', null, XmlStorageException::XSD_VALIDATION);
         $doc->resolveTemplateLocation(true);

--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -224,7 +224,7 @@ class XmlDocumentTest extends QtiSmTestCase {
         $doc->load(self::samplesDir() . 'invalid/noversion.xml');
     }
     
-    public function testLoadFromEmptyFile() {
+    public function testLoadFromNonExistingFile() {
         $doc = new XmlDocument('2.1');
         // This path does not resolve anything.
         $path = self::samplesDir() . 'invalid/unknown.xml';

--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -448,7 +448,8 @@ class XmlDocumentTest extends QtiSmTestCase {
     {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
-        $doc->loadFromFileSystem($fileSystem, 'ims/items/2_1/choice.xml');
+        $doc->setFileSystem($fileSystem);
+        $doc->load('ims/items/2_1/choice.xml');
 
         $this->assertInstanceOf(AssessmentItem::class, $doc->getDocumentComponent());
     }
@@ -457,7 +458,8 @@ class XmlDocumentTest extends QtiSmTestCase {
     {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
-        $doc->loadFromFileSystem($fileSystem, 'ims/items/2_1/choice.xml', true);
+        $doc->setFileSystem($fileSystem);
+        $doc->load('ims/items/2_1/choice.xml', true);
 
         $this->assertInstanceOf(AssessmentItem::class, $doc->getDocumentComponent());
     }
@@ -466,19 +468,21 @@ class XmlDocumentTest extends QtiSmTestCase {
     {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
+        $doc->setFileSystem($fileSystem);
 
         $this->setExpectedException(
             XmlStorageException::class,
             'The document could not be validated with XML Schema'
         );
 
-        $doc->loadFromFileSystem($fileSystem, 'invalid/xsdinvalid.xml', true);
+        $doc->load('invalid/xsdinvalid.xml', true);
     }
 
     public function testLoadFromFileSystemNotExistingFile()
     {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
+        $doc->setFileSystem($fileSystem);
         $path = 'invalid/unknown.xml';
 
         $this->setExpectedException(
@@ -486,12 +490,13 @@ class XmlDocumentTest extends QtiSmTestCase {
             "Cannot load QTI file at path '${path}'. It does not exist or is not readable."
         );
 
-        $doc->loadFromFileSystem($fileSystem, $path);
+        $doc->load($path);
     }
 
     public function testLoadFromFileSystemEmptyFile() {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
+        $doc->setFileSystem($fileSystem);
         $path = 'invalid/empty.xml';
 
         $this->setExpectedException(
@@ -499,6 +504,6 @@ class XmlDocumentTest extends QtiSmTestCase {
             'Cannot load QTI from an empty string.'
         );
 
-        $doc->loadFromFileSystem($fileSystem, $path);
+        $doc->load($path);
     }
 }

--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -278,7 +278,7 @@ class XmlDocumentTest extends QtiSmTestCase {
     public function testSaveWrongLocationFileSystem()
     {
         $doc = new XmlDocument('2.1.1');
-        $doc->setFileSystem($this->getOutputFileSystem());
+        $doc->setFilesystem($this->getOutputFileSystem());
         $doc->loadFromString('<assessmentItemRef identifier="Q01" href="./Q01.xml"/>');
 
         $expectedMsg = "An error occured while saving QTI-XML file";
@@ -453,7 +453,7 @@ class XmlDocumentTest extends QtiSmTestCase {
         $doc = new XmlDocument();
 
         if ($filesystem === true) {
-            $doc->setFileSystem($this->getFileSystem());
+            $doc->setFilesystem($this->getFileSystem());
         }
         
         $this->setExpectedException(
@@ -476,7 +476,7 @@ class XmlDocumentTest extends QtiSmTestCase {
     {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
-        $doc->setFileSystem($fileSystem);
+        $doc->setFilesystem($fileSystem);
         $doc->load('ims/items/2_1/choice.xml');
 
         $this->assertInstanceOf(AssessmentItem::class, $doc->getDocumentComponent());
@@ -486,7 +486,7 @@ class XmlDocumentTest extends QtiSmTestCase {
     {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
-        $doc->setFileSystem($fileSystem);
+        $doc->setFilesystem($fileSystem);
         $doc->load('ims/items/2_1/choice.xml', true);
 
         $this->assertInstanceOf(AssessmentItem::class, $doc->getDocumentComponent());
@@ -496,7 +496,7 @@ class XmlDocumentTest extends QtiSmTestCase {
     {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
-        $doc->setFileSystem($fileSystem);
+        $doc->setFilesystem($fileSystem);
 
         $this->setExpectedException(
             XmlStorageException::class,
@@ -510,7 +510,7 @@ class XmlDocumentTest extends QtiSmTestCase {
     {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
-        $doc->setFileSystem($fileSystem);
+        $doc->setFilesystem($fileSystem);
         $path = 'invalid/unknown.xml';
 
         $this->setExpectedException(
@@ -524,7 +524,7 @@ class XmlDocumentTest extends QtiSmTestCase {
     public function testLoadFromFileSystemEmptyFile() {
         $fileSystem = $this->getFileSystem();
         $doc = new XmlDocument();
-        $doc->setFileSystem($fileSystem);
+        $doc->setFilesystem($fileSystem);
         $path = 'invalid/empty.xml';
 
         $this->setExpectedException(
@@ -539,7 +539,7 @@ class XmlDocumentTest extends QtiSmTestCase {
     {
         $filesystem = $this->getFileSystem();
         $doc = new XmlDocument();
-        $doc->setFileSystem($filesystem);
+        $doc->setFilesystem($filesystem);
         $path = 'ims/items/2_1/choice.xml';
 
         $doc->load($path);
@@ -547,7 +547,7 @@ class XmlDocumentTest extends QtiSmTestCase {
         $strXml = $doc->saveToString();
         $outputFilesystem = $this->getOutputFileSystem();
 
-        $doc->setFileSystem($outputFilesystem);
+        $doc->setFilesystem($outputFilesystem);
         $doc->save('XmlDocumentTest/choice-test-save.xml');
 
         $this->assertSame($strXml, $outputFilesystem->read('XmlDocumentTest/choice-test-save.xml'));

--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace qtismtest\data\storage\xml;
 
+use qtism\data\AssessmentItem;
 use qtismtest\QtiSmTestCase;
 use qtism\data\content\TextRun;
 use qtism\data\storage\xml\XmlDocument;
@@ -441,5 +442,63 @@ class XmlDocumentTest extends QtiSmTestCase {
         );
         
         $doc->save('path.xml');
+    }
+
+    public function testLoadFromFileSystemNoValidation()
+    {
+        $fileSystem = $this->getFileSystem();
+        $doc = new XmlDocument();
+        $doc->loadFromFileSystem($fileSystem, 'ims/items/2_1/choice.xml');
+
+        $this->assertInstanceOf(AssessmentItem::class, $doc->getDocumentComponent());
+    }
+
+    public function testLoadFromFileSystemPositiveValidation()
+    {
+        $fileSystem = $this->getFileSystem();
+        $doc = new XmlDocument();
+        $doc->loadFromFileSystem($fileSystem, 'ims/items/2_1/choice.xml', true);
+
+        $this->assertInstanceOf(AssessmentItem::class, $doc->getDocumentComponent());
+    }
+
+    public function testLoadFromFileSystemNegativeValidation()
+    {
+        $fileSystem = $this->getFileSystem();
+        $doc = new XmlDocument();
+
+        $this->setExpectedException(
+            XmlStorageException::class,
+            'The document could not be validated with XML Schema'
+        );
+
+        $doc->loadFromFileSystem($fileSystem, 'invalid/xsdinvalid.xml', true);
+    }
+
+    public function testLoadFromFileSystemNotExistingFile()
+    {
+        $fileSystem = $this->getFileSystem();
+        $doc = new XmlDocument();
+        $path = 'invalid/unknown.xml';
+
+        $this->setExpectedException(
+            XmlStorageException::class,
+            "Cannot load QTI file at path '${path}'. It does not exist or is not readable."
+        );
+
+        $doc->loadFromFileSystem($fileSystem, $path);
+    }
+
+    public function testLoadFromFileSystemEmptyFile() {
+        $fileSystem = $this->getFileSystem();
+        $doc = new XmlDocument();
+        $path = 'invalid/empty.xml';
+
+        $this->setExpectedException(
+            XmlStorageException::class,
+            'Cannot load QTI from an empty string.'
+        );
+
+        $doc->loadFromFileSystem($fileSystem, $path);
     }
 }

--- a/test/qtismtest/data/storage/xml/XmlDocumentXIncludeTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentXIncludeTest.php
@@ -30,10 +30,16 @@ class XmlDocumentXIncludeTest extends QtiSmTestCase {
     
     /**
      * @depends testLoadAndSaveXIncludeNsInTag
+     * @dataProvider loadAndResolveXIncludeSameBaseProvider
      */
-    public function testLoadAndResolveXIncludeSameBase() {
+    public function testLoadAndResolveXIncludeSameBase($file, $filesystem) {
         $doc = new XmlDocument();
-        $doc->load(self::samplesDir() . 'custom/items/xinclude/xinclude_ns_in_tag.xml', true);
+
+        if ($filesystem === true) {
+            $doc->setFileSystem($this->getFileSystem());
+        }
+
+        $doc->load($file, true);
         
         // At this moment, includes are not resolved.
         $includes = $doc->getDocumentComponent()->getComponentsByClassName('include');
@@ -56,6 +62,14 @@ class XmlDocumentXIncludeTest extends QtiSmTestCase {
         // no content for xml:base because 'xinclude_ns_in_tag_content1.xml' is in the
         // same directory as the main xml file.
         $this->assertEquals('', $imgs[0]->getXmlBase());
+    }
+
+    public function loadAndResolveXIncludeSameBaseProvider()
+    {
+        return [
+            [self::samplesDir() . 'custom/items/xinclude/xinclude_ns_in_tag.xml', false],
+            ['custom/items/xinclude/xinclude_ns_in_tag.xml', true]
+        ];
     }
     
     /**

--- a/test/qtismtest/data/storage/xml/XmlDocumentXIncludeTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentXIncludeTest.php
@@ -36,7 +36,7 @@ class XmlDocumentXIncludeTest extends QtiSmTestCase {
         $doc = new XmlDocument();
 
         if ($filesystem === true) {
-            $doc->setFileSystem($this->getFileSystem());
+            $doc->setFilesystem($this->getFileSystem());
         }
 
         $doc->load($file, true);


### PR DESCRIPTION
This PR aims at providing filesystem abstraction via `League/Flysystem`. The usage is pretty simple and transparent. Before loading/save any file via the `XmlDocument` object, just inject a Filesystem implementation as in the example below:

```php
use qtism\data\storage\xml\XmlDocument;
use League\Flysystem\Adapter\Local;
use League\Flysystem\Filesystem;

$adapter = new Local('somewhere/only/we/know');
$doc = new XmlDocument();
$doc->setFilesystem(new Filesystem($adapter));

// Load file at 'somewhere/only/we/know/qti.xml'
$doc->load('qti.xml');
// ...
// save file at 'somewhere/only/we/know/qti-copy.xml'
$doc->save('qti-copy.xml');
```

The former usage whitout using `League/Filesystem` implementation is of course still valid as in the example below.


```php
use qtism\data\storage\xml\XmlDocument;

$doc = new XmlDocument();

// Load file at 'somewhere/only/we/know/qti.xml'
$doc->load('somewhere/only/we/know/qti.xml');
// ...
// save file at 'somewhere/only/we/know/qti-copy.xml'
$doc->save('somewhere/only/we/know/qti-copy.xml');
```