### PR TITLE
Feature/add session identifier result context

### DIFF
--- a/src/qtism/common/datatypes/Utils.php
+++ b/src/qtism/common/datatypes/Utils.php
@@ -17,6 +17,7 @@
  * Copyright (c) 2014 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @author Julien Sébire <julien@taotesting.com>
  * @license GPLv2
  */
 
@@ -25,9 +26,6 @@ namespace qtism\common\datatypes;
 /**
  * A class focusing on providing utility methods
  * for QTI Datatypes handling.
- *
- * @author Jérôme Bogaerts <jerome@taotesting.com>
- *
  */
 class Utils
 {
@@ -35,20 +33,27 @@ class Utils
      * Whether a given $integer value is a QTI compliant
      * integer in the [-2147483647, 2147483647] range.
      *
-     * @param mixed $integer
+     * @param mixed $integer the value to test
      * @return boolean
      */
-    public static function isQtiInteger($integer)
+    public static function isQtiInteger($integer): bool
     {
         // QTI integers are twos-complement 32-bits integers.
-        if (is_int($integer) === false) {
-            return false;
-        } elseif ($integer > 2147483647) {
-            return false;
-        } elseif ($integer < -2147483647) {
-            return false;
-        } else {
-            return true;
-        }
+        return is_int($integer)
+            && $integer <= 2147483647
+            && $integer >= -2147483647;
+    }
+
+    /**
+     * Normalizes a string in the sense of xs:simpleType normalizedString with
+     * whiteSpace constraint as replace.
+     * See http://www.w3.org/TR/xmlschema-2/#normalizedString
+     *
+     * @param string $string the string to normalize
+     * @return string
+     */
+    public static function normalizeString(string $string): string
+    {
+        return str_replace(["\n", "\r", "\t"], ' ', $string);
     }
 }

--- a/src/qtism/data/results/Context.php
+++ b/src/qtism/data/results/Context.php
@@ -17,21 +17,20 @@
  * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Moyon Camille, <camille@taotesting.com>
+ * @author Julien Sébire, <julien@taotesting.com>
  * @license GPLv2
  */
 
 namespace qtism\data\results;
 
 use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiUri;
