### PR TITLE
Added QTI version change method to amend namespace of assessmentTest for both regular and compact test definitions.

### DIFF
--- a/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/qtism/data/storage/xml/XmlCompactDocument.php
@@ -116,7 +116,7 @@ class XmlCompactDocument extends XmlDocument
      */
     public static function createFromXmlAssessmentTestDocument(XmlDocument $xmlAssessmentTestDocument, Resolver $itemResolver = null, Resolver $sectionResolver = null)
     {
-        $compactAssessmentTest = new XmlCompactDocument();
+        $compactAssessmentTest = new XmlCompactDocument($xmlAssessmentTestDocument->getVersion());
         $identifier = $xmlAssessmentTestDocument->getDocumentComponent()->getIdentifier();
         $title = $xmlAssessmentTestDocument->getDocumentComponent()->getTitle();
 
@@ -313,9 +313,26 @@ class XmlCompactDocument extends XmlDocument
      */
     public function decorateRootElement(DOMElement $rootElement)
     {
-        $rootElement->setAttribute('xmlns', "http://www.imsglobal.org/xsd/imsqti_v2p1");
+        $namespaces = [
+            '2.1' => 'v2p1',
+            '2.2' => 'v2p2',
+        ];
+        $compactLocations = [
+            '2.1' => 'v1p0',
+            '2.2' => 'v1p1',
+        ];
+
+        $rootElement->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns', sprintf('http://www.imsglobal.org/xsd/imsqti_%s', $namespaces[$this->getVersion()]));
         $rootElement->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-        $rootElement->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', "http://www.taotesting.com/xsd/qticompact_v1p0.xsd");
+        $rootElement->setAttributeNS(
+            'http://www.w3.org/2001/XMLSchema-instance',
+            'xsi:schemaLocation',
+            sprintf(
+                'http://www.imsglobal.org/xsd/imsqti_%s http://www.taotesting.com/xsd/qticompact_%s.xsd',
+                $namespaces[$this->getVersion()],
+                $compactLocations[$this->getVersion()]
+            )
+        );
     }
 
     /**

--- a/qtism/data/storage/xml/XmlDocument.php
+++ b/qtism/data/storage/xml/XmlDocument.php
@@ -443,28 +443,41 @@ class XmlDocument extends QtiDocument
      */
     protected function decorateRootElement(DOMElement $rootElement)
     {
-        $qtiSuffix = 'v2p1';
-        $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd';
         switch (trim($this->getVersion())) {
             case '2.0':
                 $qtiSuffix = 'v2p0';
                 $xsdLocation = 'http://www.imsglobal.org/xsd/imsqti_v2p0.xsd';
                 break;
 
+            case '2.2':
+                $qtiSuffix = 'v2p2';
+                $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p2p1/imsqti_v2p2p1.xsd';
+                break;
+
+            case '2.1':
             case '2.1.0':
+            default:
                 $qtiSuffix = 'v2p1';
                 $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd';
                 break;
-
-            case '2.2':
-                $qtiSuffix = 'v2p2';
-                $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd';
-                break;
         }
-
-        $rootElement->setAttribute('xmlns', "http://www.imsglobal.org/xsd/imsqti_${qtiSuffix}");
+        
+        $rootElement->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns', "http://www.imsglobal.org/xsd/imsqti_${qtiSuffix}");
         $rootElement->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
         $rootElement->setAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'xsi:schemaLocation', "http://www.imsglobal.org/xsd/imsqti_${qtiSuffix} ${xsdLocation}");
+    }
+
+    /**
+     * Changes to Qti version of the root element.
+     *
+     * @param string $toVersion
+     * @return self
+     */
+    public function changeVersion(string $toVersion)
+    {
+        $this->setVersion($toVersion);
+        $this->decorateRootElement($this->domDocument->documentElement);
+        return $this;
     }
 
     /**

--- a/qtism/data/storage/xml/schemes/qticompact_v1p1.xsd
+++ b/qtism/data/storage/xml/schemes/qticompact_v1p1.xsd
@@ -1,0 +1,52 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<xs:schema xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.imsglobal.org/xsd/imsqti_v2p2"
+    version="QTI Compact 1.1"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified">
+
+    <xs:redefine schemaLocation="../../xml/schemes/qtiv2p2p1/imsqti_v2p2p1.xsd">
+	    <xs:complexType name="AssessmentItemRef.Type">
+	    	<xs:complexContent>
+	    		<xs:extension base="AssessmentItemRef.Type">
+	    			<xs:sequence>
+	    				<xs:element name="responseDeclaration" minOccurs="0" maxOccurs="unbounded"/>
+	    				<xs:element name="outcomeDeclaration" minOccurs="0" maxOccurs="unbounded"/>
+	    				<xs:element name="responseProcessing" minOccurs="0" maxOccurs="1"/>
+	    			</xs:sequence>
+	    			<xs:attribute name="adaptive" default="false" use="optional" type="xs:boolean"/>
+	    			<xs:attribute name="timeDependent" use="required" type="xs:boolean"/>
+	    		</xs:extension>
+	    	</xs:complexContent>
+	    </xs:complexType>
+	    
+	    <xs:complexType name="AssessmentSection.Type">
+    		<xs:complexContent>
+    			<xs:extension base="AssessmentSection.Type">
+    				<xs:sequence>
+    					<xs:element name="rubricBlockRef" type="RubricBlockRef.Type" minOccurs="0" maxOccurs="unbounded"/>
+    				</xs:sequence>
+    			</xs:extension>
+    		</xs:complexContent>
+    	</xs:complexType>
+    </xs:redefine>
+    
+    <xs:complexType name="RubricBlockRef.Type" mixed="true">
+	        <xs:annotation>
+	            <xs:documentation>
+	               A reference to an existing rubrickBlock.
+	            </xs:documentation>
+	        </xs:annotation>
+	        <xs:attributeGroup ref="identifier.RubricBlockRef.Attr"/>
+	        <xs:attributeGroup ref="href.RubricBlockRef.Attr"/>
+    	</xs:complexType>
+    
+    <xs:attributeGroup name="href.RubricBlockRef.Attr">
+        <xs:attribute name="href" use="required" type="xs:anyURI"/>
+    </xs:attributeGroup>
+    
+    <xs:attributeGroup name="identifier.RubricBlockRef.Attr">
+    	<xs:attribute name="identifier" use="required" type="xs:normalizedString"/>
+    </xs:attributeGroup>
+</xs:schema>

--- a/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
@@ -248,4 +248,20 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase
         $doc->load($file);
         $compactDoc = XmlCompactDocument::createFromXmlAssessmentTestDocument($doc, new LocalFileResolver());
     }
+
+    public function testChangeVersion()
+    {
+        $file10 = self::samplesDir() . 'custom/tests/empty_compact_test/empty_compact_test_1.0.xml';
+        $file11 = self::samplesDir() . 'custom/tests/empty_compact_test/empty_compact_test_1.1.xml';
+
+        $doc = new XmlCompactDocument('1.0');
+        $doc->load($file10);
+
+        $doc->changeVersion('2.2');
+
+        $expected = new XmlCompactDocument('1.1');
+        $expected->load($file11);
+
+        $this->assertEquals($expected->getDomDocument()->documentElement, $doc->getDomDocument()->documentElement);
+    }
 }

--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -189,4 +189,20 @@ class XmlDocumentTest extends QtiSmTestCase
         $divText = $divContent[0];
         $this->assertEquals('Hello there & there! I am trying to make <you> "crazy"', $divText->getcontent());
     }
+
+    public function testChangeVersion()
+    {
+        $file21 = self::samplesDir() . 'ims/tests/empty_test/empty_test_qti_2.1.xml';
+        $file22 = self::samplesDir() . 'ims/tests/empty_test/empty_test_qti_2.2.xml';
+        
+        $doc = new XmlDocument('2.1');
+        $doc->load($file21);
+
+        $doc->changeVersion('2.2');
+
+        $expected = new XmlDocument('2.2');
+        $expected->load($file22);
+
+        $this->assertEquals($expected->getDomDocument()->documentElement, $doc->getDomDocument()->documentElement);
+    }
 }

--- a/test/samples/custom/tests/empty_compact_test/empty_compact_test_1.0.xml
+++ b/test/samples/custom/tests/empty_compact_test/empty_compact_test_1.0.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.taotesting.com/xsd/qticompact_v1p0.xsd"
+                identifier="Test1" title="testTitle">
+    <testPart navigationMode="linear" submissionMode="individual" identifier="TP01">
+        <itemSessionControl maxAttempts="0" allowSkipping="true"/>
+        <assessmentSection identifier="S01" title="Section 1" visible="true" required="true">
+        </assessmentSection>
+    </testPart>
+</assessmentTest>

--- a/test/samples/custom/tests/empty_compact_test/empty_compact_test_1.1.xml
+++ b/test/samples/custom/tests/empty_compact_test/empty_compact_test_1.1.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.taotesting.com/xsd/qticompact_v1p1.xsd"
+                identifier="Test1" title="testTitle">
+    <testPart navigationMode="linear" submissionMode="individual" identifier="TP01">
+        <itemSessionControl maxAttempts="0" allowSkipping="true"/>
+        <assessmentSection identifier="S01" title="Section 1" visible="true" required="true">
+        </assessmentSection>
+    </testPart>
+</assessmentTest>

--- a/test/samples/ims/tests/empty_test/empty_test_qti_2.1.xml
+++ b/test/samples/ims/tests/empty_test/empty_test_qti_2.1.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+                identifier="Test1" title="testTitle">
+    <testPart navigationMode="linear" submissionMode="individual" identifier="TP01">
+        <itemSessionControl maxAttempts="0" allowSkipping="true"/>
+        <assessmentSection identifier="S01" title="Section 1" visible="true" required="true">
+        </assessmentSection>
+    </testPart>
+</assessmentTest>

--- a/test/samples/ims/tests/empty_test/empty_test_qti_2.2.xml
+++ b/test/samples/ims/tests/empty_test/empty_test_qti_2.2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2p1/imsqti_v2p2p1.xsd"
+                identifier="Test1" title="testTitle">
+    <testPart navigationMode="linear" submissionMode="individual" identifier="TP01">
+        <itemSessionControl maxAttempts="0" allowSkipping="true"/>
+        <assessmentSection identifier="S01" title="Section 1" visible="true" required="true">
+        </assessmentSection>
+    </testPart>
+</assessmentTest>


### PR DESCRIPTION
This PR allows simple QTI version change.
A TestAssessment element can be amended with different QTI versions. As to now, only versions 2.1 and 2.2 are taken in account. This will allow us to compile tests to QTI 2.2 version.
