### PR TITLE
Merging to master for release 12.2.0

### DIFF
--- a/src/qtism/data/QtiComponentCollection.php
+++ b/src/qtism/data/QtiComponentCollection.php
@@ -23,8 +23,8 @@
 namespace qtism\data;
 
 use qtism\common\collections\AbstractCollection;
-use \InvalidArgumentException;
-use \RuntimeException;
+use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * A collection that aims at storing QtiComponent objects. The QtiComponentCollection
@@ -37,10 +37,12 @@ use \RuntimeException;
 class QtiComponentCollection extends AbstractCollection
 {
     /**
-	 * Check if $value is a QtiComponent object.
-	 *
-	 * @throws \InvalidArgumentException If $value is not a QtiComponent object.
-	 */
+     * Check if $value is a QtiComponent object.
+     *
+     * @param mixed $value The value of which we want to test the type.
+     * 
+     * @throws InvalidArgumentException If $value is not a QtiComponent object.
+     */
     protected function checkType($value)
     {
         if (!$value instanceof QtiComponent) {
@@ -50,7 +52,8 @@ class QtiComponentCollection extends AbstractCollection
     }
 
     /**
-     * @see \qtism\common\collections\AbstractCollection::offsetSet()
+     * @inheritDoc
+     * @see AbstractCollection::offsetSet()
      */
     public function offsetSet($offset, $value)
     {
@@ -63,7 +66,8 @@ class QtiComponentCollection extends AbstractCollection
     }
 
     /**
-     * @see \qtism\common\collections\AbstractCollection::offsetUnset()
+     * @inheritDoc
+     * @see AbstractCollection::offsetUnset()
      */
     public function offsetUnset($offset)
     {
@@ -79,20 +83,19 @@ class QtiComponentCollection extends AbstractCollection
      * Whether the collection contains exclusively QtiComponent objects having a given $className.
      * 
      * @param string $className A QTI class name.
-     * @param boolean $recursive Wether to check children QtiComponent objects.
-     * @return boolean
+     * @param bool $recursive Whether to check children QtiComponent objects.
+     * @return bool
      */
-    public function exclusivelyContainsComponentsWithClassName($className, $recursive = true)
+    public function exclusivelyContainsComponentsWithClassName($className, $recursive = true): bool
     {
         $data = $this->getDataPlaceHolder();
         foreach ($data as $component) {
             if ($component->getQtiClassName() !== $className) {
-                
                 return false;
-            } else if ($recursive === true) {
+            } 
+            if ($recursive === true) {
                 foreach ($component->getIterator() as $subComponent) {
                     if ($subComponent->getQtiClassName() !== $className) {
-                        
                         return false;
                     }
                 }

--- a/src/qtism/data/results/Context.php
+++ b/src/qtism/data/results/Context.php
@@ -158,11 +158,16 @@ class Context extends QtiComponent
      * @param string $sourceId
      * @param string $identifier
      * @return $this
+     * @throws DuplicateSourceIdException when an already existing sourceId is given.
      */
     public function addSessionIdentifier(string $sourceId, string $identifier): self
     {
         $identifier = Utils::normalizeString($identifier);
 
+        if ($this->hasSessionIdentifierWithSourceId($sourceId)) {
+            throw new DuplicateSourceIdException('SourceId "' . $sourceId . '" already exist in this AssessmentResult context.');
+        }
+        
         $this->sessionIdentifiers->attach(
             new SessionIdentifier(
                 new QtiUri($sourceId),
@@ -181,5 +186,22 @@ class Context extends QtiComponent
     public function hasSessionIdentifiers(): bool
     {
         return (bool)$this->sessionIdentifiers->count();
+    }
+
+    /**
+     * Check if the context has a session identifier with the given sourceId.
+     *
+     * @param $sourceId
+     * @return bool
+     */
+    private function hasSessionIdentifierWithSourceId($sourceId): bool
+    {
+        foreach ($this->sessionIdentifiers as $sessionIdentifier) {
+            if ($sessionIdentifier->getSourceID()->getValue() === $sourceId) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/qtism/data/results/Context.php
+++ b/src/qtism/data/results/Context.php
@@ -78,7 +78,7 @@ class Context extends QtiComponent
      *
      * @return string A QTI class name.
      */
-    public function getQtiClassName()
+    public function getQtiClassName(): string
     {
         return 'context';
     }
@@ -165,9 +165,11 @@ class Context extends QtiComponent
         $identifier = Utils::normalizeString($identifier);
 
         if ($this->hasSessionIdentifierWithSourceId($sourceId)) {
-            throw new DuplicateSourceIdException('SourceId "' . $sourceId . '" already exist in this AssessmentResult context.');
+            throw new DuplicateSourceIdException(
+                sprintf('SourceId "%s" already exist in this AssessmentResult context.', $sourceId)
+            );
         }
-        
+
         $this->sessionIdentifiers->attach(
             new SessionIdentifier(
                 new QtiUri($sourceId),

--- a/src/qtism/data/results/DuplicateSourceIdException.php
+++ b/src/qtism/data/results/DuplicateSourceIdException.php
@@ -22,7 +22,7 @@
 
 namespace qtism\data\results;
 
-use \Exception;
+use Exception;
 
 class DuplicateSourceIdException extends Exception
 {

--- a/src/qtism/data/results/DuplicateSourceIdException.php
+++ b/src/qtism/data/results/DuplicateSourceIdException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Julien Sébire, <julien@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\results;
+
+use \Exception;
+
+class DuplicateSourceIdException extends Exception
+{
+}

--- a/src/qtism/data/results/SessionIdentifierCollection.php
+++ b/src/qtism/data/results/SessionIdentifierCollection.php
@@ -22,19 +22,22 @@
 
 namespace qtism\data\results;
 
+use InvalidArgumentException;
 use qtism\data\QtiComponentCollection;
 
 class SessionIdentifierCollection extends QtiComponentCollection
 {
     /**
      * Check if a given $value is an instance of SessionIdentifier.
+     * 
+     * @param mixed $value The value of which we want to test the type.
      *
-     * @throws \InvalidArgumentException If the given $value is not an instance of SessionIdentifier.
+     * @throws InvalidArgumentException If the given $value is not an instance of SessionIdentifier.
      */
     protected function checkType($value)
     {
         if (!$value instanceof SessionIdentifier) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 "SessionIdentifierCollection only accepts to store SessionIdentifier objects, '%s' given.",
                 is_object($value) ? get_class($value) : gettype($value)
             ));

--- a/test/qtismtest/data/results/ContextTest.php
+++ b/test/qtismtest/data/results/ContextTest.php
@@ -65,7 +65,7 @@ class ContextTest extends TestCase
         $this->assertTrue($subject->hasSessionIdentifiers());
 
         $this->expectException(DuplicateSourceIdException::class);
-        $this->expectExceptionMessage('SourceId "' . $sourceId . '" already exist in this AssessmentResult context.');
+        $this->expectExceptionMessage(sprintf('SourceId "%s" already exist in this AssessmentResult context.', $sourceId));
         $subject->addSessionIdentifier($sourceId, $identifier2);
     }
 

--- a/test/qtismtest/data/results/ContextTest.php
+++ b/test/qtismtest/data/results/ContextTest.php
@@ -24,6 +24,7 @@ namespace qtismtest\data\results;
 
 use PHPUnit\Framework\TestCase;
 use qtism\data\results\Context;
+use qtism\data\results\DuplicateSourceIdException;
 use qtism\data\results\SessionIdentifier;
 
 class ContextTest extends TestCase
@@ -33,21 +34,54 @@ class ContextTest extends TestCase
         $sourceId = 'a source id';
         $identifier = "string with\n\rtabulations\tand\r\nnew lines\nto be replaced\rby spaces";
         $normalizedIdentifier = 'string with  tabulations and  new lines to be replaced by spaces';
-        
+
         $subject = new Context();
         $this->assertFalse($subject->hasSessionIdentifiers());
-        
+
         $subject->addSessionIdentifier($sourceId, $identifier);
         $this->assertTrue($subject->hasSessionIdentifiers());
-        
+
         $sessionIdentifierCollection = $subject->getSessionIdentifiers();
         $this->assertCount(1, $sessionIdentifierCollection);
-        
+
         $sessionIdentifier = $sessionIdentifierCollection->current();
         $this->assertInstanceOf(SessionIdentifier::class, $sessionIdentifier);
         /** @var SessionIdentifier $sessionIdentifier */
-        
+
         $this->assertEquals($sourceId, $sessionIdentifier->getSourceID()->getValue());
         $this->assertEquals($normalizedIdentifier, $sessionIdentifier->getIdentifier()->getValue());
+    }
+
+    public function testAddSessionIdentifierWithDuplicateSourceIdThrowsException()
+    {
+        $sourceId = 'a source id';
+        $identifier1 = 'id1';
+        $identifier2 = 'id2';
+
+        $subject = new Context();
+        $this->assertFalse($subject->hasSessionIdentifiers());
+
+        $subject->addSessionIdentifier($sourceId, $identifier1);
+        $this->assertTrue($subject->hasSessionIdentifiers());
+
+        $this->expectException(DuplicateSourceIdException::class);
+        $this->expectExceptionMessage('SourceId "' . $sourceId . '" already exist in this AssessmentResult context.');
+        $subject->addSessionIdentifier($sourceId, $identifier2);
+    }
+
+    public function testAddSessionIdentifierWithDuplicateIdentifierAdds()
+    {
+        $sourceId1 = 'sourceId1';
+        $sourceId2 = 'sourceId2';
+        $identifier = 'identifier';
+
+        $subject = new Context();
+        $this->assertFalse($subject->hasSessionIdentifiers());
+
+        $subject->addSessionIdentifier($sourceId1, $identifier);
+        $this->assertTrue($subject->hasSessionIdentifiers());
+
+        $subject->addSessionIdentifier($sourceId2, $identifier);
+        $this->assertCount(2, $subject->getSessionIdentifiers());
     }
 }


### PR DESCRIPTION
This PR allows adding one or more session identifier(s) built from two parameters:
- `sourceId`: a unique URI identifying the application which is adding the sessionIdentifier.
- `identifier`: a normalized string in the sense of https://www.w3.org/TR/xmlschema-2/#normalizedString, with a constraint of `whiteSpace` as `replace` (see https://www.w3.org/TR/xmlschema-2/#rf-whiteSpace for more details).

The unicity of the `sourceId` parameter is checked and a `DuplicateSourceIdException` is thrown when asked to add a new session identifier with an already existing `sourceId`.

A utility to normalize strings has been added in `qtism\common\datatypes\Utils::normalizeString` (tested with multi-bytes string, utf-8 and non-utf-8).