### PR TITLE
Added version check for externalScored management.

### DIFF
--- a/src/qtism/data/state/ExternalScored.php
+++ b/src/qtism/data/state/ExternalScored.php
@@ -51,7 +51,7 @@ class ExternalScored implements Enumeration
      *
      * @param string $name
      *
-     * @return integer|bool
+     * @return int|bool
      */
     public static function getConstantByName($name)
     {

--- a/src/qtism/data/state/OutcomeDeclaration.php
+++ b/src/qtism/data/state/OutcomeDeclaration.php
@@ -374,7 +374,7 @@ class OutcomeDeclaration extends VariableDeclaration
     /**
      * Set external score attribute to determine how scoring should be proceed
      *
-     * @param string $externalScored
+     * @param int|null $externalScored
      */
     public function setExternalScored($externalScored = null)
     {
@@ -391,5 +391,32 @@ class OutcomeDeclaration extends VariableDeclaration
     public function getExternalScored()
     {
         return $this->externalScored;
+    }
+
+    /**
+     * Is the outcome declaration externally scored?
+     * @return string
+     */
+    public function isExternallyScored()
+    {
+        return $this->externalScored !== null;
+    }
+
+    /**
+     * Get externalScored attribute
+     * @return string
+     */
+    public function isScoredByHuman()
+    {
+        return $this->externalScored === ExternalScored::HUMAN;
+    }
+
+    /**
+     * Get externalScored attribute
+     * @return string
+     */
+    public function isScoredByExternalMachine()
+    {
+        return $this->externalScored === ExternalScored::EXTERNAL_MACHINE;
     }
 }

--- a/src/qtism/data/state/OutcomeDeclaration.php
+++ b/src/qtism/data/state/OutcomeDeclaration.php
@@ -386,7 +386,7 @@ class OutcomeDeclaration extends VariableDeclaration
 
     /**
      * Get externalScored attribute
-     * @return string
+     * @return int|null
      */
     public function getExternalScored()
     {
@@ -395,7 +395,7 @@ class OutcomeDeclaration extends VariableDeclaration
 
     /**
      * Is the outcome declaration externally scored?
-     * @return string
+     * @return bool
      */
     public function isExternallyScored()
     {
@@ -404,7 +404,7 @@ class OutcomeDeclaration extends VariableDeclaration
 
     /**
      * Get externalScored attribute
-     * @return string
+     * @return bool
      */
     public function isScoredByHuman()
     {
@@ -413,7 +413,7 @@ class OutcomeDeclaration extends VariableDeclaration
 
     /**
      * Get externalScored attribute
-     * @return string
+     * @return bool
      */
     public function isScoredByExternalMachine()
     {

--- a/src/qtism/data/storage/xml/marshalling/OutcomeDeclarationMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/OutcomeDeclarationMarshaller.php
@@ -96,8 +96,8 @@ class OutcomeDeclarationMarshaller extends VariableDeclarationMarshaller
             $element->appendChild($lookupTableMarshaller->marshall($component->geTLookupTable()));
         }
 
-        if ($component->getExternalScored() !== null) {
-            static::setDOMElementAttribute($element, 'externalScored', ExternalScored::getNameByConstant($component->getExternalScored()));
+        if (Version::compare($version, '2.2.0', '>=') === true && $component->isExternallyScored()) {
+            $this->setDOMElementAttribute($element, 'externalScored', ExternalScored::getNameByConstant($component->getExternalScored()));
         }
 
         return $element;
@@ -122,7 +122,7 @@ class OutcomeDeclarationMarshaller extends VariableDeclarationMarshaller
             $object->setDefaultValue($baseComponent->getDefaultValue());
 
             // Set external scored attribute
-            if (($externalScored = static::getDOMElementAttributeAs($element, 'externalScored')) != null) {
+            if (($externalScored = $this->getDOMElementAttributeAs($element, 'externalScored')) != null) {
                 $object->setExternalScored(ExternalScored::getConstantByName($externalScored));
             }
 

--- a/src/qtism/data/storage/xml/marshalling/OutcomeDeclarationMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/OutcomeDeclarationMarshaller.php
@@ -66,12 +66,12 @@ class OutcomeDeclarationMarshaller extends VariableDeclarationMarshaller
         }
 
         // deal with interpretation.
-        if ($component->getInterpretation() != '') {
+        if ($component->getInterpretation() !== '') {
             $this->setDOMElementAttribute($element, 'interpretation', $component->getInterpretation());
         }
 
         // deal with long interpretation.
-        if ($component->getLongInterpretation() != '') {
+        if ($component->getLongInterpretation() !== '') {
             $this->setDOMElementAttribute($element, 'longInterpretation', $component->getLongInterpretation());
         }
 

--- a/src/qtism/data/storage/xml/marshalling/OutcomeDeclarationMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/OutcomeDeclarationMarshaller.php
@@ -91,7 +91,7 @@ class OutcomeDeclarationMarshaller extends VariableDeclarationMarshaller
         }
 
         // Deal with lookup table.
-        if ($component->getLookupTable() != null) {
+        if ($component->getLookupTable() !== null) {
             $lookupTableMarshaller = $this->getMarshallerFactory()->createMarshaller($component->getLookupTable(), array($component->getBaseType()));
             $element->appendChild($lookupTableMarshaller->marshall($component->geTLookupTable()));
         }

--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -1440,7 +1440,7 @@ class AssessmentItemSession extends State
     {
         /** @var OutcomeDeclaration $outcomeDeclaration */
         foreach ($outcomeDeclarations as $outcomeDeclaration) {
-            if ($outcomeDeclaration->getExternalScored() !== null) {
+            if ($outcomeDeclaration->isExternallyScored()) {
                 return true;
             }
         }

--- a/test/qtismtest/data/state/OutcomeDeclarationTest.php
+++ b/test/qtismtest/data/state/OutcomeDeclarationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace qtismtest\data\state;
 
+use qtism\data\state\ExternalScored;
 use qtismtest\QtiSmTestCase;
 use qtism\data\state\OutcomeDeclaration;
 use qtism\data\state\MatchTable;
@@ -11,70 +12,67 @@ use qtism\common\enums\Cardinality;
 
 class OutcomeDeclarationTest extends QtiSmTestCase
 {
+    /** @var OutcomeDeclaration */
+    private $subject;
+
+    public function setUp()
+    {
+        $this->subject = new OutcomeDeclaration('SCORE', BaseType::FLOAT, Cardinality::SINGLE);
+    }
+
     public function testSetInterpretationWrongType()
     {
-        $outcomeDeclaration = new OutcomeDeclaration('SCORE', BaseType::FLOAT, Cardinality::SINGLE);
-        
         $this->setExpectedException(
             '\\InvalidArgumentException',
             "Interpretation must be a string, 'integer' given."
         );
-        
-        $outcomeDeclaration->setInterpretation(999);
+
+        $this->subject->setInterpretation(999);
     }
     
     public function testSetLongInterpretationWrongType()
     {
-        $outcomeDeclaration = new OutcomeDeclaration('SCORE', BaseType::FLOAT, Cardinality::SINGLE);
-        
         $this->setExpectedException(
             '\\InvalidArgumentException',
             "LongInterpretation must be a string, 'integer' given."
         );
-        
-        $outcomeDeclaration->setLongInterpretation(999);
+
+        $this->subject->setLongInterpretation(999);
     }
     
     public function testSetNormalMinimumWrongType()
     {
-        $outcomeDeclaration = new OutcomeDeclaration('SCORE', BaseType::FLOAT, Cardinality::SINGLE);
-        
         $this->setExpectedException(
             '\\InvalidArgumentException',
             "NormalMinimum must be a number or (boolean) false, 'string' given."
         );
-        
-        $outcomeDeclaration->setNormalMinimum('string');
+
+        $this->subject->setNormalMinimum('string');
     }
     
     public function testSetNormalMaximumWrongType()
     {
-        $outcomeDeclaration = new OutcomeDeclaration('SCORE', BaseType::FLOAT, Cardinality::SINGLE);
-        
         $this->setExpectedException(
             '\\InvalidArgumentException',
             "NormalMaximum must be a number or (boolean) false, 'string' given."
         );
-        
-        $outcomeDeclaration->setNormalMaximum('string');
+
+        $this->subject->setNormalMaximum('string');
     }
     
     public function testSetMasteryValueWrongType()
     {
-        $outcomeDeclaration = new OutcomeDeclaration('SCORE', BaseType::FLOAT, Cardinality::SINGLE);
-        
         $this->setExpectedException(
             '\\InvalidArgumentException',
             "MasteryValue must be a number or (boolean) false, 'string' given."
         );
-        
-        $outcomeDeclaration->setMasteryValue('string');
+
+        $this->subject->setMasteryValue('string');
     }
     
     public function getComponentsWithLookupTable()
     {
-        $outcomeDeclaration = new OutcomeDeclaration('SCORE', BaseType::FLOAT, Cardinality::SINGLE);
-        $outcomeDeclaration->setLookupTable(
+        $this->subject->setLookupTable(
             new MatchTable(
                 new MatchTableEntryCollection(
                     new MatchTableEntry(3, 3.33)
@@ -85,5 +83,30 @@ class OutcomeDeclarationTest extends QtiSmTestCase
         $components = $this->getComponents();
         $last = $components[count($components) - 1];
         $this->assertInstanceOf('qtism\\data\\state\\MatchTable', $last);
+    }
+
+    public function testExternalScoredAccessors()
+    {
+        $this->assertFalse($this->subject->isExternallyScored());
+        $this->assertFalse($this->subject->isScoredByHuman());
+        $this->assertFalse($this->subject->isScoredByExternalMachine());
+
+        $this->subject->setExternalScored(ExternalScored::getConstantByName('human'));
+
+        $this->assertTrue($this->subject->isExternallyScored());
+        $this->assertTrue($this->subject->isScoredByHuman());
+        $this->assertFalse($this->subject->isScoredByExternalMachine());
+
+        $this->subject->setExternalScored(ExternalScored::getConstantByName('externalMachine'));
+
+        $this->assertTrue($this->subject->isExternallyScored());
+        $this->assertFalse($this->subject->isScoredByHuman());
+        $this->assertTrue($this->subject->isScoredByExternalMachine());
+
+        $this->subject->setExternalScored();
+
+        $this->assertFalse($this->subject->isExternallyScored());
+        $this->assertFalse($this->subject->isScoredByHuman());
+        $this->assertFalse($this->subject->isScoredByExternalMachine());
     }
 }

--- a/test/qtismtest/data/storage/xml/marshalling/OutcomeDeclarationMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/OutcomeDeclarationMarshallerTest.php
@@ -58,24 +58,43 @@ class OutcomeDeclarationMarshallerTest extends QtiSmTestCase {
         $marshaller->unmarshall($element);
     }
 
-    public function testMarshallExternalScored()
+    /**
+     * @dataProvider qtiVersionsToTestForExternalScored
+     * @param $qtiVersion
+     * @param $externalScored
+     * @param $expectedExternalScored
+     */
+    public function testMarshallExternalScored($qtiVersion, $externalScored, $expectedExternalScored)
     {
         // Initialize a minimal outcomeDeclaration.
         $identifier = 'outcome1';
         $cardinality = Cardinality::SINGLE;
         $baseType = BaseType::INTEGER;
-        $externalScored = ExternalScored::HUMAN;
 
         $component = new OutcomeDeclaration($identifier, $baseType, $cardinality, null, $externalScored);
-        $marshaller = $this->getMarshallerFactory()->createMarshaller($component);
+        $marshaller = $this->getMarshallerFactory($qtiVersion)->createMarshaller($component);
         /** @var DOMElement $element */
         $element = $marshaller->marshall($component);
 
         $this->assertInstanceOf('\\DOMElement', $element);
-        $this->assertEquals('human', $element->getAttribute('externalScored'));
+        $this->assertEquals($expectedExternalScored, $element->getAttribute('externalScored'));
         $this->assertEquals('integer', $element->getAttribute('baseType'));
         $this->assertEquals('outcome1', $element->getAttribute('identifier'));
         $this->assertEquals('single', $element->getAttribute('cardinality'));
+    }
+    
+    public function qtiVersionsToTestForExternalScored()
+    {
+        return [
+            ['2.0', ExternalScored::HUMAN,  ''],
+            ['2.0', ExternalScored::EXTERNAL_MACHINE,  ''],
+            ['2.1.0', ExternalScored::HUMAN,  ''],
+            ['2.1.0', ExternalScored::EXTERNAL_MACHINE,  ''],
+            ['2.2.0', ExternalScored::HUMAN,  'human'],
+            ['2.2.0', ExternalScored::EXTERNAL_MACHINE,  'externalMachine'],
+            ['3.0.0', ExternalScored::HUMAN,  'human'],
+            ['3.0.0', ExternalScored::EXTERNAL_MACHINE,  'externalMachine'],
+        ];
     }
 	
 	/**

--- a/test/qtismtest/data/storage/xml/marshalling/OutcomeDeclarationMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/OutcomeDeclarationMarshallerTest.php
@@ -60,9 +60,6 @@ class OutcomeDeclarationMarshallerTest extends QtiSmTestCase {
 
     /**
      * @dataProvider qtiVersionsToTestForExternalScored
-     * @param $qtiVersion
-     * @param $externalScored
-     * @param $expectedExternalScored
      */
     public function testMarshallExternalScored($qtiVersion, $externalScored, $expectedExternalScored)
     {


### PR DESCRIPTION
ExternalScored attribute is a QTI 2.2 feature. It must not be taken in account in previous versions.
This PR also adds externalScore checking methods, to avoid disclosing enumeration constants to SDK users.
