### PR TITLE
Added getValue for all DataTypes.

### DIFF
--- a/src/qtism/common/datatypes/QtiCoords.php
+++ b/src/qtism/common/datatypes/QtiCoords.php
@@ -180,6 +180,17 @@ class QtiCoords extends IntegerCollection implements QtiDatatype
     }
 
     /**
+     * Get the encapsulated value from the Non-Scalar object, represented as a string.
+     * This is what we can find in result report variables for example.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return (string) $this;
+    }
+
+    /**
      * Whether or not $obj is equals to $this. Two Coords objects are
      * considered to be equal if they have the same coordinates and shape.
      *

--- a/src/qtism/common/datatypes/QtiDuration.php
+++ b/src/qtism/common/datatypes/QtiDuration.php
@@ -259,6 +259,17 @@ class QtiDuration implements QtiDatatype
     }
 
     /**
+     * Get the encapsulated value from the Non-Scalar object, represented as a string.
+     * This is what we can find in result report variables for example.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return (string) $this;
+    }
+
+    /**
      * Whether a given $obj is equal to this Duration.
      *
      * @param mixed $obj A given value.

--- a/src/qtism/common/datatypes/QtiPair.php
+++ b/src/qtism/common/datatypes/QtiPair.php
@@ -129,6 +129,17 @@ class QtiPair implements QtiDatatype
     }
 
     /**
+     * Get the encapsulated value from the Non-Scalar object, represented as a string.
+     * This is what we can find in result report variables for example.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return (string) $this;
+    }
+
+    /**
      * Whether a given $obj is equal to this Pair. Two Pair objects
      * are considered to be identical if the first and second values
      * of $obj are the same as the ones of $obj.

--- a/src/qtism/common/datatypes/QtiPoint.php
+++ b/src/qtism/common/datatypes/QtiPoint.php
@@ -147,6 +147,17 @@ class QtiPoint implements QtiDatatype
     }
 
     /**
+     * Get the encapsulated value from the Non-Scalar object, represented as a string.
+     * This is what we can find in result report variables for example.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return (string) $this;
+    }
+
+    /**
      * Get the BaseType of the value. This method systematically returns
      * the BaseType::POINT value.
      *

--- a/src/qtism/common/datatypes/QtiPoint.php
+++ b/src/qtism/common/datatypes/QtiPoint.php
@@ -104,7 +104,7 @@ class QtiPoint implements QtiDatatype
         if (is_int($y)) {
             $this->y = $y;
         } else {
-            $msg = "The Y argument must be an integer value, '" . gettype($x) . "' given.";
+            $msg = "The Y argument must be an integer value, '" . gettype($y) . "' given.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/common/datatypes/files/FileSystemFile.php
+++ b/src/qtism/common/datatypes/files/FileSystemFile.php
@@ -399,4 +399,15 @@ class FileSystemFile implements QtiFile
     {
         return $this->getFilename();
     }
+
+    /**
+     * Get the encapsulated value from the Non-Scalar object, represented as a string.
+     * This is what we can find in result report variables for example.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return (string) $this;
+    }
 }

--- a/test/qtismtest/common/datatypes/CoordsTest.php
+++ b/test/qtismtest/common/datatypes/CoordsTest.php
@@ -14,6 +14,7 @@ class CoordsTest extends QtiSmTestCase {
         $coords = new QtiCoords(QtiShape::POLY, array(0, 0, 0, 3, 3, 0));
         $this->assertEquals(BaseType::COORDS, $coords->getBaseType());
         $this->assertEquals(Cardinality::SINGLE, $coords->getCardinality());
+        $this->assertEquals('0,0,0,3,3,0', $coords->getValue());
     }
     
 	public function testInsideCircle() {

--- a/test/qtismtest/common/datatypes/CoordsTest.php
+++ b/test/qtismtest/common/datatypes/CoordsTest.php
@@ -1,98 +1,91 @@
 <?php
-
 namespace qtismtest\common\datatypes;
 
+use qtismtest\QtiSmTestCase;
+use qtism\common\datatypes\QtiShape;
 use qtism\common\datatypes\QtiCoords;
 use qtism\common\datatypes\QtiPoint;
-use qtism\common\datatypes\QtiShape;
-use qtism\common\enums\BaseType;
 use qtism\common\enums\Cardinality;
-use qtismtest\QtiSmTestCase;
+use qtism\common\enums\BaseType;
 
-class CoordsTest extends QtiSmTestCase
-{
-    public function testInstantiate()
-    {
-        $coords = new QtiCoords(QtiShape::POLY, [0, 0, 0, 3, 3, 0]);
+class CoordsTest extends QtiSmTestCase {
+
+    public function testInstantiate() {
+        $coords = new QtiCoords(QtiShape::POLY, array(0, 0, 0, 3, 3, 0));
         $this->assertEquals(BaseType::COORDS, $coords->getBaseType());
         $this->assertEquals(Cardinality::SINGLE, $coords->getCardinality());
         $this->assertEquals('0,0,0,3,3,0', $coords->getValue());
     }
-
-    public function testInsideCircle()
-    {
-        $coords = new QtiCoords(QtiShape::CIRCLE, [5, 5, 5]);
-
-        $point = new QtiPoint(1, 1); // 1,1 is outside
-        $this->assertFalse($coords->inside($point));
-
-        $point = new QtiPoint(3, 3); // 3,3 is inside
-        $this->assertTrue($coords->inside($point));
-
-        $point = new QtiPoint(5, 5); // 5,5 is inside
-        $this->assertTrue($coords->inside($point));
-
-        $point = new QtiPoint(10, 10); // 10,10 is outside
-        $this->assertFalse($coords->inside($point));
-    }
-
-    public function testInsideRectangle()
-    {
-        // Do not forget (x1, y1) -> left top corner, (x2, y2) -> right bottom corner. 
-        $coords = new QtiCoords(QtiShape::RECT, [0, 0, 5, 3]);
-
-        $point = new QtiPoint(0, 0); // 0, 0 is inside.
-        $this->assertTrue($coords->inside($point));
-
-        $point = new QtiPoint(-1, -1); // -1, -1 is outside.
-        $this->assertFalse($coords->inside($point));
-
-        $point = new QtiPoint(2, 1); // 2, 1 is inside.
-        $this->assertTrue($coords->inside($point));
-
-        $point = new QtiPoint(5, 3); // 5, 3 is inside.
-        $this->assertTrue($coords->inside($point));
-
-        $point = new QtiPoint(5, 4); // 5, 4 is outside.
-        $this->assertFalse($coords->inside($point));
-    }
-
-    public function testInsidePolygon()
-    {
-        $coords = new QtiCoords(QtiShape::POLY, [0, 8, 7, 4, 2, 2, 8, -4, -2, 1]);
-
-        $point = new QtiPoint(0, 8); // 0, 8 is inside.
-        $this->assertTrue($coords->inside($point));
-
-        $point = new QtiPoint(10, 9); // 10, 9 is outside.
-        $this->assertFalse($coords->inside($point));
-
-        $point = new QtiPoint(3, 2); // 3, 2 is outside.
-        $this->assertFalse($coords->inside($point));
-
-        $point = new QtiPoint(1, 2); // 1, 2 is inside;
-        $this->assertTrue($coords->inside($point));
-
-        $point = new QtiPoint(-1, -1); // -1, -1 is outside.
-        $this->assertFalse($coords->inside($point));
-
-        $point = new QtiPoint(6, 4); // 6, 4 is inside.
-        $this->assertTrue($coords->inside($point));
-    }
-
-    public function testOnEdgePolygon()
-    {
-        $coords = new QtiCoords(QtiShape::POLY, [0, 0, 0, 3, 3, 0]);
-        $point = new QtiPoint(0, 2);
-        $this->assertTrue($coords->inside($point));
-    }
-
-    public function testInsideDefault()
-    {
-        // always true.
-        $coords = new QtiCoords(QtiShape::DEF);
-        $this->assertTrue($coords->inside(new QtiPoint(0, 0)));
-        $this->assertTrue($coords->inside(new QtiPoint(100, 200)));
-        $this->assertTrue($coords->inside(new QtiPoint(-200, -100)));
-    }
+    
+	public function testInsideCircle() {
+		$coords = new QtiCoords(QtiShape::CIRCLE, array(5, 5, 5));
+		
+		$point = new QtiPoint(1, 1); // 1,1 is outside
+		$this->assertFalse($coords->inside($point));
+		
+		$point = new QtiPoint(3, 3); // 3,3 is inside
+		$this->assertTrue($coords->inside($point));
+		
+		$point = new QtiPoint(5, 5); // 5,5 is inside
+		$this->assertTrue($coords->inside($point));
+		
+		$point = new QtiPoint(10, 10); // 10,10 is outside
+		$this->assertFalse($coords->inside($point));
+	}
+	
+	public function testInsideRectangle() {
+		// Do not forget (x1, y1) -> left top corner, (x2, y2) -> right bottom corner. 
+		$coords = new QtiCoords(QtiShape::RECT, array(0, 0, 5, 3));
+		
+		$point = new QtiPoint(0, 0); // 0, 0 is inside.
+		$this->assertTrue($coords->inside($point));
+		
+		$point = new QtiPoint(-1, -1); // -1, -1 is outside.
+		$this->assertFalse($coords->inside($point));
+		
+		$point = new QtiPoint(2, 1); // 2, 1 is inside.
+		$this->assertTrue($coords->inside($point));
+		
+		$point = new QtiPoint(5, 3); // 5, 3 is inside.
+		$this->assertTrue($coords->inside($point));
+		
+		$point = new QtiPoint(5, 4); // 5, 4 is outside.
+		$this->assertFalse($coords->inside($point));
+	}
+	
+	public function testInsidePolygon() {
+		$coords = new QtiCoords(QtiShape::POLY, array(0, 8, 7, 4, 2, 2, 8, -4, -2, 1));
+		
+		$point = new QtiPoint(0, 8); // 0, 8 is inside.
+		$this->assertTrue($coords->inside($point));
+		
+		$point = new QtiPoint(10, 9); // 10, 9 is outside.
+		$this->assertFalse($coords->inside($point));
+		
+		$point = new QtiPoint(3, 2); // 3, 2 is outside.
+		$this->assertFalse($coords->inside($point));
+		
+		$point = new QtiPoint(1, 2); // 1, 2 is inside;
+		$this->assertTrue($coords->inside($point));
+		
+		$point = new QtiPoint(-1, -1); // -1, -1 is outside.
+		$this->assertFalse($coords->inside($point));
+		
+		$point = new QtiPoint(6, 4); // 6, 4 is inside.
+		$this->assertTrue($coords->inside($point));
+	}
+	
+	public function testOnEdgePolygon() {
+	    $coords = new QtiCoords(QtiShape::POLY, array(0, 0, 0, 3, 3, 0));
+	    $point = new QtiPoint(0, 2);
+	    $this->assertTrue($coords->inside($point));
+	}
+	
+	public function testInsideDefault() {
+		// always true.
+		$coords = new QtiCoords(QtiShape::DEF);
+		$this->assertTrue($coords->inside(new QtiPoint(0, 0)));
+		$this->assertTrue($coords->inside(new QtiPoint(100, 200)));
+		$this->assertTrue($coords->inside(new QtiPoint(-200, -100)));
+	}
 }

--- a/test/qtismtest/common/datatypes/CoordsTest.php
+++ b/test/qtismtest/common/datatypes/CoordsTest.php
@@ -1,91 +1,98 @@
 <?php
+
 namespace qtismtest\common\datatypes;
 
-use qtismtest\QtiSmTestCase;
-use qtism\common\datatypes\QtiShape;
 use qtism\common\datatypes\QtiCoords;
 use qtism\common\datatypes\QtiPoint;
-use qtism\common\enums\Cardinality;
+use qtism\common\datatypes\QtiShape;
 use qtism\common\enums\BaseType;
+use qtism\common\enums\Cardinality;
+use qtismtest\QtiSmTestCase;
 
-class CoordsTest extends QtiSmTestCase {
-
-    public function testInstantiate() {
-        $coords = new QtiCoords(QtiShape::POLY, array(0, 0, 0, 3, 3, 0));
+class CoordsTest extends QtiSmTestCase
+{
+    public function testInstantiate()
+    {
+        $coords = new QtiCoords(QtiShape::POLY, [0, 0, 0, 3, 3, 0]);
         $this->assertEquals(BaseType::COORDS, $coords->getBaseType());
         $this->assertEquals(Cardinality::SINGLE, $coords->getCardinality());
         $this->assertEquals('0,0,0,3,3,0', $coords->getValue());
     }
-    
-	public function testInsideCircle() {
-		$coords = new QtiCoords(QtiShape::CIRCLE, array(5, 5, 5));
-		
-		$point = new QtiPoint(1, 1); // 1,1 is outside
-		$this->assertFalse($coords->inside($point));
-		
-		$point = new QtiPoint(3, 3); // 3,3 is inside
-		$this->assertTrue($coords->inside($point));
-		
-		$point = new QtiPoint(5, 5); // 5,5 is inside
-		$this->assertTrue($coords->inside($point));
-		
-		$point = new QtiPoint(10, 10); // 10,10 is outside
-		$this->assertFalse($coords->inside($point));
-	}
-	
-	public function testInsideRectangle() {
-		// Do not forget (x1, y1) -> left top corner, (x2, y2) -> right bottom corner. 
-		$coords = new QtiCoords(QtiShape::RECT, array(0, 0, 5, 3));
-		
-		$point = new QtiPoint(0, 0); // 0, 0 is inside.
-		$this->assertTrue($coords->inside($point));
-		
-		$point = new QtiPoint(-1, -1); // -1, -1 is outside.
-		$this->assertFalse($coords->inside($point));
-		
-		$point = new QtiPoint(2, 1); // 2, 1 is inside.
-		$this->assertTrue($coords->inside($point));
-		
-		$point = new QtiPoint(5, 3); // 5, 3 is inside.
-		$this->assertTrue($coords->inside($point));
-		
-		$point = new QtiPoint(5, 4); // 5, 4 is outside.
-		$this->assertFalse($coords->inside($point));
-	}
-	
-	public function testInsidePolygon() {
-		$coords = new QtiCoords(QtiShape::POLY, array(0, 8, 7, 4, 2, 2, 8, -4, -2, 1));
-		
-		$point = new QtiPoint(0, 8); // 0, 8 is inside.
-		$this->assertTrue($coords->inside($point));
-		
-		$point = new QtiPoint(10, 9); // 10, 9 is outside.
-		$this->assertFalse($coords->inside($point));
-		
-		$point = new QtiPoint(3, 2); // 3, 2 is outside.
-		$this->assertFalse($coords->inside($point));
-		
-		$point = new QtiPoint(1, 2); // 1, 2 is inside;
-		$this->assertTrue($coords->inside($point));
-		
-		$point = new QtiPoint(-1, -1); // -1, -1 is outside.
-		$this->assertFalse($coords->inside($point));
-		
-		$point = new QtiPoint(6, 4); // 6, 4 is inside.
-		$this->assertTrue($coords->inside($point));
-	}
-	
-	public function testOnEdgePolygon() {
-	    $coords = new QtiCoords(QtiShape::POLY, array(0, 0, 0, 3, 3, 0));
-	    $point = new QtiPoint(0, 2);
-	    $this->assertTrue($coords->inside($point));
-	}
-	
-	public function testInsideDefault() {
-		// always true.
-		$coords = new QtiCoords(QtiShape::DEF);
-		$this->assertTrue($coords->inside(new QtiPoint(0, 0)));
-		$this->assertTrue($coords->inside(new QtiPoint(100, 200)));
-		$this->assertTrue($coords->inside(new QtiPoint(-200, -100)));
-	}
+
+    public function testInsideCircle()
+    {
+        $coords = new QtiCoords(QtiShape::CIRCLE, [5, 5, 5]);
+
+        $point = new QtiPoint(1, 1); // 1,1 is outside
+        $this->assertFalse($coords->inside($point));
+
+        $point = new QtiPoint(3, 3); // 3,3 is inside
+        $this->assertTrue($coords->inside($point));
+
+        $point = new QtiPoint(5, 5); // 5,5 is inside
+        $this->assertTrue($coords->inside($point));
+
+        $point = new QtiPoint(10, 10); // 10,10 is outside
+        $this->assertFalse($coords->inside($point));
+    }
+
+    public function testInsideRectangle()
+    {
+        // Do not forget (x1, y1) -> left top corner, (x2, y2) -> right bottom corner. 
+        $coords = new QtiCoords(QtiShape::RECT, [0, 0, 5, 3]);
+
+        $point = new QtiPoint(0, 0); // 0, 0 is inside.
+        $this->assertTrue($coords->inside($point));
+
+        $point = new QtiPoint(-1, -1); // -1, -1 is outside.
+        $this->assertFalse($coords->inside($point));
+
+        $point = new QtiPoint(2, 1); // 2, 1 is inside.
+        $this->assertTrue($coords->inside($point));
+
+        $point = new QtiPoint(5, 3); // 5, 3 is inside.
+        $this->assertTrue($coords->inside($point));
+
+        $point = new QtiPoint(5, 4); // 5, 4 is outside.
+        $this->assertFalse($coords->inside($point));
+    }
+
+    public function testInsidePolygon()
+    {
+        $coords = new QtiCoords(QtiShape::POLY, [0, 8, 7, 4, 2, 2, 8, -4, -2, 1]);
+
+        $point = new QtiPoint(0, 8); // 0, 8 is inside.
+        $this->assertTrue($coords->inside($point));
+
+        $point = new QtiPoint(10, 9); // 10, 9 is outside.
+        $this->assertFalse($coords->inside($point));
+
+        $point = new QtiPoint(3, 2); // 3, 2 is outside.
+        $this->assertFalse($coords->inside($point));
+
+        $point = new QtiPoint(1, 2); // 1, 2 is inside;
+        $this->assertTrue($coords->inside($point));
+
+        $point = new QtiPoint(-1, -1); // -1, -1 is outside.
+        $this->assertFalse($coords->inside($point));
+
+        $point = new QtiPoint(6, 4); // 6, 4 is inside.
+        $this->assertTrue($coords->inside($point));
+    }
+
+    public function testOnEdgePolygon()
+    {
+        $coords = new QtiCoords(QtiShape::POLY, [0, 0, 0, 3, 3, 0]);
+        $point = new QtiPoint(0, 2);
+        $this->assertTrue($coords->inside($point));
+    }
+
+    public function testInsideDefault()
+    {
+        // always true.
+        $coords = new QtiCoords(QtiShape::DEF);
+        $this->assertTrue($coords->inside(new QtiPoint(0, 0)));
+        $this->assertTrue($coords->inside(new QtiPoint(100, 200)));
+        $this->assertTrue($coords->inside(new QtiPoint(-200, -100)));
+    }
 }

--- a/test/qtismtest/common/datatypes/DirectedPairTest.php
+++ b/test/qtismtest/common/datatypes/DirectedPairTest.php
@@ -14,7 +14,7 @@ class DirectedPairTest extends QtiSmTestCase {
 		$p4 = new QtiPair('A', 'B');
 		$p5 = new QtiDirectedPair('D', 'C');
 
-        $this->assertEquals('A B', $p1->getValue());
+		$this->assertEquals('A B', $p1->getValue());
 		
 		$this->assertTrue($p1->equals($p2));
 		$this->assertTrue($p2->equals($p1));

--- a/test/qtismtest/common/datatypes/DirectedPairTest.php
+++ b/test/qtismtest/common/datatypes/DirectedPairTest.php
@@ -13,6 +13,8 @@ class DirectedPairTest extends QtiSmTestCase {
 		$p3 = new QtiDirectedPair('C', 'D');
 		$p4 = new QtiPair('A', 'B');
 		$p5 = new QtiDirectedPair('D', 'C');
+
+        $this->assertEquals('A B', $p1->getValue());
 		
 		$this->assertTrue($p1->equals($p2));
 		$this->assertTrue($p2->equals($p1));
@@ -27,5 +29,7 @@ class DirectedPairTest extends QtiSmTestCase {
 		$p8 = new QtiDirectedPair('def', 'abc');
 		$this->assertFalse($p7->equals($p8));
 		$this->assertFalse($p8->equals($p7));
+		
+		$this->assertEquals('abc def', $p7->getValue());
 	}
 }

--- a/test/qtismtest/common/datatypes/DirectedPairTest.php
+++ b/test/qtismtest/common/datatypes/DirectedPairTest.php
@@ -1,35 +1,37 @@
 <?php
+
 namespace qtismtest\common\datatypes;
 
-use qtismtest\QtiSmTestCase;
-use qtism\common\datatypes\QtiPair;
 use qtism\common\datatypes\QtiDirectedPair;
+use qtism\common\datatypes\QtiPair;
+use qtismtest\QtiSmTestCase;
 
-class DirectedPairTest extends QtiSmTestCase {
-
-	public function testEquality() {
-		$p1 = new QtiDirectedPair('A', 'B');
-		$p2 = new QtiDirectedPair('A', 'B');
-		$p3 = new QtiDirectedPair('C', 'D');
-		$p4 = new QtiPair('A', 'B');
-		$p5 = new QtiDirectedPair('D', 'C');
+class DirectedPairTest extends QtiSmTestCase
+{
+    public function testEquality()
+    {
+        $p1 = new QtiDirectedPair('A', 'B');
+        $p2 = new QtiDirectedPair('A', 'B');
+        $p3 = new QtiDirectedPair('C', 'D');
+        $p4 = new QtiPair('A', 'B');
+        $p5 = new QtiDirectedPair('D', 'C');
 
         $this->assertEquals('A B', $p1->getValue());
-		
-		$this->assertTrue($p1->equals($p2));
-		$this->assertTrue($p2->equals($p1));
-		$this->assertFalse($p1->equals($p3));
-		$this->assertFalse($p3->equals($p1));
-		$this->assertFalse($p3->equals(1337));
-		$this->assertTrue($p3->equals($p3));
-		$this->assertFalse($p1->equals($p4));
-		$this->assertFalse($p3->equals($p5));
-		
-		$p7 = new QtiDirectedPair('abc', 'def');
-		$p8 = new QtiDirectedPair('def', 'abc');
-		$this->assertFalse($p7->equals($p8));
-		$this->assertFalse($p8->equals($p7));
-		
-		$this->assertEquals('abc def', $p7->getValue());
-	}
+
+        $this->assertTrue($p1->equals($p2));
+        $this->assertTrue($p2->equals($p1));
+        $this->assertFalse($p1->equals($p3));
+        $this->assertFalse($p3->equals($p1));
+        $this->assertFalse($p3->equals(1337));
+        $this->assertTrue($p3->equals($p3));
+        $this->assertFalse($p1->equals($p4));
+        $this->assertFalse($p3->equals($p5));
+
+        $p7 = new QtiDirectedPair('abc', 'def');
+        $p8 = new QtiDirectedPair('def', 'abc');
+        $this->assertFalse($p7->equals($p8));
+        $this->assertFalse($p8->equals($p7));
+
+        $this->assertEquals('abc def', $p7->getValue());
+    }
 }

--- a/test/qtismtest/common/datatypes/DirectedPairTest.php
+++ b/test/qtismtest/common/datatypes/DirectedPairTest.php
@@ -1,37 +1,35 @@
 <?php
-
 namespace qtismtest\common\datatypes;
 
-use qtism\common\datatypes\QtiDirectedPair;
-use qtism\common\datatypes\QtiPair;
 use qtismtest\QtiSmTestCase;
+use qtism\common\datatypes\QtiPair;
+use qtism\common\datatypes\QtiDirectedPair;
 
-class DirectedPairTest extends QtiSmTestCase
-{
-    public function testEquality()
-    {
-        $p1 = new QtiDirectedPair('A', 'B');
-        $p2 = new QtiDirectedPair('A', 'B');
-        $p3 = new QtiDirectedPair('C', 'D');
-        $p4 = new QtiPair('A', 'B');
-        $p5 = new QtiDirectedPair('D', 'C');
+class DirectedPairTest extends QtiSmTestCase {
+
+	public function testEquality() {
+		$p1 = new QtiDirectedPair('A', 'B');
+		$p2 = new QtiDirectedPair('A', 'B');
+		$p3 = new QtiDirectedPair('C', 'D');
+		$p4 = new QtiPair('A', 'B');
+		$p5 = new QtiDirectedPair('D', 'C');
 
         $this->assertEquals('A B', $p1->getValue());
-
-        $this->assertTrue($p1->equals($p2));
-        $this->assertTrue($p2->equals($p1));
-        $this->assertFalse($p1->equals($p3));
-        $this->assertFalse($p3->equals($p1));
-        $this->assertFalse($p3->equals(1337));
-        $this->assertTrue($p3->equals($p3));
-        $this->assertFalse($p1->equals($p4));
-        $this->assertFalse($p3->equals($p5));
-
-        $p7 = new QtiDirectedPair('abc', 'def');
-        $p8 = new QtiDirectedPair('def', 'abc');
-        $this->assertFalse($p7->equals($p8));
-        $this->assertFalse($p8->equals($p7));
-
-        $this->assertEquals('abc def', $p7->getValue());
-    }
+		
+		$this->assertTrue($p1->equals($p2));
+		$this->assertTrue($p2->equals($p1));
+		$this->assertFalse($p1->equals($p3));
+		$this->assertFalse($p3->equals($p1));
+		$this->assertFalse($p3->equals(1337));
+		$this->assertTrue($p3->equals($p3));
+		$this->assertFalse($p1->equals($p4));
+		$this->assertFalse($p3->equals($p5));
+		
+		$p7 = new QtiDirectedPair('abc', 'def');
+		$p8 = new QtiDirectedPair('def', 'abc');
+		$this->assertFalse($p7->equals($p8));
+		$this->assertFalse($p8->equals($p7));
+		
+		$this->assertEquals('abc def', $p7->getValue());
+	}
 }

--- a/test/qtismtest/common/datatypes/DurationTest.php
+++ b/test/qtismtest/common/datatypes/DurationTest.php
@@ -13,6 +13,7 @@ class DurationTest extends QtiSmTestCase {
 	public function testValidDurationCreation($intervalSpec) {
 		$duration = new QtiDuration($intervalSpec);
 		$this->assertInstanceOf('qtism\\common\\datatypes\\QtiDuration', $duration);
+        $this->assertEquals($intervalSpec, $duration->getValue());
 	}
 	
 	/**

--- a/test/qtismtest/common/datatypes/DurationTest.php
+++ b/test/qtismtest/common/datatypes/DurationTest.php
@@ -13,7 +13,7 @@ class DurationTest extends QtiSmTestCase {
 	public function testValidDurationCreation($intervalSpec) {
 		$duration = new QtiDuration($intervalSpec);
 		$this->assertInstanceOf('qtism\\common\\datatypes\\QtiDuration', $duration);
-        $this->assertEquals($intervalSpec, $duration->getValue());
+		$this->assertEquals($intervalSpec, $duration->getValue());
 	}
 	
 	/**

--- a/test/qtismtest/common/datatypes/DurationTest.php
+++ b/test/qtismtest/common/datatypes/DurationTest.php
@@ -1,198 +1,215 @@
 <?php
+
 namespace qtismtest\common\datatypes;
 
-use qtismtest\QtiSmTestCase;
+use DateInterval;
 use qtism\common\datatypes\QtiDuration;
-use \DateInterval;
+use qtismtest\QtiSmTestCase;
 
-class DurationTest extends QtiSmTestCase {
-	
-	/**
-	 * @dataProvider validDurationProvider
-	 */
-	public function testValidDurationCreation($intervalSpec) {
-		$duration = new QtiDuration($intervalSpec);
-		$this->assertInstanceOf('qtism\\common\\datatypes\\QtiDuration', $duration);
+class DurationTest extends QtiSmTestCase
+{
+    /**
+     * @dataProvider validDurationProvider
+     */
+    public function testValidDurationCreation($intervalSpec)
+    {
+        $duration = new QtiDuration($intervalSpec);
+        $this->assertInstanceOf('qtism\\common\\datatypes\\QtiDuration', $duration);
         $this->assertEquals($intervalSpec, $duration->getValue());
-	}
-	
-	/**
-	 * @dataProvider invalidDurationProvider
-	 */
-	public function testInvalidDurationCreation($intervalSpec) {
-		$this->setExpectedException('\\InvalidArgumentException');
-		$duration = new QtiDuration($intervalSpec);
-	}
-	
-	public function testPositiveDuration() {
-		$duration = new QtiDuration('P3YT6H8M'); // 2 years, 0 days, 6 hours, 8 minutes.
-		$this->assertEquals(3, $duration->getYears());
-		$this->assertEquals(0, $duration->getDays());
-		$this->assertEquals(6, $duration->getHours());
-		$this->assertEquals(8, $duration->getMinutes());
-		$this->assertEquals(0, $duration->getMonths());
-		$this->assertEquals(0, $duration->getSeconds());
-	}
-	
-	public function testEquality() {
-		$d1 = new QtiDuration('P1DT12H'); // 1 day + 12 hours.
-		$d2 = new QtiDuration('P1DT12H');
-		$d3 = new QtiDuration('PT3600S'); // 3600 seconds.
-		
-		$this->assertTrue($d1->equals($d2));
-		$this->assertTrue($d2->equals($d1));
-		$this->assertFalse($d1->equals($d3));
-		$this->assertFalse($d3->equals($d1));
-		$this->assertTrue($d3->equals($d3));
-	}
-	
-	public function testClone() {
-		$d = new QtiDuration('P1DT12H'); // 1 day + 12 hours.
-		$c = clone $d;
-		$this->assertFalse($c === $d);
-		$this->assertTrue($c->equals($d));
-		$this->assertEquals($d->getDays(), $c->getDays());
-		$this->assertEquals($d->getHours(), $c->getHours());
-		$this->assertEquals($d->getMinutes(), $c->getMinutes());
-		$this->assertEquals($d->getSeconds(), $c->getSeconds());
-		$this->assertEquals($d->getMonths(), $c->getMonths());
-		$this->assertEquals($d->getYears(), $c->getYears());
-	}
-	
-	/**
-	 * @dataProvider toStringProvider
-	 * 
-	 * @param Duration $duration
-	 * @param string $expected
-	 */
-	public function testToString(QtiDuration $duration, $expected) {
-		$this->assertEquals($duration->__toString(), $expected);
-	}
-	
-	public function testAdd() {
-		$d1 = new QtiDuration('PT1S');
-		$d2 = new QtiDuration('PT1S');
-		$d1->add($d2);
-		$this->assertEquals('PT2S', $d1->__toString());
-		
-		$d1 = new QtiDuration('PT23H59M59S');
-		$d2 = new QtiDuration('PT10S');
-		$d1->add($d2);
-		$this->assertEquals('P1DT9S', $d1->__toString());
-		
-		$d1 = new QtiDuration('PT1S');
-		$d2 = new DateInterval('PT1S');
-		$d1->add($d2);
-		$this->assertEquals('PT2S', $d1->__toString());
-	}
-	
-	public function testSub() {
-	    $d1 = new QtiDuration('PT2S');
-	    $d2 = new QtiDuration('PT1S');
-	    $d1->sub($d2);
-	    $this->assertEquals('PT1S', $d1->__toString());
-	    
-	    $d1 = new QtiDuration('PT2S');
-	    $d2 = new QtiDuration('PT4S');
-	    $d1->sub($d2);
-	    $this->assertEquals('PT0S', $d1->__toString());
-	    
-	    $d1 = new QtiDuration('P1DT2H25M30S');
-	    $d2 = new QtiDuration('P1DT2H');
-	    $d1->sub($d2);
-	    $this->assertEquals('PT25M30S', $d1->__toString());
-	    
-	    $d1 = new QtiDuration('PT20S');
-	    $d2 = new QtiDuration('PT20S');
-	    $d1->sub($d2);
-	    $this->assertEquals('PT0S', $d1->__toString());
-	    
-	    $d1 = new QtiDuration('PT20S');
-	    $d2 = new QtiDuration('PT21S');
-	    $d1->sub($d2);
-	    $this->assertTrue($d1->isNegative());
-	}
-	
-	public function createFromDateInterval() {
-	    $interval = new DateInterval('PT5S');
-	    $duration = QtiDuration::createFromDateInterval($interval);
-	    $this->assertEquals(5, $duration->getSeconds(true));
-	}
-		
-	/**
-	 * @dataProvider shorterThanProvider
-	 * 
-	 * @param Duration $duration1
-	 * @param Duration $duration2
-	 * @param boolean $expected
-	 */
-	public function testShorterThan(QtiDuration $duration1, QtiDuration $duration2, $expected) {
-		$this->assertSame($expected, $duration1->shorterThan($duration2));
-	}
-	
-	/**
-	 * @dataProvider longerThanOrEqualsProvider
-	 *
-	 * @param Duration $duration1
-	 * @param Duration $duration2
-	 * @param boolean $expected
-	 */
-	public function testLongerThanOrEquals(QtiDuration $duration1, QtiDuration $duration2, $expected) {
-		$this->assertSame($expected, $duration1->longerThanOrEquals($duration2));
-	}
-	
-	public function shorterThanProvider() {
-		$returnValue = array();
-		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P2Y'), true);
-		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P1Y'), false);
-		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P1YT2S'), true);
-		$returnValue[] = array(new QtiDuration('P2Y'), new QtiDuration('P1Y'), false);
-		$returnValue[] = array(new QtiDuration('PT0S'), new QtiDuration('PT1S'), true);
-		$returnValue[] = array(new QtiDuration('PT1H25M0S'), new QtiDuration('PT1H26M12S'), true);
-		$returnValue[] = array(new QtiDuration('PT1H26M12S'), new QtiDuration('PT1H25M0S'), false);
-		
-		return $returnValue;
-	}
-	
-	public function longerThanOrEqualsProvider() {
-		$returnValue = array();
-		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P2Y'), false);
-		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P1Y'), true);
-		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P1YT2S'), false);
-		$returnValue[] = array(new QtiDuration('P2Y'), new QtiDuration('P1Y'), true);
-		$returnValue[] = array(new QtiDuration('PT0S'), new QtiDuration('PT1S'), false);
-		$returnValue[] = array(new QtiDuration('PT1H25M0S'), new QtiDuration('PT1H26M12S'), false);
-		$returnValue[] = array(new QtiDuration('PT1H26M12S'), new QtiDuration('PT1H25M0S'), true);
-		$returnValue[] = array(new QtiDuration('PT1H26M'), new QtiDuration('PT1H26M'), true);
-		$returnValue[] = array(new QtiDuration('PT1M5S'), new QtiDuration('PT1M'), true);
-		$returnValue[] = array(new QtiDuration('PT1M15S'), new QtiDuration('PT45S'), true);
-	
-		return $returnValue;
-	}
-	
-	public function validDurationProvider() {
-		return array(
-			array('P2D'), // 2 days
-			array('PT2S'), // 2 seconds
-			array('P6YT5M') // 6 years, 5 months
-		);
-	}
-	
-	public function invalidDurationProvider() {
-		return array(
-			array('D2P'),
-			array('PSSST'),
-			array('Invalid'),
-			array('')
-		);
-	}
-	
-	public function toStringProvider() {
-		return array(
-			array(new QtiDuration('P2D'), 'P2D'), // 2 days
-			array(new QtiDuration('PT2S'), 'PT2S'), // 2 seconds
-			array(new QtiDuration('P6YT5M'), 'P6YT5M'), // 6 years, 5 months
-			array(new QtiDuration('PT0S'), 'PT0S'), // 0 seconds
-		);
-	}
+    }
+
+    /**
+     * @dataProvider invalidDurationProvider
+     */
+    public function testInvalidDurationCreation($intervalSpec)
+    {
+        $this->setExpectedException('\\InvalidArgumentException');
+        $duration = new QtiDuration($intervalSpec);
+    }
+
+    public function testPositiveDuration()
+    {
+        $duration = new QtiDuration('P3YT6H8M'); // 2 years, 0 days, 6 hours, 8 minutes.
+        $this->assertEquals(3, $duration->getYears());
+        $this->assertEquals(0, $duration->getDays());
+        $this->assertEquals(6, $duration->getHours());
+        $this->assertEquals(8, $duration->getMinutes());
+        $this->assertEquals(0, $duration->getMonths());
+        $this->assertEquals(0, $duration->getSeconds());
+    }
+
+    public function testEquality()
+    {
+        $d1 = new QtiDuration('P1DT12H'); // 1 day + 12 hours.
+        $d2 = new QtiDuration('P1DT12H');
+        $d3 = new QtiDuration('PT3600S'); // 3600 seconds.
+
+        $this->assertTrue($d1->equals($d2));
+        $this->assertTrue($d2->equals($d1));
+        $this->assertFalse($d1->equals($d3));
+        $this->assertFalse($d3->equals($d1));
+        $this->assertTrue($d3->equals($d3));
+    }
+
+    public function testClone()
+    {
+        $d = new QtiDuration('P1DT12H'); // 1 day + 12 hours.
+        $c = clone $d;
+        $this->assertFalse($c === $d);
+        $this->assertTrue($c->equals($d));
+        $this->assertEquals($d->getDays(), $c->getDays());
+        $this->assertEquals($d->getHours(), $c->getHours());
+        $this->assertEquals($d->getMinutes(), $c->getMinutes());
+        $this->assertEquals($d->getSeconds(), $c->getSeconds());
+        $this->assertEquals($d->getMonths(), $c->getMonths());
+        $this->assertEquals($d->getYears(), $c->getYears());
+    }
+
+    /**
+     * @dataProvider toStringProvider
+     *
+     * @param Duration $duration
+     * @param string $expected
+     */
+    public function testToString(QtiDuration $duration, $expected)
+    {
+        $this->assertEquals($duration->__toString(), $expected);
+    }
+
+    public function testAdd()
+    {
+        $d1 = new QtiDuration('PT1S');
+        $d2 = new QtiDuration('PT1S');
+        $d1->add($d2);
+        $this->assertEquals('PT2S', $d1->__toString());
+
+        $d1 = new QtiDuration('PT23H59M59S');
+        $d2 = new QtiDuration('PT10S');
+        $d1->add($d2);
+        $this->assertEquals('P1DT9S', $d1->__toString());
+
+        $d1 = new QtiDuration('PT1S');
+        $d2 = new DateInterval('PT1S');
+        $d1->add($d2);
+        $this->assertEquals('PT2S', $d1->__toString());
+    }
+
+    public function testSub()
+    {
+        $d1 = new QtiDuration('PT2S');
+        $d2 = new QtiDuration('PT1S');
+        $d1->sub($d2);
+        $this->assertEquals('PT1S', $d1->__toString());
+
+        $d1 = new QtiDuration('PT2S');
+        $d2 = new QtiDuration('PT4S');
+        $d1->sub($d2);
+        $this->assertEquals('PT0S', $d1->__toString());
+
+        $d1 = new QtiDuration('P1DT2H25M30S');
+        $d2 = new QtiDuration('P1DT2H');
+        $d1->sub($d2);
+        $this->assertEquals('PT25M30S', $d1->__toString());
+
+        $d1 = new QtiDuration('PT20S');
+        $d2 = new QtiDuration('PT20S');
+        $d1->sub($d2);
+        $this->assertEquals('PT0S', $d1->__toString());
+
+        $d1 = new QtiDuration('PT20S');
+        $d2 = new QtiDuration('PT21S');
+        $d1->sub($d2);
+        $this->assertTrue($d1->isNegative());
+    }
+
+    public function createFromDateInterval()
+    {
+        $interval = new DateInterval('PT5S');
+        $duration = QtiDuration::createFromDateInterval($interval);
+        $this->assertEquals(5, $duration->getSeconds(true));
+    }
+
+    /**
+     * @dataProvider shorterThanProvider
+     *
+     * @param Duration $duration1
+     * @param Duration $duration2
+     * @param boolean $expected
+     */
+    public function testShorterThan(QtiDuration $duration1, QtiDuration $duration2, $expected)
+    {
+        $this->assertSame($expected, $duration1->shorterThan($duration2));
+    }
+
+    /**
+     * @dataProvider longerThanOrEqualsProvider
+     *
+     * @param Duration $duration1
+     * @param Duration $duration2
+     * @param boolean $expected
+     */
+    public function testLongerThanOrEquals(QtiDuration $duration1, QtiDuration $duration2, $expected)
+    {
+        $this->assertSame($expected, $duration1->longerThanOrEquals($duration2));
+    }
+
+    public function shorterThanProvider()
+    {
+        $returnValue = [];
+        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P2Y'), true];
+        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P1Y'), false];
+        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P1YT2S'), true];
+        $returnValue[] = [new QtiDuration('P2Y'), new QtiDuration('P1Y'), false];
+        $returnValue[] = [new QtiDuration('PT0S'), new QtiDuration('PT1S'), true];
+        $returnValue[] = [new QtiDuration('PT1H25M0S'), new QtiDuration('PT1H26M12S'), true];
+        $returnValue[] = [new QtiDuration('PT1H26M12S'), new QtiDuration('PT1H25M0S'), false];
+
+        return $returnValue;
+    }
+
+    public function longerThanOrEqualsProvider()
+    {
+        $returnValue = [];
+        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P2Y'), false];
+        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P1Y'), true];
+        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P1YT2S'), false];
+        $returnValue[] = [new QtiDuration('P2Y'), new QtiDuration('P1Y'), true];
+        $returnValue[] = [new QtiDuration('PT0S'), new QtiDuration('PT1S'), false];
+        $returnValue[] = [new QtiDuration('PT1H25M0S'), new QtiDuration('PT1H26M12S'), false];
+        $returnValue[] = [new QtiDuration('PT1H26M12S'), new QtiDuration('PT1H25M0S'), true];
+        $returnValue[] = [new QtiDuration('PT1H26M'), new QtiDuration('PT1H26M'), true];
+        $returnValue[] = [new QtiDuration('PT1M5S'), new QtiDuration('PT1M'), true];
+        $returnValue[] = [new QtiDuration('PT1M15S'), new QtiDuration('PT45S'), true];
+
+        return $returnValue;
+    }
+
+    public function validDurationProvider()
+    {
+        return [
+            ['P2D'], // 2 days
+            ['PT2S'], // 2 seconds
+            ['P6YT5M'] // 6 years, 5 months
+        ];
+    }
+
+    public function invalidDurationProvider()
+    {
+        return [
+            ['D2P'],
+            ['PSSST'],
+            ['Invalid'],
+            [''],
+        ];
+    }
+
+    public function toStringProvider()
+    {
+        return [
+            [new QtiDuration('P2D'), 'P2D'], // 2 days
+            [new QtiDuration('PT2S'), 'PT2S'], // 2 seconds
+            [new QtiDuration('P6YT5M'), 'P6YT5M'], // 6 years, 5 months
+            [new QtiDuration('PT0S'), 'PT0S'], // 0 seconds
+        ];
+    }
 }

