### PR TITLE
Allow string baseType with null value

### DIFF
--- a/src/qtism/data/storage/xml/marshalling/ValueMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ValueMarshaller.php
@@ -136,18 +136,20 @@ class ValueMarshaller extends Marshaller
         } else {
             // baseType attribute not set -> not part of a record.
             $nodeValue = trim($element->nodeValue);
-            if ($nodeValue !== '') {
-                // Try to use the marshaller as parametric to know how to unserialize the value.
-                if ($this->getBaseType() != -1) {
-                    $object = new Value(Utils::stringToDatatype($nodeValue, $this->getBaseType()), $this->getBaseType());
-                } else {
-                    // value used as plain string (at your own risks).
-                    $object = new Value($nodeValue);
+
+            if ($this->getBaseType() !== -1) {
+                // Empty value only accepted if base type is string (consider empty string).
+                if ($nodeValue === '' && $this->getBaseType() !== BaseType::STRING) {
+                    throw new UnmarshallingException(
+                        sprintf('The element "%s" has no value', $element->localName),
+                        $element
+                    );
                 }
 
+                $object = new Value(Utils::stringToDatatype($nodeValue, $this->getBaseType()), $this->getBaseType());
             } else {
-                $msg = "The element '" . $element->localName . "' has no value.";
-                throw new UnmarshallingException($msg, $element);
+                // value used as plain string (at your own risks).
+                $object = new Value($nodeValue);
             }
         }
 

--- a/test/qtismtest/data/storage/xml/marshalling/ValueMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ValueMarshallerTest.php
@@ -15,116 +15,116 @@ class ValueMarshallerTest extends QtiSmTestCase {
 		$fieldIdentifier = 'goodIdentifier';
 		$baseType = BaseType::INTEGER;
 		$value = 666;
-		
+
 		$component = new Value($value, $baseType, $fieldIdentifier);
 		$component->setPartOfRecord(true); // to get the baseType written in output.
 		$marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($component);
 		$element = $marshaller->marshall($component);
-		
+
 		$this->assertInstanceOf('\\DOMElement', $element);
 		$this->assertEquals('value', $element->nodeName);
 		$this->assertEquals($fieldIdentifier, $element->getAttribute('fieldIdentifier'));
 		$this->assertEquals('integer', $element->getAttribute('baseType'));
 		$this->assertEquals($value . '', $element->nodeValue);
 	}
-	
+
 	public function testMarshallBaseTypeBoolean() {
-		
+
 		$fieldIdentifier = 'goodIdentifier';
 		$baseType = BaseType::BOOLEAN;
 		$value = false;
-		
+
 		$component = new Value($value, $baseType, $fieldIdentifier);
 		$marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($component);
 		$element = $marshaller->marshall($component);
-		
+
 		$this->assertInstanceOf('\\DOMElement', $element);
 		$this->assertTrue('false' === $element->nodeValue);
 	}
-	
+
 	public function testMarshallNoBaseType() {
-		
+
 		$value = new QtiPair('id1', 'id2');
-		
+
 		$component = new Value($value);
 		$marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($component);
 		$element = $marshaller->marshall($component);
-		
+
 		$this->assertEquals('id1 id2', $element->nodeValue);
 	}
-	
+
 	public function testUnmarshallNoBaseType() {
 		$dom = new DOMDocument('1.0', 'UTF-8');
 		$dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1">A B</value>');
 		$element = $dom->documentElement;
-		
+
 		$marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element);
 		$component = $marshaller->unmarshall($element);
-		
+
 		$this->assertInstanceOf('qtism\\data\\state\\Value', $component);
 		$this->assertInternalType('string', $component->getValue());
 		$this->assertEquals($component->getValue(), 'A B');
 	}
-	
+
 	public function testUnmarshallNoBaseTypeButForced() {
 		// Here we use the ValueMarshaller as a parametric marshaller
 		// to force the Pair to be unserialized as a Pair object
 		$dom = new DOMDocument('1.0', 'UTF-8');
 		$dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1">A B</value>');
 		$element = $dom->documentElement;
-	
+
 		$marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element, array(BaseType::PAIR));
 		$component = $marshaller->unmarshall($element);
-	
+
 		$this->assertInstanceOf('qtism\\data\\state\\Value', $component);
 		$this->assertInstanceOf('qtism\\common\\datatypes\\QtiPair', $component->getValue());
 		$this->assertEquals($component->getValue()->getFirst(), 'A');
 		$this->assertEquals($component->getValue()->getSecond(), 'B');
 	}
-	
+
 	public function testUnmarshallNoBaseTypeButForcedAndEntities() {
 	    $dom = new DOMDocument('1.0', 'UTF-8');
 	    $dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1">Hello &lt;b&gt;bold&lt;/b&gt;</value>');
 	    $element = $dom->documentElement;
-	    
+
 	    $marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element, array(BaseType::STRING));
 	    $component = $marshaller->unmarshall($element);
