### PR TITLE
Fix/graphic gap match interaction optional prompt

### DIFF
--- a/src/qtism/data/content/interactions/GraphicGapMatchInteraction.php
+++ b/src/qtism/data/content/interactions/GraphicGapMatchInteraction.php
@@ -177,9 +177,14 @@ class GraphicGapMatchInteraction extends GraphicInteraction
      */
     public function getComponents()
     {
+        $prompt = $this->getPrompt();
+        $components = $prompt
+            ? [$prompt]
+            : [];
+                
         return new QtiComponentCollection(
             array_merge(
-                array($this->getPrompt()),
+                $components,
                 array($this->getObject()),
                 $this->getGapImgs()->getArrayCopy(),
                 $this->getAssociableHotspots()->getArrayCopy()

--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -210,7 +210,7 @@ class XmlDocumentTest extends QtiSmTestCase {
     public function testLoadFromMalformedString() {
         $doc = new XmlDocument('2.1');
         
-        $expectedMsg = "An internal error occured while parsing QTI-XML:\nFatal Error: Premature end of data in tag assessmentItem line 1 at 1:17.";
+        $expectedMsg = "An internal error occured while parsing QTI-XML:\nFatal Error: EndTag: '</' not found at 1:17.";
         $this->setExpectedException('\\qtism\\data\\storage\\xml\\XmlStorageException', $expectedMsg, XmlStorageException::READ);
         
         $doc->loadFromString('<assessmentItem>');

--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -210,7 +210,7 @@ class XmlDocumentTest extends QtiSmTestCase {
     public function testLoadFromMalformedString() {
         $doc = new XmlDocument('2.1');
         
-        $expectedMsg = "An internal error occured while parsing QTI-XML:\nFatal Error: EndTag: '</' not found at 1:17.";
+        $expectedMsg = "An internal error occured while parsing QTI-XML:\nFatal Error: Premature end of data in tag assessmentItem line 1 at 1:17.";
         $this->setExpectedException('\\qtism\\data\\storage\\xml\\XmlStorageException', $expectedMsg, XmlStorageException::READ);
         
         $doc->loadFromString('<assessmentItem>');


### PR DESCRIPTION
This hotfix allows prompt in graphic gap match interaction to be optional.
Possibly affected tests:
- qtismtest\data\AssessmentItemTest::testGetResponseValidityConstraints
- qtismtest\data\storage\xml\XmlAssessmentItemDocumentTest::testRetrievePromptFromGraphicGapMatch
- qtismtest\runtime\rendering\markup\goldilocks\GoldilocksRenderingEngineTest::testRendering with data set #11

**The optionality of prompt has not been tested at all so test must be added.**