--- a/test/qtismtest/common/datatypes/DurationTest.php
+++ b/test/qtismtest/common/datatypes/DurationTest.php
@@ -1,215 +1,198 @@
 <?php
-
 namespace qtismtest\common\datatypes;
 
-use DateInterval;
-use qtism\common\datatypes\QtiDuration;
 use qtismtest\QtiSmTestCase;
+use qtism\common\datatypes\QtiDuration;
+use \DateInterval;
 
-class DurationTest extends QtiSmTestCase
-{
-    /**
-     * @dataProvider validDurationProvider
-     */
-    public function testValidDurationCreation($intervalSpec)
-    {
-        $duration = new QtiDuration($intervalSpec);
-        $this->assertInstanceOf('qtism\\common\\datatypes\\QtiDuration', $duration);
+class DurationTest extends QtiSmTestCase {
+	
+	/**
+	 * @dataProvider validDurationProvider
+	 */
+	public function testValidDurationCreation($intervalSpec) {
+		$duration = new QtiDuration($intervalSpec);
+		$this->assertInstanceOf('qtism\\common\\datatypes\\QtiDuration', $duration);
         $this->assertEquals($intervalSpec, $duration->getValue());
-    }
-
-    /**
-     * @dataProvider invalidDurationProvider
-     */
-    public function testInvalidDurationCreation($intervalSpec)
-    {
-        $this->setExpectedException('\\InvalidArgumentException');
-        $duration = new QtiDuration($intervalSpec);
-    }
-
-    public function testPositiveDuration()
-    {
-        $duration = new QtiDuration('P3YT6H8M'); // 2 years, 0 days, 6 hours, 8 minutes.
-        $this->assertEquals(3, $duration->getYears());
-        $this->assertEquals(0, $duration->getDays());
-        $this->assertEquals(6, $duration->getHours());
-        $this->assertEquals(8, $duration->getMinutes());
-        $this->assertEquals(0, $duration->getMonths());
-        $this->assertEquals(0, $duration->getSeconds());
-    }
-
-    public function testEquality()
-    {
-        $d1 = new QtiDuration('P1DT12H'); // 1 day + 12 hours.
-        $d2 = new QtiDuration('P1DT12H');
-        $d3 = new QtiDuration('PT3600S'); // 3600 seconds.
-
-        $this->assertTrue($d1->equals($d2));
-        $this->assertTrue($d2->equals($d1));
-        $this->assertFalse($d1->equals($d3));
-        $this->assertFalse($d3->equals($d1));
-        $this->assertTrue($d3->equals($d3));
-    }
-
-    public function testClone()
-    {
-        $d = new QtiDuration('P1DT12H'); // 1 day + 12 hours.
-        $c = clone $d;
-        $this->assertFalse($c === $d);
-        $this->assertTrue($c->equals($d));
-        $this->assertEquals($d->getDays(), $c->getDays());
-        $this->assertEquals($d->getHours(), $c->getHours());
-        $this->assertEquals($d->getMinutes(), $c->getMinutes());
-        $this->assertEquals($d->getSeconds(), $c->getSeconds());
-        $this->assertEquals($d->getMonths(), $c->getMonths());
-        $this->assertEquals($d->getYears(), $c->getYears());
-    }
-
-    /**
-     * @dataProvider toStringProvider
-     *
-     * @param Duration $duration
-     * @param string $expected
-     */
-    public function testToString(QtiDuration $duration, $expected)
-    {
-        $this->assertEquals($duration->__toString(), $expected);
-    }
-
-    public function testAdd()
-    {
-        $d1 = new QtiDuration('PT1S');
-        $d2 = new QtiDuration('PT1S');
-        $d1->add($d2);
-        $this->assertEquals('PT2S', $d1->__toString());
-
-        $d1 = new QtiDuration('PT23H59M59S');
-        $d2 = new QtiDuration('PT10S');
-        $d1->add($d2);
-        $this->assertEquals('P1DT9S', $d1->__toString());
-
-        $d1 = new QtiDuration('PT1S');
-        $d2 = new DateInterval('PT1S');
-        $d1->add($d2);
-        $this->assertEquals('PT2S', $d1->__toString());
-    }
-
-    public function testSub()
-    {
-        $d1 = new QtiDuration('PT2S');
-        $d2 = new QtiDuration('PT1S');
-        $d1->sub($d2);
-        $this->assertEquals('PT1S', $d1->__toString());
-
-        $d1 = new QtiDuration('PT2S');
-        $d2 = new QtiDuration('PT4S');
-        $d1->sub($d2);
-        $this->assertEquals('PT0S', $d1->__toString());
-
-        $d1 = new QtiDuration('P1DT2H25M30S');
-        $d2 = new QtiDuration('P1DT2H');
-        $d1->sub($d2);
-        $this->assertEquals('PT25M30S', $d1->__toString());
-
-        $d1 = new QtiDuration('PT20S');
-        $d2 = new QtiDuration('PT20S');
-        $d1->sub($d2);
-        $this->assertEquals('PT0S', $d1->__toString());
-
-        $d1 = new QtiDuration('PT20S');
-        $d2 = new QtiDuration('PT21S');
-        $d1->sub($d2);
-        $this->assertTrue($d1->isNegative());
-    }
-
-    public function createFromDateInterval()
-    {
-        $interval = new DateInterval('PT5S');
-        $duration = QtiDuration::createFromDateInterval($interval);
-        $this->assertEquals(5, $duration->getSeconds(true));
-    }
-
-    /**
-     * @dataProvider shorterThanProvider
-     *
-     * @param Duration $duration1
-     * @param Duration $duration2
-     * @param boolean $expected
-     */
-    public function testShorterThan(QtiDuration $duration1, QtiDuration $duration2, $expected)
-    {
-        $this->assertSame($expected, $duration1->shorterThan($duration2));
-    }
-
-    /**
-     * @dataProvider longerThanOrEqualsProvider
-     *
-     * @param Duration $duration1
-     * @param Duration $duration2
-     * @param boolean $expected
-     */
-    public function testLongerThanOrEquals(QtiDuration $duration1, QtiDuration $duration2, $expected)
-    {
-        $this->assertSame($expected, $duration1->longerThanOrEquals($duration2));
-    }
-
-    public function shorterThanProvider()
-    {
-        $returnValue = [];
-        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P2Y'), true];
-        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P1Y'), false];
-        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P1YT2S'), true];
-        $returnValue[] = [new QtiDuration('P2Y'), new QtiDuration('P1Y'), false];
-        $returnValue[] = [new QtiDuration('PT0S'), new QtiDuration('PT1S'), true];
-        $returnValue[] = [new QtiDuration('PT1H25M0S'), new QtiDuration('PT1H26M12S'), true];
-        $returnValue[] = [new QtiDuration('PT1H26M12S'), new QtiDuration('PT1H25M0S'), false];
-
-        return $returnValue;
-    }
-
-    public function longerThanOrEqualsProvider()
-    {
-        $returnValue = [];
-        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P2Y'), false];
-        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P1Y'), true];
-        $returnValue[] = [new QtiDuration('P1Y'), new QtiDuration('P1YT2S'), false];
-        $returnValue[] = [new QtiDuration('P2Y'), new QtiDuration('P1Y'), true];
-        $returnValue[] = [new QtiDuration('PT0S'), new QtiDuration('PT1S'), false];
-        $returnValue[] = [new QtiDuration('PT1H25M0S'), new QtiDuration('PT1H26M12S'), false];
-        $returnValue[] = [new QtiDuration('PT1H26M12S'), new QtiDuration('PT1H25M0S'), true];
-        $returnValue[] = [new QtiDuration('PT1H26M'), new QtiDuration('PT1H26M'), true];
-        $returnValue[] = [new QtiDuration('PT1M5S'), new QtiDuration('PT1M'), true];
-        $returnValue[] = [new QtiDuration('PT1M15S'), new QtiDuration('PT45S'), true];
-
-        return $returnValue;
-    }
-
-    public function validDurationProvider()
-    {
-        return [
-            ['P2D'], // 2 days
-            ['PT2S'], // 2 seconds
-            ['P6YT5M'] // 6 years, 5 months
-        ];
-    }
-
-    public function invalidDurationProvider()
-    {
-        return [
-            ['D2P'],
-            ['PSSST'],
-            ['Invalid'],
-            [''],
-        ];
-    }
-
-    public function toStringProvider()
-    {
-        return [
-            [new QtiDuration('P2D'), 'P2D'], // 2 days
-            [new QtiDuration('PT2S'), 'PT2S'], // 2 seconds
-            [new QtiDuration('P6YT5M'), 'P6YT5M'], // 6 years, 5 months
-            [new QtiDuration('PT0S'), 'PT0S'], // 0 seconds
-        ];
-    }
+	}
+	
+	/**
+	 * @dataProvider invalidDurationProvider
+	 */
+	public function testInvalidDurationCreation($intervalSpec) {
+		$this->setExpectedException('\\InvalidArgumentException');
+		$duration = new QtiDuration($intervalSpec);
+	}
+	
+	public function testPositiveDuration() {
+		$duration = new QtiDuration('P3YT6H8M'); // 2 years, 0 days, 6 hours, 8 minutes.
+		$this->assertEquals(3, $duration->getYears());
+		$this->assertEquals(0, $duration->getDays());
+		$this->assertEquals(6, $duration->getHours());
+		$this->assertEquals(8, $duration->getMinutes());
+		$this->assertEquals(0, $duration->getMonths());
+		$this->assertEquals(0, $duration->getSeconds());
+	}
+	
+	public function testEquality() {
+		$d1 = new QtiDuration('P1DT12H'); // 1 day + 12 hours.
+		$d2 = new QtiDuration('P1DT12H');
+		$d3 = new QtiDuration('PT3600S'); // 3600 seconds.
+		
+		$this->assertTrue($d1->equals($d2));
+		$this->assertTrue($d2->equals($d1));
+		$this->assertFalse($d1->equals($d3));
+		$this->assertFalse($d3->equals($d1));
+		$this->assertTrue($d3->equals($d3));
+	}
+	
+	public function testClone() {
+		$d = new QtiDuration('P1DT12H'); // 1 day + 12 hours.
+		$c = clone $d;
+		$this->assertFalse($c === $d);
+		$this->assertTrue($c->equals($d));
+		$this->assertEquals($d->getDays(), $c->getDays());
+		$this->assertEquals($d->getHours(), $c->getHours());
+		$this->assertEquals($d->getMinutes(), $c->getMinutes());
+		$this->assertEquals($d->getSeconds(), $c->getSeconds());
+		$this->assertEquals($d->getMonths(), $c->getMonths());
+		$this->assertEquals($d->getYears(), $c->getYears());
+	}
+	
+	/**
+	 * @dataProvider toStringProvider
+	 * 
+	 * @param Duration $duration
+	 * @param string $expected
+	 */
+	public function testToString(QtiDuration $duration, $expected) {
+		$this->assertEquals($duration->__toString(), $expected);
+	}
+	
+	public function testAdd() {
+		$d1 = new QtiDuration('PT1S');
+		$d2 = new QtiDuration('PT1S');
+		$d1->add($d2);
+		$this->assertEquals('PT2S', $d1->__toString());
+		
+		$d1 = new QtiDuration('PT23H59M59S');
+		$d2 = new QtiDuration('PT10S');
+		$d1->add($d2);
+		$this->assertEquals('P1DT9S', $d1->__toString());
+		
+		$d1 = new QtiDuration('PT1S');
+		$d2 = new DateInterval('PT1S');
+		$d1->add($d2);
+		$this->assertEquals('PT2S', $d1->__toString());
+	}
+	
+	public function testSub() {
+	    $d1 = new QtiDuration('PT2S');
+	    $d2 = new QtiDuration('PT1S');
+	    $d1->sub($d2);
+	    $this->assertEquals('PT1S', $d1->__toString());
+	    
+	    $d1 = new QtiDuration('PT2S');
+	    $d2 = new QtiDuration('PT4S');
+	    $d1->sub($d2);
+	    $this->assertEquals('PT0S', $d1->__toString());
+	    
+	    $d1 = new QtiDuration('P1DT2H25M30S');
+	    $d2 = new QtiDuration('P1DT2H');
+	    $d1->sub($d2);
+	    $this->assertEquals('PT25M30S', $d1->__toString());
+	    
+	    $d1 = new QtiDuration('PT20S');
+	    $d2 = new QtiDuration('PT20S');
+	    $d1->sub($d2);
+	    $this->assertEquals('PT0S', $d1->__toString());
+	    
+	    $d1 = new QtiDuration('PT20S');
+	    $d2 = new QtiDuration('PT21S');
+	    $d1->sub($d2);
+	    $this->assertTrue($d1->isNegative());
+	}
+	
+	public function createFromDateInterval() {
+	    $interval = new DateInterval('PT5S');
+	    $duration = QtiDuration::createFromDateInterval($interval);
+	    $this->assertEquals(5, $duration->getSeconds(true));
+	}
+		
+	/**
+	 * @dataProvider shorterThanProvider
+	 * 
+	 * @param Duration $duration1
+	 * @param Duration $duration2
+	 * @param boolean $expected
+	 */
+	public function testShorterThan(QtiDuration $duration1, QtiDuration $duration2, $expected) {
+		$this->assertSame($expected, $duration1->shorterThan($duration2));
+	}
+	
+	/**
+	 * @dataProvider longerThanOrEqualsProvider
+	 *
+	 * @param Duration $duration1
+	 * @param Duration $duration2
+	 * @param boolean $expected
+	 */
+	public function testLongerThanOrEquals(QtiDuration $duration1, QtiDuration $duration2, $expected) {
+		$this->assertSame($expected, $duration1->longerThanOrEquals($duration2));
+	}
+	
+	public function shorterThanProvider() {
+		$returnValue = array();
+		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P2Y'), true);
+		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P1Y'), false);
+		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P1YT2S'), true);
+		$returnValue[] = array(new QtiDuration('P2Y'), new QtiDuration('P1Y'), false);
+		$returnValue[] = array(new QtiDuration('PT0S'), new QtiDuration('PT1S'), true);
+		$returnValue[] = array(new QtiDuration('PT1H25M0S'), new QtiDuration('PT1H26M12S'), true);
+		$returnValue[] = array(new QtiDuration('PT1H26M12S'), new QtiDuration('PT1H25M0S'), false);
+		
+		return $returnValue;
+	}
+	
+	public function longerThanOrEqualsProvider() {
+		$returnValue = array();
+		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P2Y'), false);
+		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P1Y'), true);
+		$returnValue[] = array(new QtiDuration('P1Y'), new QtiDuration('P1YT2S'), false);
+		$returnValue[] = array(new QtiDuration('P2Y'), new QtiDuration('P1Y'), true);
+		$returnValue[] = array(new QtiDuration('PT0S'), new QtiDuration('PT1S'), false);
+		$returnValue[] = array(new QtiDuration('PT1H25M0S'), new QtiDuration('PT1H26M12S'), false);
+		$returnValue[] = array(new QtiDuration('PT1H26M12S'), new QtiDuration('PT1H25M0S'), true);
+		$returnValue[] = array(new QtiDuration('PT1H26M'), new QtiDuration('PT1H26M'), true);
+		$returnValue[] = array(new QtiDuration('PT1M5S'), new QtiDuration('PT1M'), true);
+		$returnValue[] = array(new QtiDuration('PT1M15S'), new QtiDuration('PT45S'), true);
+	
+		return $returnValue;
+	}
+	
+	public function validDurationProvider() {
+		return array(
+			array('P2D'), // 2 days
+			array('PT2S'), // 2 seconds
+			array('P6YT5M') // 6 years, 5 months
+		);
+	}
+	
+	public function invalidDurationProvider() {
+		return array(
+			array('D2P'),
+			array('PSSST'),
+			array('Invalid'),
+			array('')
+		);
+	}
+	
+	public function toStringProvider() {
+		return array(
+			array(new QtiDuration('P2D'), 'P2D'), // 2 days
+			array(new QtiDuration('PT2S'), 'PT2S'), // 2 seconds
+			array(new QtiDuration('P6YT5M'), 'P6YT5M'), // 6 years, 5 months
+			array(new QtiDuration('PT0S'), 'PT0S'), // 0 seconds
+		);
+	}
 }

--- a/test/qtismtest/common/datatypes/PairTest.php
+++ b/test/qtismtest/common/datatypes/PairTest.php
@@ -1,18 +1,16 @@
 <?php
-
 namespace qtismtest\common\datatypes;
 
-use qtism\common\datatypes\QtiPair;
 use qtismtest\QtiSmTestCase;
+use qtism\common\datatypes\QtiPair;
 
-class PairTest extends QtiSmTestCase
-{
-    public function testEquality()
-    {
-        $p1 = new QtiPair('A', 'B');
-        $p2 = new QtiPair('A', 'B');
-        $p3 = new QtiPair('C', 'D');
-        $p4 = new QtiPair('D', 'C');
+class PairTest extends QtiSmTestCase {
+
+	public function testEquality() {
+		$p1 = new QtiPair('A', 'B');
+		$p2 = new QtiPair('A', 'B');
+		$p3 = new QtiPair('C', 'D');
+		$p4 = new QtiPair('D', 'C');
 
         $this->assertEquals('A B', $p1->getValue());
         $this->assertEquals('A B', $p2->getValue());
@@ -20,23 +18,21 @@ class PairTest extends QtiSmTestCase
         $this->assertEquals('D C', $p4->getValue());
 
         $this->assertTrue($p1->equals($p2));
-        $this->assertTrue($p2->equals($p1));
-        $this->assertFalse($p1->equals($p3));
-        $this->assertFalse($p3->equals($p1));
-        $this->assertFalse($p3->equals(1337));
-        $this->assertTrue($p3->equals($p3));
-        $this->assertTrue($p4->equals($p3));
-    }
-
-    public function testInvalidFirstIdentifier()
-    {
-        $this->setExpectedException('\\InvalidArgumentException');
-        $pair = new QtiPair('_33', '33tt');
-    }
-
-    public function testInvalidSecondIdentifier()
-    {
-        $this->setExpectedException('\\InvalidArgumentException');
-        $pair = new QtiPair('33tt', '_33');
-    }
+		$this->assertTrue($p2->equals($p1));
+		$this->assertFalse($p1->equals($p3));
+		$this->assertFalse($p3->equals($p1));
+		$this->assertFalse($p3->equals(1337));
+		$this->assertTrue($p3->equals($p3));
+		$this->assertTrue($p4->equals($p3));
+	}
+	
+	public function testInvalidFirstIdentifier() {
+	    $this->setExpectedException('\\InvalidArgumentException');
+	    $pair = new QtiPair('_33', '33tt');
+	}
+	
+	public function testInvalidSecondIdentifier() {
+	    $this->setExpectedException('\\InvalidArgumentException');
+	    $pair = new QtiPair('33tt', '_33');
+	}
 }

--- a/test/qtismtest/common/datatypes/PairTest.php
+++ b/test/qtismtest/common/datatypes/PairTest.php
@@ -1,16 +1,18 @@
 <?php
+
 namespace qtismtest\common\datatypes;
 
-use qtismtest\QtiSmTestCase;
 use qtism\common\datatypes\QtiPair;
+use qtismtest\QtiSmTestCase;
 
-class PairTest extends QtiSmTestCase {
-
-	public function testEquality() {
-		$p1 = new QtiPair('A', 'B');
-		$p2 = new QtiPair('A', 'B');
-		$p3 = new QtiPair('C', 'D');
-		$p4 = new QtiPair('D', 'C');
+class PairTest extends QtiSmTestCase
+{
+    public function testEquality()
+    {
+        $p1 = new QtiPair('A', 'B');
+        $p2 = new QtiPair('A', 'B');
+        $p3 = new QtiPair('C', 'D');
+        $p4 = new QtiPair('D', 'C');
 
         $this->assertEquals('A B', $p1->getValue());
         $this->assertEquals('A B', $p2->getValue());
@@ -18,21 +20,23 @@ class PairTest extends QtiSmTestCase {
         $this->assertEquals('D C', $p4->getValue());
 
         $this->assertTrue($p1->equals($p2));
-		$this->assertTrue($p2->equals($p1));
-		$this->assertFalse($p1->equals($p3));
-		$this->assertFalse($p3->equals($p1));
-		$this->assertFalse($p3->equals(1337));
-		$this->assertTrue($p3->equals($p3));
-		$this->assertTrue($p4->equals($p3));
-	}
-	
-	public function testInvalidFirstIdentifier() {
-	    $this->setExpectedException('\\InvalidArgumentException');
-	    $pair = new QtiPair('_33', '33tt');
-	}
-	
-	public function testInvalidSecondIdentifier() {
-	    $this->setExpectedException('\\InvalidArgumentException');
-	    $pair = new QtiPair('33tt', '_33');
-	}
+        $this->assertTrue($p2->equals($p1));
+        $this->assertFalse($p1->equals($p3));
+        $this->assertFalse($p3->equals($p1));
+        $this->assertFalse($p3->equals(1337));
+        $this->assertTrue($p3->equals($p3));
+        $this->assertTrue($p4->equals($p3));
+    }
+
+    public function testInvalidFirstIdentifier()
+    {
+        $this->setExpectedException('\\InvalidArgumentException');
+        $pair = new QtiPair('_33', '33tt');
+    }
+
+    public function testInvalidSecondIdentifier()
+    {
+        $this->setExpectedException('\\InvalidArgumentException');
+        $pair = new QtiPair('33tt', '_33');
+    }
 }

--- a/test/qtismtest/common/datatypes/PairTest.php
+++ b/test/qtismtest/common/datatypes/PairTest.php
@@ -11,8 +11,13 @@ class PairTest extends QtiSmTestCase {
 		$p2 = new QtiPair('A', 'B');
 		$p3 = new QtiPair('C', 'D');
 		$p4 = new QtiPair('D', 'C');
-		
-		$this->assertTrue($p1->equals($p2));
+
+        $this->assertEquals('A B', $p1->getValue());
+        $this->assertEquals('A B', $p2->getValue());
+        $this->assertEquals('C D', $p3->getValue());
+        $this->assertEquals('D C', $p4->getValue());
+
+        $this->assertTrue($p1->equals($p2));
 		$this->assertTrue($p2->equals($p1));
 		$this->assertFalse($p1->equals($p3));
 		$this->assertFalse($p3->equals($p1));

--- a/test/qtismtest/common/datatypes/PairTest.php
+++ b/test/qtismtest/common/datatypes/PairTest.php
@@ -12,12 +12,12 @@ class PairTest extends QtiSmTestCase {
 		$p3 = new QtiPair('C', 'D');
 		$p4 = new QtiPair('D', 'C');
 
-        $this->assertEquals('A B', $p1->getValue());
-        $this->assertEquals('A B', $p2->getValue());
-        $this->assertEquals('C D', $p3->getValue());
-        $this->assertEquals('D C', $p4->getValue());
+		$this->assertEquals('A B', $p1->getValue());
+		$this->assertEquals('A B', $p2->getValue());
+		$this->assertEquals('C D', $p3->getValue());
+		$this->assertEquals('D C', $p4->getValue());
 
-        $this->assertTrue($p1->equals($p2));
+		$this->assertTrue($p1->equals($p2));
 		$this->assertTrue($p2->equals($p1));
 		$this->assertFalse($p1->equals($p3));
 		$this->assertFalse($p3->equals($p1));

--- a/test/qtismtest/common/datatypes/PointTest.php
+++ b/test/qtismtest/common/datatypes/PointTest.php
@@ -10,7 +10,11 @@ class PointTest extends QtiSmTestCase {
 		$p1 = new QtiPoint(10, 10);
 		$p2 = new QtiPoint(10, 10);
 		$p3 = new QtiPoint(100, 100);
-		
+
+        $this->assertEquals('10 10', $p1->getValue());
+        $this->assertEquals('10 10', $p2->getValue());
+        $this->assertEquals('100 100', $p3->getValue());
+
 		$this->assertTrue($p1->equals($p2));
 		$this->assertTrue($p2->equals($p1));
 		$this->assertFalse($p1->equals($p3));

--- a/test/qtismtest/common/datatypes/PointTest.php
+++ b/test/qtismtest/common/datatypes/PointTest.php
@@ -1,27 +1,25 @@
 <?php
-
 namespace qtismtest\common\datatypes;
 
-use qtism\common\datatypes\QtiPoint;
 use qtismtest\QtiSmTestCase;
+use qtism\common\datatypes\QtiPoint;
 
-class PointTest extends QtiSmTestCase
-{
-    public function testEquality()
-    {
-        $p1 = new QtiPoint(10, 10);
-        $p2 = new QtiPoint(10, 10);
-        $p3 = new QtiPoint(100, 100);
+class PointTest extends QtiSmTestCase {
+
+	public function testEquality() {
+		$p1 = new QtiPoint(10, 10);
+		$p2 = new QtiPoint(10, 10);
+		$p3 = new QtiPoint(100, 100);
 
         $this->assertEquals('10 10', $p1->getValue());
         $this->assertEquals('10 10', $p2->getValue());
         $this->assertEquals('100 100', $p3->getValue());
 
-        $this->assertTrue($p1->equals($p2));
-        $this->assertTrue($p2->equals($p1));
-        $this->assertFalse($p1->equals($p3));
-        $this->assertFalse($p3->equals($p1));
-        $this->assertFalse($p3->equals(1337));
-        $this->assertTrue($p3->equals($p3));
-    }
+		$this->assertTrue($p1->equals($p2));
+		$this->assertTrue($p2->equals($p1));
+		$this->assertFalse($p1->equals($p3));
+		$this->assertFalse($p3->equals($p1));
+		$this->assertFalse($p3->equals(1337));
+		$this->assertTrue($p3->equals($p3));
+	}
 }

--- a/test/qtismtest/common/datatypes/PointTest.php
+++ b/test/qtismtest/common/datatypes/PointTest.php
@@ -11,9 +11,9 @@ class PointTest extends QtiSmTestCase {
 		$p2 = new QtiPoint(10, 10);
 		$p3 = new QtiPoint(100, 100);
 
-        $this->assertEquals('10 10', $p1->getValue());
-        $this->assertEquals('10 10', $p2->getValue());
-        $this->assertEquals('100 100', $p3->getValue());
+		$this->assertEquals('10 10', $p1->getValue());
+		$this->assertEquals('10 10', $p2->getValue());
+		$this->assertEquals('100 100', $p3->getValue());
 
 		$this->assertTrue($p1->equals($p2));
 		$this->assertTrue($p2->equals($p1));

--- a/test/qtismtest/common/datatypes/PointTest.php
+++ b/test/qtismtest/common/datatypes/PointTest.php
@@ -1,25 +1,27 @@
 <?php
+
 namespace qtismtest\common\datatypes;
 
-use qtismtest\QtiSmTestCase;
 use qtism\common\datatypes\QtiPoint;
+use qtismtest\QtiSmTestCase;
 
-class PointTest extends QtiSmTestCase {
-
-	public function testEquality() {
-		$p1 = new QtiPoint(10, 10);
-		$p2 = new QtiPoint(10, 10);
-		$p3 = new QtiPoint(100, 100);
+class PointTest extends QtiSmTestCase
+{
+    public function testEquality()
+    {
+        $p1 = new QtiPoint(10, 10);
+        $p2 = new QtiPoint(10, 10);
+        $p3 = new QtiPoint(100, 100);
 
         $this->assertEquals('10 10', $p1->getValue());
         $this->assertEquals('10 10', $p2->getValue());
         $this->assertEquals('100 100', $p3->getValue());
 
-		$this->assertTrue($p1->equals($p2));
-		$this->assertTrue($p2->equals($p1));
-		$this->assertFalse($p1->equals($p3));
-		$this->assertFalse($p3->equals($p1));
-		$this->assertFalse($p3->equals(1337));
-		$this->assertTrue($p3->equals($p3));
-	}
+        $this->assertTrue($p1->equals($p2));
+        $this->assertTrue($p2->equals($p1));
+        $this->assertFalse($p1->equals($p3));
+        $this->assertFalse($p3->equals($p1));
+        $this->assertFalse($p3->equals(1337));
+        $this->assertTrue($p3->equals($p3));
+    }
 }

--- a/test/qtismtest/common/datatypes/files/FileSystemFileTest.php
+++ b/test/qtismtest/common/datatypes/files/FileSystemFileTest.php
@@ -16,6 +16,7 @@ class FileSystemFileTest extends QtiSmTestCase {
         $this->assertEquals($expectedFilename, $pFile->getFilename());
         $this->assertEquals($expectedMimeType, $pFile->getMimeType());
         $this->assertEquals($expectedData, $pFile->getData());
+        $this->assertEquals($expectedFilename, $pFile->getValue());
     }
     
     /**

--- a/test/qtismtest/common/datatypes/files/FileSystemFileTest.php
+++ b/test/qtismtest/common/datatypes/files/FileSystemFileTest.php
@@ -1,27 +1,29 @@
 <?php
+
 namespace qtismtest\common\datatypes\files;
 
-use qtismtest\QtiSmTestCase;
 use qtism\common\datatypes\files\FileSystemFile;
+use qtismtest\QtiSmTestCase;
 
-class FileSystemFileTest extends QtiSmTestCase {
-    
+class FileSystemFileTest extends QtiSmTestCase
+{
     /**
      * @dataProvider retrieveProvider
-     * 
+     *
      * @param string $path The path to the QTI file instance.
      */
-    public function testRetrieve($path, $expectedFilename, $expectedMimeType, $expectedData) {
+    public function testRetrieve($path, $expectedFilename, $expectedMimeType, $expectedData)
+    {
         $pFile = FileSystemFile::retrieveFile($path);
         $this->assertEquals($expectedFilename, $pFile->getFilename());
         $this->assertEquals($expectedMimeType, $pFile->getMimeType());
         $this->assertEquals($expectedData, $pFile->getData());
         $this->assertEquals($expectedFilename, $pFile->getValue());
     }
-    
+
     /**
      * @dataProvider createFromExistingFileProvider
-     * 
+     *
      * @param string $source
      * @param string $mimeType
      * @param boolean|string $withFilename
@@ -30,24 +32,23 @@ class FileSystemFileTest extends QtiSmTestCase {
     {
         $destination = tempnam('/tmp', 'qtism');
         $pFile = FileSystemFile::createFromExistingFile($source, $destination, $mimeType, $withFilename);
-        
+
         $expectedContent = file_get_contents($source);
-        
+
         if ($withFilename === true) {
             // Check if the name is the original one.
             $pathinfo = pathinfo($source);
             $this->assertEquals($pathinfo['basename'], $pFile->getFilename());
-        }
-        else {
+        } else {
             $this->assertEquals($withFilename, $pFile->getFilename());
         }
-        
+
         $this->assertEquals($expectedContent, $pFile->getData());
         $this->assertEquals($mimeType, $pFile->getMimeType());
         
         unlink($destination);
     }
-    
+
     public function testCreateFromExistingFileMalformedDestinationPath()
     {
         try {
@@ -56,13 +57,13 @@ class FileSystemFileTest extends QtiSmTestCase {
                 '/root/root/root/root.txt',
                 'text/plain'
             );
-            
+
             $this->assertFalse(true, "Should throw an error.");
         } catch (\RuntimeException $e) {
             $this->assertEquals("Unable to create destination directory at '/root/root/root'.", $e->getMessage());
         }
     }
-    
+
     public function testCreateFromExistingFileMalformedDestinationPathTwo()
     {
         try {
@@ -75,7 +76,7 @@ class FileSystemFileTest extends QtiSmTestCase {
             $this->assertInstanceOf('\\RuntimeException', $e);
         }
     }
-    
+
     public function testCreateFromExistingFileSourceIsNotAFile()
     {
         try {
@@ -89,11 +90,11 @@ class FileSystemFileTest extends QtiSmTestCase {
             $this->assertInstanceOf('\\RuntimeException', $e);
         }
     }
-    
+
     /**
      * @dataProvider getStreamProvider
-     * @depends testRetrieve
-     * 
+     * @depends      testRetrieve
+     *
      * @param string $path
      * @param string $expectedData
      */
@@ -101,18 +102,18 @@ class FileSystemFileTest extends QtiSmTestCase {
     {
         $pFile = FileSystemFile::retrieveFile($path);
         $stream = $pFile->getStream();
-        
+
         $data = '';
-        
+
         while (!feof($stream)) {
             $data .= fread($stream, 2048);
         }
-        
+
         @fclose($stream);
-        
+
         $this->assertEquals($expectedData, $data);
     }
-    
+
     public function testGetStreamError()
     {
         $path = tempnam(sys_get_temp_dir(), 'qtism');
@@ -120,10 +121,10 @@ class FileSystemFileTest extends QtiSmTestCase {
             $path,
             file_get_contents(self::samplesDir() . 'datatypes/file/text-plain_name.txt')
         );
-        
+
         $pFile = FileSystemFile::retrieveFile($path);
         @unlink($path);
-        
+
         try {
             $pFile->getStream();
             $this->assertFalse(true, "calling FileSystemFile::getStream() on a non-existing file must throw an exception!");
@@ -131,39 +132,39 @@ class FileSystemFileTest extends QtiSmTestCase {
             $this->assertTrue(true);
         }
     }
-    
+
     public function testInstantiationWrongPath()
     {
         $this->setExpectedException('\\RuntimeException');
         new FileSystemFile('/qtism/test');
     }
-    
+
     public function retrieveProvider()
     {
-        return array(
-            array(self::samplesDir() . 'datatypes/file/text-plain_name.txt', 'yours.txt', 'text/plain', ''),
-            array(self::samplesDir() . 'datatypes/file/text-plain_noname.txt', '', 'text/plain', ''),
-            array(self::samplesDir() . 'datatypes/file/text-plain_text_data.txt', 'text.txt', 'text/plain', 'Some text...'),
-        );
+        return [
+            [self::samplesDir() . 'datatypes/file/text-plain_name.txt', 'yours.txt', 'text/plain', ''],
+            [self::samplesDir() . 'datatypes/file/text-plain_noname.txt', '', 'text/plain', ''],
+            [self::samplesDir() . 'datatypes/file/text-plain_text_data.txt', 'text.txt', 'text/plain', 'Some text...'],
+        ];
     }
-    
+
     public function getStreamProvider()
     {
-        return array(
-            array(self::samplesDir() . 'datatypes/file/text-plain_name.txt', ''),          
-            array(self::samplesDir() . 'datatypes/file/text-plain_noname.txt', ''),
-            array(self::samplesDir() . 'datatypes/file/text-plain_text_data.txt', 'Some text...'),
-        );
+        return [
+            [self::samplesDir() . 'datatypes/file/text-plain_name.txt', ''],
+            [self::samplesDir() . 'datatypes/file/text-plain_noname.txt', ''],
+            [self::samplesDir() . 'datatypes/file/text-plain_text_data.txt', 'Some text...'],
+        ];
     }
-    
+
     public function createFromExistingFileProvider()
     {
-        return array(
-            array(self::samplesDir() . 'datatypes/file/raw/text.txt', 'text/plain', true),
-            array(self::samplesDir() . 'datatypes/file/raw/text.txt', 'text/plain', 'new-name.txt'),
-        );
+        return [
+            [self::samplesDir() . 'datatypes/file/raw/text.txt', 'text/plain', true],
+            [self::samplesDir() . 'datatypes/file/raw/text.txt', 'text/plain', 'new-name.txt'],
+        ];
     }
-    
+
     public function testEqualsNonQtiFile()
     {
         $destination = tempnam('/tmp', 'qtism');
@@ -175,7 +176,7 @@ class FileSystemFileTest extends QtiSmTestCase {
         $this->assertFalse($pFile->equals(new \stdClass()));
         @unlink($destination);
     }
-    
+
     public function testEqualsMimeTypeDifference()
     {
         $destination1 = tempnam('/tmp', 'qtism');
@@ -184,14 +185,14 @@ class FileSystemFileTest extends QtiSmTestCase {
             $destination1,
             'text/plain'
         );
-    
+
         $destination2 = tempnam('/tmp', 'qtism');
         $pFile2 = FileSystemFile::createFromExistingFile(
             self::samplesDir() . 'datatypes/file/text-css_name.txt',
             $destination2,
             'text/css'
         );
-        
+
         $this->assertFalse($pFile1->equals($pFile2));
         @unlink($destination1);
         @unlink($destination2);

--- a/test/qtismtest/common/datatypes/files/FileSystemFileTest.php
+++ b/test/qtismtest/common/datatypes/files/FileSystemFileTest.php
@@ -1,29 +1,27 @@
 <?php
-
 namespace qtismtest\common\datatypes\files;
 
-use qtism\common\datatypes\files\FileSystemFile;
 use qtismtest\QtiSmTestCase;
+use qtism\common\datatypes\files\FileSystemFile;
 
-class FileSystemFileTest extends QtiSmTestCase
-{
+class FileSystemFileTest extends QtiSmTestCase {
+    
     /**
      * @dataProvider retrieveProvider
-     *
+     * 
      * @param string $path The path to the QTI file instance.
      */
-    public function testRetrieve($path, $expectedFilename, $expectedMimeType, $expectedData)
-    {
+    public function testRetrieve($path, $expectedFilename, $expectedMimeType, $expectedData) {
         $pFile = FileSystemFile::retrieveFile($path);
         $this->assertEquals($expectedFilename, $pFile->getFilename());
         $this->assertEquals($expectedMimeType, $pFile->getMimeType());
         $this->assertEquals($expectedData, $pFile->getData());
         $this->assertEquals($expectedFilename, $pFile->getValue());
     }
-
+    
     /**
      * @dataProvider createFromExistingFileProvider
-     *
+     * 
      * @param string $source
      * @param string $mimeType
      * @param boolean|string $withFilename
@@ -32,23 +30,24 @@ class FileSystemFileTest extends QtiSmTestCase
     {
         $destination = tempnam('/tmp', 'qtism');
         $pFile = FileSystemFile::createFromExistingFile($source, $destination, $mimeType, $withFilename);
-
+        
         $expectedContent = file_get_contents($source);
-
+        
         if ($withFilename === true) {
             // Check if the name is the original one.
             $pathinfo = pathinfo($source);
             $this->assertEquals($pathinfo['basename'], $pFile->getFilename());
-        } else {
+        }
+        else {
             $this->assertEquals($withFilename, $pFile->getFilename());
         }
-
+        
         $this->assertEquals($expectedContent, $pFile->getData());
         $this->assertEquals($mimeType, $pFile->getMimeType());
         
         unlink($destination);
     }
-
+    
     public function testCreateFromExistingFileMalformedDestinationPath()
     {
         try {
@@ -57,13 +56,13 @@ class FileSystemFileTest extends QtiSmTestCase
                 '/root/root/root/root.txt',
                 'text/plain'
             );
-
+            
             $this->assertFalse(true, "Should throw an error.");
         } catch (\RuntimeException $e) {
             $this->assertEquals("Unable to create destination directory at '/root/root/root'.", $e->getMessage());
         }
     }
-
+    
     public function testCreateFromExistingFileMalformedDestinationPathTwo()
     {
         try {
@@ -76,7 +75,7 @@ class FileSystemFileTest extends QtiSmTestCase
             $this->assertInstanceOf('\\RuntimeException', $e);
         }
     }
-
+    
     public function testCreateFromExistingFileSourceIsNotAFile()
     {
         try {
@@ -90,11 +89,11 @@ class FileSystemFileTest extends QtiSmTestCase
             $this->assertInstanceOf('\\RuntimeException', $e);
         }
     }
-
+    
     /**
      * @dataProvider getStreamProvider
-     * @depends      testRetrieve
-     *
+     * @depends testRetrieve
+     * 
      * @param string $path
      * @param string $expectedData
      */
@@ -102,18 +101,18 @@ class FileSystemFileTest extends QtiSmTestCase
     {
         $pFile = FileSystemFile::retrieveFile($path);
         $stream = $pFile->getStream();
-
+        
         $data = '';
-
+        
         while (!feof($stream)) {
             $data .= fread($stream, 2048);
         }
-
+        
         @fclose($stream);
-
+        
         $this->assertEquals($expectedData, $data);
     }
-
+    
     public function testGetStreamError()
     {
         $path = tempnam(sys_get_temp_dir(), 'qtism');
@@ -121,10 +120,10 @@ class FileSystemFileTest extends QtiSmTestCase
             $path,
             file_get_contents(self::samplesDir() . 'datatypes/file/text-plain_name.txt')
         );
-
+        
         $pFile = FileSystemFile::retrieveFile($path);
         @unlink($path);
-
+        
         try {
             $pFile->getStream();
             $this->assertFalse(true, "calling FileSystemFile::getStream() on a non-existing file must throw an exception!");
@@ -132,39 +131,39 @@ class FileSystemFileTest extends QtiSmTestCase
             $this->assertTrue(true);
         }
     }
-
+    
     public function testInstantiationWrongPath()
     {
         $this->setExpectedException('\\RuntimeException');
         new FileSystemFile('/qtism/test');
     }
-
+    
     public function retrieveProvider()
     {
-        return [
-            [self::samplesDir() . 'datatypes/file/text-plain_name.txt', 'yours.txt', 'text/plain', ''],
-            [self::samplesDir() . 'datatypes/file/text-plain_noname.txt', '', 'text/plain', ''],
-            [self::samplesDir() . 'datatypes/file/text-plain_text_data.txt', 'text.txt', 'text/plain', 'Some text...'],
-        ];
+        return array(
+            array(self::samplesDir() . 'datatypes/file/text-plain_name.txt', 'yours.txt', 'text/plain', ''),
+            array(self::samplesDir() . 'datatypes/file/text-plain_noname.txt', '', 'text/plain', ''),
+            array(self::samplesDir() . 'datatypes/file/text-plain_text_data.txt', 'text.txt', 'text/plain', 'Some text...'),
+        );
     }
-
+    
     public function getStreamProvider()
     {
-        return [
-            [self::samplesDir() . 'datatypes/file/text-plain_name.txt', ''],
-            [self::samplesDir() . 'datatypes/file/text-plain_noname.txt', ''],
-            [self::samplesDir() . 'datatypes/file/text-plain_text_data.txt', 'Some text...'],
-        ];
+        return array(
+            array(self::samplesDir() . 'datatypes/file/text-plain_name.txt', ''),          
+            array(self::samplesDir() . 'datatypes/file/text-plain_noname.txt', ''),
+            array(self::samplesDir() . 'datatypes/file/text-plain_text_data.txt', 'Some text...'),
+        );
     }
-
+    
     public function createFromExistingFileProvider()
     {
-        return [
-            [self::samplesDir() . 'datatypes/file/raw/text.txt', 'text/plain', true],
-            [self::samplesDir() . 'datatypes/file/raw/text.txt', 'text/plain', 'new-name.txt'],
-        ];
+        return array(
+            array(self::samplesDir() . 'datatypes/file/raw/text.txt', 'text/plain', true),
+            array(self::samplesDir() . 'datatypes/file/raw/text.txt', 'text/plain', 'new-name.txt'),
+        );
     }
-
+    
     public function testEqualsNonQtiFile()
     {
         $destination = tempnam('/tmp', 'qtism');
@@ -176,7 +175,7 @@ class FileSystemFileTest extends QtiSmTestCase
         $this->assertFalse($pFile->equals(new \stdClass()));
         @unlink($destination);
     }
-
+    
     public function testEqualsMimeTypeDifference()
     {
         $destination1 = tempnam('/tmp', 'qtism');
@@ -185,14 +184,14 @@ class FileSystemFileTest extends QtiSmTestCase
             $destination1,
             'text/plain'
         );
-
+    
         $destination2 = tempnam('/tmp', 'qtism');
         $pFile2 = FileSystemFile::createFromExistingFile(
             self::samplesDir() . 'datatypes/file/text-css_name.txt',
             $destination2,
             'text/css'
         );
-
+        
         $this->assertFalse($pFile1->equals($pFile2));
         @unlink($destination1);
         @unlink($destination2);


### PR DESCRIPTION
This PR allows the usage of getValue method for all non-QtiScalar data types, using the implemented __toString method of each of these types.