-	    
+
 	    $this->assertInstanceOf('qtism\\data\\state\\Value', $component);
 	    $this->assertInternalType('string', $component->getValue());
 	    $this->assertSame('Hello <b>bold</b>', $component->getValue());
 	}
-	
+
 	public function testMarshallNoBaseTypeButForcedAndEntities() {
 	    $value = "Hello <b>bold</b>";
 	    $baseType = BaseType::STRING;
 	    $component = new Value($value, $baseType);
-	    
+
 	    $marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($component);
 	    $element = $marshaller->marshall($component);
-	    
+
 	    $this->assertSame('<value>Hello &lt;b&gt;bold&lt;/b&gt;</value>', $element->ownerDocument->saveXML($element));
 	}
-	
-	public function testUnmarshallNoValue() {
-		$this->setExpectedException('qtism\\data\\storage\\xml\\marshalling\\UnmarshallingException');
-		
-		$dom = new DOMDocument('1.0', 'UTF-8');
-		$dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"></value>');
-		$element = $dom->documentElement;
-		
-		$marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element);
-		$component = $marshaller->unmarshall($element);
-	}
-	
+
+	public function testUnmarshallStringBaseTypeWithNullValue() {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" baseType="string"></value>');
+        $element = $dom->documentElement;
+
+        $marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element);
+        $component = $marshaller->unmarshall($element);
+        $this->assertSame(BaseType::STRING, $component->getBaseType());
+        $this->assertSame('', $component->getValue());
+    }
+
 	public function testUnmarshallBaseType() {
 		$dom = new DOMDocument('1.0', 'UTF-8');
 		$dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" baseType="pair" fieldIdentifier="fieldIdentifier1">A B</value>');
 		$element = $dom->documentElement;
-		
+
 		$marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element);
 		$component = $marshaller->unmarshall($element);
-		
+
 		$this->assertInstanceOf('qtism\\data\\state\\Value', $component);
 		$this->assertInstanceOf('qtism\\common\\datatypes\\QtiPair', $component->getValue());
 		$this->assertEquals($component->getValue()->getFirst(), 'A');

--- a/test/qtismtest/data/storage/xml/marshalling/ValueMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ValueMarshallerTest.php
@@ -106,7 +106,8 @@ class ValueMarshallerTest extends QtiSmTestCase {
 	    $this->assertSame('<value>Hello &lt;b&gt;bold&lt;/b&gt;</value>', $element->ownerDocument->saveXML($element));
 	}
 
-	public function testUnmarshallStringBaseTypeWithNullValue() {
+    public function testUnmarshallStringBaseTypeWithNullValue()
+    {
         $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" baseType="string"></value>');
         $element = $dom->documentElement;

--- a/test/qtismtest/data/storage/xml/marshalling/ValueMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ValueMarshallerTest.php
@@ -2,7 +2,6 @@
 namespace qtismtest\data\storage\xml\marshalling;
 
 use qtismtest\QtiSmTestCase;
-use qtism\data\storage\xml\marshalling\Marshaller;
 use qtism\data\state\Value;
 use qtism\common\enums\BaseType;
 use qtism\common\datatypes\QtiPair;
@@ -105,6 +104,18 @@ class ValueMarshallerTest extends QtiSmTestCase {
 
 	    $this->assertSame('<value>Hello &lt;b&gt;bold&lt;/b&gt;</value>', $element->ownerDocument->saveXML($element));
 	}
+
+    public function testUnmarshallNoValue()
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"></value>');
+        $element = $dom->documentElement;
+        $marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element);
+        $component = $marshaller->unmarshall($element);
+
+        $this->assertSame(-1, $component->getBaseType());
+        $this->assertSame('', $component->getValue());
+    }
 
     public function testUnmarshallStringBaseTypeWithNullValue()
     {


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/MS-90

You can test it with the following code snippet:
```
<?php

use qtism\data\storage\xml\XmlResultDocument;

require_once __DIR__ . '/vendor/autoload.php';

$xmlDocument = new XmlResultDocument();
$xml = <<<XML
<?xml version="1.0" encoding="UTF-8"?>
<assessmentResult xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p1">
  <context sourcedId="i5e4195ae583c374de82f78712be21a"/>
  <itemResult identifier="item-1" datestamp="2020-02-11T09:12:15.703" sessionStatus="final">
    <responseVariable identifier="RESPONSE" cardinality="multiple" baseType="identifier">
      <candidateResponse>
        <value><![CDATA[]]></value>
      </candidateResponse>
    </responseVariable>
  </itemResult>
</assessmentResult>
XML;

$xmlDocument->loadFromString($xml);
```