### PR TITLE
Re-introduced CLASS_NAME constant which is accessed by TaoQtiItem ImportService

### DIFF
--- a/qtism/data/rules/SetOutcomeValue.php
+++ b/qtism/data/rules/SetOutcomeValue.php
@@ -44,6 +44,13 @@ use qtism\data\QtiComponentCollection;
 class SetOutcomeValue extends QtiComponent implements OutcomeRule, ResponseRule
 {
     /**
+     * FIXME: This constant is accessed directly in Tao ImportService.
+     * Every other places are using hard-coded string, which is even worse.
+     * It shouldn't be disclosed and another way of selecting elements must be found.
+     */
+    const CLASS_NAME = 'setOutcomeValue';
+
+    /**
      * From IMS QTI:
      *
      * The outcome variable to set.


### PR DESCRIPTION
In a previous commit (https://github.com/oat-sa/qti-sdk/commit/41e0b29ab0a2c7284c56d44d1847e0d0ee7f050d#diff-89ab65b95ada3a7351e8ce3a05bf11e8L50), this constant was removed, because it was accessed in the same class by the getQtiClassName only, allowing undisclosed constant to external usages.
In fact, it was also accessed directly by Tao \ImportService\ to select QTI components with the `QtiComponents::getComponentsByClassName` method.
Every other calls to `QtiComponents::getComponentsByClassName` are using hard-coded strings, which is even worse.

Another way of selecting elements must be found.