### PR TITLE
Removed version tag in composer.json, locking tags on packagist.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
 	"name": "qtism/qtism",
 	"description": "OAT QTI Software Module Library",
 	"type": "library",
-	"version": "0.19.0",
 	"authors": [
 		{
 			"name": "Open Assessment Technologies S.A.",


### PR DESCRIPTION
This PR removes the version tag in composer.json. It was overriding the actual release tag and prevented packagist to find out the releases.