+use qtism\common\datatypes\Utils;
 use qtism\data\QtiComponent;
 use qtism\data\QtiComponentCollection;
 
 /**
- * Class Context
- *
  * This is the context for the 'assessmentResult'. It provides the corresponding set of identifiers.
- *
- * @package qtism\data\results
  */
 class Context extends QtiComponent
 {
@@ -39,6 +38,7 @@ class Context extends QtiComponent
      * A unique identifier for the test candidate. The attribute is defined by the IMS Learning Information Services specification [LIS, 13].
      *
      * Multiplicity [0,1]
+     *
      * @var QtiIdentifier
      */
     protected $sourcedId;
@@ -49,6 +49,7 @@ class Context extends QtiComponent
      * to the session which should be added to the context if the result is modified and exported for transport again.
      *
      * Multiplicity [0,*]
+     *
      * @var SessionIdentifierCollection
      */
     protected $sessionIdentifiers;
@@ -61,9 +62,14 @@ class Context extends QtiComponent
      * @param QtiIdentifier|null $sourcedId
      * @param SessionIdentifierCollection|null $sessionIdentifiers
      */
-    public function __construct(QtiIdentifier $sourcedId=null, SessionIdentifierCollection $sessionIdentifiers=null)
-    {
+    public function __construct(
+        QtiIdentifier $sourcedId = null,
+        SessionIdentifierCollection $sessionIdentifiers = null
+    ) {
         $this->setSourcedId($sourcedId);
+        if ($sessionIdentifiers === null) {
+            $sessionIdentifiers = new SessionIdentifierCollection();
+        }
         $this->setSessionIdentifiers($sessionIdentifiers);
     }
 
@@ -82,7 +88,7 @@ class Context extends QtiComponent
      *
      * @return QtiComponentCollection A collection of QtiComponent objects.
      */
-    public function getComponents()
+    public function getComponents(): QtiComponentCollection
     {
         if ($this->hasSessionIdentifiers()) {
             $components = $this->getSessionIdentifiers()->getArrayCopy();
@@ -95,7 +101,7 @@ class Context extends QtiComponent
     /**
      * Get the sourcedId of the context
      *
-     * @return QtiIdentifier
+     * @return QtiIdentifier|null
      */
     public function getSourcedId()
     {
@@ -108,7 +114,7 @@ class Context extends QtiComponent
      * @param QtiIdentifier $sourcedId
      * @return $this
      */
-    public function setSourcedId(QtiIdentifier $sourcedId=null)
+    public function setSourcedId(QtiIdentifier $sourcedId = null): self
     {
         $this->sourcedId = $sourcedId;
         return $this;
@@ -119,9 +125,9 @@ class Context extends QtiComponent
      *
      * @return bool
      */
-    public function hasSourcedId()
+    public function hasSourcedId(): bool
     {
-        return !is_null($this->sourcedId);
+        return $this->sourcedId !== null;
     }
 
     /**
@@ -129,20 +135,41 @@ class Context extends QtiComponent
      *
      * @return SessionIdentifierCollection
      */
-    public function getSessionIdentifiers()
+    public function getSessionIdentifiers(): SessionIdentifierCollection
     {
         return $this->sessionIdentifiers;
     }
-    
+
     /**
      * Set the Session identifiers
      *
-     * @param $sessionIdentifiers
+     * @param SessionIdentifierCollection $sessionIdentifiers
      * @return $this
      */
-    public function setSessionIdentifiers(SessionIdentifierCollection $sessionIdentifiers=null)
+    public function setSessionIdentifiers(SessionIdentifierCollection $sessionIdentifiers): self
     {
         $this->sessionIdentifiers = $sessionIdentifiers;
+        return $this;
+    }
+
+    /**
+     * Adds a Session identifier given its parameters.
+     *
+     * @param string $sourceId
+     * @param string $identifier
+     * @return $this
+     */
+    public function addSessionIdentifier(string $sourceId, string $identifier): self
+    {
+        $identifier = Utils::normalizeString($identifier);
+
+        $this->sessionIdentifiers->attach(
+            new SessionIdentifier(
+                new QtiUri($sourceId),
+                new QtiIdentifier($identifier)
+            )
+        );
+
         return $this;
     }
 
@@ -151,9 +178,8 @@ class Context extends QtiComponent
      *
      * @return bool
      */
-    public function hasSessionIdentifiers()
+    public function hasSessionIdentifiers(): bool
     {
-        return !is_null($this->sessionIdentifiers);
+        return (bool)$this->sessionIdentifiers->count();
     }
-
 }

--- a/test/qtismtest/common/datatypes/UtilsTest.php
+++ b/test/qtismtest/common/datatypes/UtilsTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Julien Sébire <julien@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\common\datatypes;
+
+use PHPUnit\Framework\TestCase;
+use qtism\common\datatypes\Utils;
+
+/**
+ * Tests for UtilsTest Class.
+ */
+class UtilsTest extends TestCase
+{
+    /**
+     * @dataProvider integersToTest
+     * @param mixed $integer integer to test
+     * @param boolean test result
+     */
+    public function testIsQtiInteger($integer, $expected)
+    {
+        $this->assertEquals($expected, Utils::isQtiInteger($integer));
+    }
+    
+    public function integersToTest(): array
+    {
+        return [
+            ['string', false],
+            [2147483648, false],
+            [-2147483648, false],
+            [2147483647, true],
+            [-2147483647, true],
+            [2147483646, true],
+            [-2147483646, true],
+        ];
+    }
+
+    public function testNormalizeString()
+    {
+        $string = "string with\n\rtabulations\tand\r\nnew lines\nto be replaced\rby spaces";
+        $normalizedString = 'string with  tabulations and  new lines to be replaced by spaces';
+
+        $this->assertEquals($normalizedString, Utils::normalizeString($string));
+    }
+}

--- a/test/qtismtest/common/datatypes/UtilsTest.php
+++ b/test/qtismtest/common/datatypes/UtilsTest.php
@@ -39,7 +39,7 @@ class UtilsTest extends TestCase
     {
         $this->assertEquals($expected, Utils::isQtiInteger($integer));
     }
-    
+
     public function integersToTest(): array
     {
         return [
@@ -53,11 +53,31 @@ class UtilsTest extends TestCase
         ];
     }
 
-    public function testNormalizeString()
+    /**
+     * @dataProvider stringsToNormalize
+     */
+    public function testNormalizeString($string, $normalizedString)
     {
-        $string = "string with\n\rtabulations\tand\r\nnew lines\nto be replaced\rby spaces";
-        $normalizedString = 'string with  tabulations and  new lines to be replaced by spaces';
-
         $this->assertEquals($normalizedString, Utils::normalizeString($string));
+    }
+
+    public function stringsToNormalize()
+    {
+        return [
+            [
+                "string with\n\rtabulations\tand\r\nnew lines\nto be replaced\rby spaces",
+                'string with  tabulations and  new lines to be replaced by spaces',
+            ],
+            // Multi-byte 
+            [
+                "L'élève \"\\/\"\tse lève\rénervé\n.",
+                'L\'élève "\\/" se lève énervé .',
+            ],
+            // Multi-byte not in utf-8
+            [
+                iconv('utf-8', 'ISO-8859-1', "L'élève \"\\/\"\tse lève\rénervé\n."),
+                iconv('utf-8', 'ISO-8859-1', 'L\'élève "\\/" se lève énervé .'),
+            ],
+        ];
     }
 }

--- a/test/qtismtest/data/results/ContextTest.php
+++ b/test/qtismtest/data/results/ContextTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Julien Sébire, <julien@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\results;
+
+use PHPUnit\Framework\TestCase;
+use qtism\data\results\Context;
+use qtism\data\results\SessionIdentifier;
+
+class ContextTest extends TestCase
+{
+    public function testAddSessionIdentifier()
+    {
+        $sourceId = 'a source id';
+        $identifier = "string with\n\rtabulations\tand\r\nnew lines\nto be replaced\rby spaces";
+        $normalizedIdentifier = 'string with  tabulations and  new lines to be replaced by spaces';
+        
+        $subject = new Context();
+        $this->assertFalse($subject->hasSessionIdentifiers());
+        
+        $subject->addSessionIdentifier($sourceId, $identifier);
+        $this->assertTrue($subject->hasSessionIdentifiers());
+        
+        $sessionIdentifierCollection = $subject->getSessionIdentifiers();
+        $this->assertCount(1, $sessionIdentifierCollection);
+        
+        $sessionIdentifier = $sessionIdentifierCollection->current();
+        $this->assertInstanceOf(SessionIdentifier::class, $sessionIdentifier);
+        /** @var SessionIdentifier $sessionIdentifier */
+        
+        $this->assertEquals($sourceId, $sessionIdentifier->getSourceID()->getValue());
+        $this->assertEquals($normalizedIdentifier, $sessionIdentifier->getIdentifier()->getValue());
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/ContextMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ContextMarshallerTest.php
@@ -22,6 +22,7 @@
 
 namespace qtismtest\data\storage\xml\marshalling;
 
+use DOMElement;
 use qtism\data\results\Context;
 use qtism\data\results\SessionIdentifierCollection;
 use qtism\data\results\SessionIdentifier;
@@ -63,10 +64,8 @@ class ContextMarshallerTest extends QtiSmTestCase
         $this->assertInstanceOf(Context::class, $context);
 
         $this->assertFalse($context->hasSourcedId());
-        $this->assertNull($context->getSourcedId());
 
         $this->assertFalse($context->hasSessionIdentifiers());
-        $this->assertNull($context->getSessionIdentifiers());
     }
 
     public function testMarshall()
@@ -84,7 +83,7 @@ class ContextMarshallerTest extends QtiSmTestCase
         /** @var DOMElement $element */
         $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
 
-        $this->assertInstanceOf(\DOMElement::class, $element);
+        $this->assertInstanceOf(DOMElement::class, $element);
 
         $this->assertEquals($component->getQtiClassName(), $element->nodeName);
         $this->assertEquals($sourcedId, $element->getAttribute('sourcedId'));
@@ -103,7 +102,7 @@ class ContextMarshallerTest extends QtiSmTestCase
         /** @var DOMElement $element */
         $element = $this->getMarshallerFactory()->createMarshaller($component)->marshall($component);
 
-        $this->assertInstanceOf(\DOMElement::class, $element);
+        $this->assertInstanceOf(DOMElement::class, $element);
 
         $this->assertEquals($component->getQtiClassName(), $element->nodeName);
         $this->assertFalse($element->hasAttributes());


### PR DESCRIPTION
This PR allows adding a session identifier to an existing context of AssessmentResult.

It replaces PR https://github.com/oat-sa/qti-sdk/pull/156, going in wrong direction.

Related ticket: https://oat-sa.atlassian.net/browse/NEX-641