### PR TITLE
Added php 7.4 to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
   
 before_script:
   - composer self-update && composer install --no-interaction

--- a/src/qtism/data/content/interactions/GraphicOrderInteraction.php
+++ b/src/qtism/data/content/interactions/GraphicOrderInteraction.php
@@ -232,7 +232,7 @@ class GraphicOrderInteraction extends GraphicInteraction
         return new ResponseValidityConstraint(
             $this->getResponseIdentifier(),
             ($this->hasMinChoices() === true) ? $this->getMinChoices() : count($this->getHotspotChoices()),
-            ($this->hasMinChoices() === false) ? 0 : ($this->hasMaxChoices() === true) ? $this->getMaxChoices() : 0
+            $this->hasMinChoices() && $this->hasMaxChoices() ? $this->getMaxChoices() : 0
         );
     }
 

--- a/src/qtism/data/content/interactions/OrderInteraction.php
+++ b/src/qtism/data/content/interactions/OrderInteraction.php
@@ -22,9 +22,9 @@
 
 namespace qtism\data\content\interactions;
 
+use InvalidArgumentException;
 use qtism\data\QtiComponentCollection;
 use qtism\data\state\ResponseValidityConstraint;
-use \InvalidArgumentException;
 
 /**
  * From IMS QTI:
@@ -195,7 +195,6 @@ class OrderInteraction extends BlockInteraction
     public function setMinChoices($minChoices)
     {
         if (is_int($minChoices) === true && ($minChoices > 0 || $minChoices === -1)) {
-
             if ($minChoices > count($this->getSimpleChoices())) {
                 $msg = "The value of 'minChoices' cannot exceed the number of available choices.";
                 throw new InvalidArgumentException($msg);
@@ -237,7 +236,6 @@ class OrderInteraction extends BlockInteraction
     public function setMaxChoices($maxChoices)
     {
         if (is_int($maxChoices) === true && $maxChoices > 0 || $maxChoices === -1) {
-
             if ($this->hasMinChoices() === true && $maxChoices > count($this->getSimpleChoices())) {
                 $msg = "The 'maxChoices' argument cannot exceed the number of available choices.";
                 throw new InvalidArgumentException($msg);
@@ -295,7 +293,7 @@ class OrderInteraction extends BlockInteraction
     {
         return $this->orientation;
     }
-    
+
     /**
      * @see \qtism\data\content\interactions\Interaction::getResponseValidityConstraint()
      */
@@ -304,7 +302,7 @@ class OrderInteraction extends BlockInteraction
         return new ResponseValidityConstraint(
             $this->getResponseIdentifier(),
             ($this->hasMinChoices() === true) ? $this->getMinChoices() : count($this->getSimpleChoices()),
-            ($this->hasMinChoices() === false) ? 0 : ($this->hasMaxChoices() === true) ? $this->getMaxChoices() : 0
+            $this->hasMinChoices() && $this->hasMaxChoices() ? $this->getMaxChoices() : 0
         );
     }
 

--- a/src/qtism/data/storage/xml/marshalling/Marshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/Marshaller.php
@@ -279,7 +279,7 @@ abstract class Marshaller
                     if ($component instanceof QtiComponent && ($this->getExpectedQtiClassName() === '' || ($component->getQtiClassName() == $this->getExpectedQtiClassName()))) {
                         return $this->marshall($component);
                     } else {
-                        $componentName = ($component instanceof QtiComponent) ? $component->getQtiClassName() : (is_object($component)) ? ($component instanceof DOMElement) ? $component->localName : get_class($component) : $component;
+                        $componentName = $this->getComponentName($component);
                         throw new RuntimeException("No marshaller implementation found while marshalling component '${componentName}'.");
                     }
                 } else {
@@ -287,7 +287,7 @@ abstract class Marshaller
                     if ($element instanceof DOMElement && ($this->getExpectedQtiClassName() === '' || ($element->localName == $this->getExpectedQtiClassName()))) {
                         return call_user_func_array(array($this, 'unmarshall'), $args);
                     } else {
-                        $nodeName = ($element instanceof DOMElement) ? $element->localName : (is_object($element) ? get_class($element) : $element);
+                        $nodeName = $this->getElementName($element);
                         throw new RuntimeException("No Marshaller implementation found while unmarshalling element '${nodeName}'.");
                     }
                 }
@@ -581,4 +581,32 @@ abstract class Marshaller
      * @return string A QTI class name or an empty string.
      */
     abstract public function getExpectedQtiClassName();
+
+    /**
+     * @param QtiComponent|string $component
+     * @return string
+     */
+    private function getComponentName($component)
+    {
+        if ($component instanceof QtiComponent) {
+            return $component->getQtiClassName();
+        }
+        return $this->getElementName($component);
+    }
+
+    /**
+     * @param DOMElement|string $element
+     * @return string
+     */
+    private function getElementName($element)
+    {
+        if ($element instanceof DOMElement) {
+            return $element->localName;
+        }
+        if (is_object($element)) {
+            return get_class($element);
+        }
+
+        return $element;
+    }
 }

--- a/src/qtism/runtime/pci/json/Marshaller.php
+++ b/src/qtism/runtime/pci/json/Marshaller.php
@@ -136,7 +136,7 @@ class Marshaller
 
             foreach ($unit as $u) {
                 $data = $this->marshallUnit($u);
-                $json['list'][$strBaseType][] = $data['base'][$strBaseType];
+                $json['list'][$strBaseType][] = $data['base'][$strBaseType] ?? null;
             }
         } elseif ($unit instanceof RecordContainer) {
             $json = array();


### PR DESCRIPTION
PHP 7.4 has been released one month and a half ago and we had a couple breaking tests:
- Code in the form of `a ? b : c ? d : e` without proper parentheses is deprecated and will break in the next version of PHP
- accessing `null` as an array does not return `null` any more, `?? null` was added in json marshaller.