### PR TITLE
Added unique sourceId assertion.

### DIFF
--- a/src/qtism/data/results/Context.php
+++ b/src/qtism/data/results/Context.php
@@ -158,11 +158,16 @@ class Context extends QtiComponent
      * @param string $sourceId
      * @param string $identifier
      * @return $this
+     * @throws DuplicateSourceIdException when an already existing sourceId is given.
      */
     public function addSessionIdentifier(string $sourceId, string $identifier): self
     {
         $identifier = Utils::normalizeString($identifier);
 
+        if ($this->hasSessionIdentifierWithSourceId($sourceId)) {
+            throw new DuplicateSourceIdException('SourceId "' . $sourceId . '" already exist in this AssessmentResult context.');
+        }
+        
         $this->sessionIdentifiers->attach(
             new SessionIdentifier(
                 new QtiUri($sourceId),
@@ -181,5 +186,26 @@ class Context extends QtiComponent
     public function hasSessionIdentifiers(): bool
     {
         return (bool)$this->sessionIdentifiers->count();
+    }
+
+    /**
+     * Check if the context has a session identifier with the given sourceId.
+     *
+     * @param $sourceId
+     * @return bool
+     */
+    private function hasSessionIdentifierWithSourceId($sourceId): bool
+    {
+        if (!$this->hasSessionIdentifiers()) {
+            return false;
+        }
+
+        foreach ($this->sessionIdentifiers as $sessionIdentifier) {
+            if ($sessionIdentifier->getSourceID()->getValue() === $sourceId) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/qtism/data/results/Context.php
+++ b/src/qtism/data/results/Context.php
@@ -196,10 +196,6 @@ class Context extends QtiComponent
      */
     private function hasSessionIdentifierWithSourceId($sourceId): bool
     {
-        if (!$this->hasSessionIdentifiers()) {
-            return false;
-        }
-
         foreach ($this->sessionIdentifiers as $sessionIdentifier) {
             if ($sessionIdentifier->getSourceID()->getValue() === $sourceId) {
                 return true;

--- a/src/qtism/data/results/DuplicateSourceIdException.php
+++ b/src/qtism/data/results/DuplicateSourceIdException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Julien Sébire, <julien@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use \Exception;
+
+class DuplicateSourceIdException extends Exception
+{
+}

--- a/test/qtismtest/data/results/ContextTest.php
+++ b/test/qtismtest/data/results/ContextTest.php
@@ -24,6 +24,7 @@ namespace qtismtest\data\results;
 
 use PHPUnit\Framework\TestCase;
 use qtism\data\results\Context;
+use qtism\data\results\DuplicateSourceIdException;
 use qtism\data\results\SessionIdentifier;
 
 class ContextTest extends TestCase
@@ -33,21 +34,38 @@ class ContextTest extends TestCase
         $sourceId = 'a source id';
         $identifier = "string with\n\rtabulations\tand\r\nnew lines\nto be replaced\rby spaces";
         $normalizedIdentifier = 'string with  tabulations and  new lines to be replaced by spaces';
-        
+
         $subject = new Context();
         $this->assertFalse($subject->hasSessionIdentifiers());
-        
+
         $subject->addSessionIdentifier($sourceId, $identifier);
         $this->assertTrue($subject->hasSessionIdentifiers());
-        
+
         $sessionIdentifierCollection = $subject->getSessionIdentifiers();
         $this->assertCount(1, $sessionIdentifierCollection);
-        
+
         $sessionIdentifier = $sessionIdentifierCollection->current();
         $this->assertInstanceOf(SessionIdentifier::class, $sessionIdentifier);
         /** @var SessionIdentifier $sessionIdentifier */
-        
+
         $this->assertEquals($sourceId, $sessionIdentifier->getSourceID()->getValue());
         $this->assertEquals($normalizedIdentifier, $sessionIdentifier->getIdentifier()->getValue());
+    }
+
+    public function testAddSessionIdentifierWithDuplicateSourceIdThrowsException()
+    {
+        $sourceId = 'a source id';
+        $identifier1 = 'id1';
+        $identifier2 = 'id2';
+
+        $subject = new Context();
+        $this->assertFalse($subject->hasSessionIdentifiers());
+
+        $subject->addSessionIdentifier($sourceId, $identifier1);
+        $this->assertTrue($subject->hasSessionIdentifiers());
+
+        $this->expectException(DuplicateSourceIdException::class);
+        $this->expectExceptionMessage('SourceId "' . $sourceId . '" already exist in this AssessmentResult context.');
+        $subject->addSessionIdentifier($sourceId, $identifier2);
     }
 }

--- a/test/qtismtest/data/results/ContextTest.php
+++ b/test/qtismtest/data/results/ContextTest.php
@@ -68,4 +68,20 @@ class ContextTest extends TestCase
         $this->expectExceptionMessage('SourceId "' . $sourceId . '" already exist in this AssessmentResult context.');
         $subject->addSessionIdentifier($sourceId, $identifier2);
     }
+
+    public function testAddSessionIdentifierWithDuplicateIdentifierAdds()
+    {
+        $sourceId1 = 'sourceId1';
+        $sourceId2 = 'sourceId2';
+        $identifier = 'identifier';
+
+        $subject = new Context();
+        $this->assertFalse($subject->hasSessionIdentifiers());
+
+        $subject->addSessionIdentifier($sourceId1, $identifier);
+        $this->assertTrue($subject->hasSessionIdentifiers());
+
+        $subject->addSessionIdentifier($sourceId2, $identifier);
+        $this->assertCount(2, $subject->getSessionIdentifiers());
+    }
 }


### PR DESCRIPTION
This PR is a follow-up to the https://github.com/oat-sa/qti-sdk/pull/157, adding a check for `sourceId` unicity.
If asked to add a new session identifier with an already existing `sourceId`, a `DuplicateSourceIdException` is thrown.
