### PR TITLE
Used legacy-compatible numbering for test session binary storage and added branch after version number.

### DIFF
--- a/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
@@ -46,13 +46,21 @@ class QtiBinaryVersion
      * These constants make the different versions a bit more self explanatory.
      */
     const VERSION_FIRST_MASTER = 10;
+
     const VERSION_POSITION_INTEGER = 9;
+
     const VERSION_ALWAYS_ALLOW_JUMPS = 8;
+
     const VERSION_TRACK_PATH = 7;
+
     const VERSION_FORCE_BRANCHING_PRECONDITIONS = 6;
+
     const VERSION_LAST_ACTION = 5;
+
     const VERSION_DURATIONS = 4;
+
     const VERSION_MULTIPLE_SECTIONS = 3;
+
     const VERSION_ATTEMPTING = 2;
 
     /**
@@ -67,7 +75,7 @@ class QtiBinaryVersion
 
     /**
      * Writes version into binary storage.
-     * 
+     *
      * @param QtiBinaryStreamAccess $access
      * @throws BinaryStreamAccessException
      */
@@ -79,7 +87,7 @@ class QtiBinaryVersion
 
     /**
      * Reads version from binary storage.
-     * 
+     *
      * @param QtiBinaryStreamAccess $access
      * @throws BinaryStreamAccessException
      */
@@ -107,27 +115,27 @@ class QtiBinaryVersion
         return $this->version = self::CURRENT_VERSION;
     }
 
-    public function isInBothBranches(): bool 
+    public function isInBothBranches(): bool
     {
         return $this->version >= self::VERSION_FIRST_MASTER;
     }
-    
-    public function storesPositionAndRouteCountAsInteger(): bool 
+
+    public function storesPositionAndRouteCountAsInteger(): bool
     {
         return $this->version >= self::VERSION_POSITION_INTEGER;
     }
-    
-    public function storesTrackPath(): bool 
+
+    public function storesTrackPath(): bool
     {
         return $this->version >= self::VERSION_TRACK_PATH;
     }
-    
-    public function storesAlwaysAllowJumps(): bool 
+
+    public function storesAlwaysAllowJumps(): bool
     {
         return $this->version >= self::VERSION_ALWAYS_ALLOW_JUMPS;
     }
-    
-    public function storesForceBranchingAndPreconditions(): bool 
+
+    public function storesForceBranchingAndPreconditions(): bool
     {
         return $this->version >= self::VERSION_FORCE_BRANCHING_PRECONDITIONS;
     }
@@ -137,17 +145,17 @@ class QtiBinaryVersion
         return $this->version >= self::VERSION_LAST_ACTION;
     }
 
-    public function storesDurations(): bool 
+    public function storesDurations(): bool
     {
         return $this->version >= self::VERSION_DURATIONS;
     }
-    
-    public function storesMultipleSections(): bool 
+
+    public function storesMultipleSections(): bool
     {
         return $this->version >= self::VERSION_MULTIPLE_SECTIONS;
     }
-    
-    public function storesAttempting(): bool 
+
+    public function storesAttempting(): bool
     {
         return $this->version >= self::VERSION_ATTEMPTING;
     }

--- a/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Julien Sébire <julien@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\runtime\storage\binary;
+
+use qtism\common\storage\BinaryStreamAccessException;
+
+class QtiBinaryVersion
+{
+    /**
+     * The QTI binary data version number.
+     *
+     * @var int
+     */
+    const CURRENT_VERSION = 10;
+
+    /**
+     * The QTI Sdk branch to select behaviour of the binary storage.
+     * 'M' denotes Master. 'L' denotes Legacy.
+     *
+     * @var string
+     */
+    const CURRENT_BRANCH = 'M';
+
+    /**
+     * These constants make the different versions a bit more self explanatory.
+     */
+    const VERSION_BOTH_BRANCHES = 10;
+    const VERSION_POSITION_INTEGER = 9;
+    const VERSION_ALWAYS_ALLOW_JUMPS = 8;
+    const VERSION_TRACK_PATH = 7;
+    const VERSION_FORCE_BRANCHING_PRECONDITIONS = 6;
+    const VERSION_DURATIONS = 4;
+    const VERSION_MULTIPLE_SECTIONS = 3;
+    const VERSION_ATTEMPTING = 2;
+
+    /**
+     * @var int
+     */
+    private $version;
+
+    /**
+     * @var string
+     */
+    private $branch;
+
+    /**
+     * Writes version into binary storage.
+     * 
+     * @param QtiBinaryStreamAccess $access
+     * @throws BinaryStreamAccessException
+     */
+    public function persist(QtiBinaryStreamAccess $access)
+    {
+        $access->writeTinyInt(self::CURRENT_VERSION);
+        $access->writeString(self::CURRENT_BRANCH);
+    }
+
+    /**
+     * Reads version from binary storage.
+     * 
+     * @param QtiBinaryStreamAccess $access
+     * @throws BinaryStreamAccessException
+     */
+    public function retrieve(QtiBinaryStreamAccess $access)
+    {
+        $this->version = $access->readTinyInt();
+
+        $this->branch = $this->isInBothBranches()
+            ? $access->readString()
+            : 'L';
+    }
+
+    public function isMaster(): bool
+    {
+        return $this->branch === 'M';
+    }
+
+    public function isLegacy(): bool
+    {
+        return $this->branch === 'L';
+    }
+
+    public function isInBothBranches(): bool 
+    {
+        return $this->version >= self::VERSION_BOTH_BRANCHES;
+    }
+    
+    public function storesPositionAndRouteCountAsInteger(): bool 
+    {
+        return $this->version >= self::VERSION_POSITION_INTEGER;
+    }
+    
+    public function storesTrackPath(): bool 
+    {
+        return $this->version >= self::VERSION_TRACK_PATH;
+    }
+    
+    public function storesAlwaysAllowJumps(): bool 
+    {
+        return $this->version >= self::VERSION_ALWAYS_ALLOW_JUMPS;
+    }
+    
+    public function storesForceBranchingAndPreconditions(): bool 
+    {
+        return $this->version >= self::VERSION_FORCE_BRANCHING_PRECONDITIONS;
+    }
+    
+    public function storesDurations(): bool 
+    {
+        return $this->version >= self::VERSION_DURATIONS;
+    }
+    
+    public function storesMultipleSections(): bool 
+    {
+        return $this->version >= self::VERSION_MULTIPLE_SECTIONS;
+    }
+    
+    public function storesAttempting(): bool 
+    {
+        return $this->version >= self::VERSION_ATTEMPTING;
+    }
+}

--- a/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
@@ -45,11 +45,12 @@ class QtiBinaryVersion
     /**
      * These constants make the different versions a bit more self explanatory.
      */
-    const VERSION_BOTH_BRANCHES = 10;
+    const VERSION_FIRST_MASTER = 10;
     const VERSION_POSITION_INTEGER = 9;
     const VERSION_ALWAYS_ALLOW_JUMPS = 8;
     const VERSION_TRACK_PATH = 7;
     const VERSION_FORCE_BRANCHING_PRECONDITIONS = 6;
+    const VERSION_LAST_ACTION = 5;
     const VERSION_DURATIONS = 4;
     const VERSION_MULTIPLE_SECTIONS = 3;
     const VERSION_ATTEMPTING = 2;
@@ -101,9 +102,14 @@ class QtiBinaryVersion
         return $this->branch === 'L';
     }
 
+    public function isCurrentVersion(): bool
+    {
+        return $this->version = self::CURRENT_VERSION;
+    }
+
     public function isInBothBranches(): bool 
     {
-        return $this->version >= self::VERSION_BOTH_BRANCHES;
+        return $this->version >= self::VERSION_FIRST_MASTER;
     }
     
     public function storesPositionAndRouteCountAsInteger(): bool 
@@ -125,7 +131,12 @@ class QtiBinaryVersion
     {
         return $this->version >= self::VERSION_FORCE_BRANCHING_PRECONDITIONS;
     }
-    
+
+    public function storesLastAction(): bool
+    {
+        return $this->version >= self::VERSION_LAST_ACTION;
+    }
+
     public function storesDurations(): bool 
     {
         return $this->version >= self::VERSION_DURATIONS;

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
@@ -61,8 +61,8 @@ class QtiBinaryVersionTest extends QtiSmTestCase
 
         $this->assertTrue($subject->isLegacy());
         $this->assertFalse($subject->isMaster());
-        
-        foreach($expectedFeatures as $featureMethod => $expectedSupported) {
+
+        foreach ($expectedFeatures as $featureMethod => $expectedSupported) {
             $this->assertEquals($expectedSupported, $subject->$featureMethod());
         }
     }
@@ -97,7 +97,7 @@ class QtiBinaryVersionTest extends QtiSmTestCase
         $this->assertFalse($subject->isLegacy());
         $this->assertTrue($subject->isMaster());
 
-        foreach($expectedFeatures as $featureMethod => $expectedSupported) {
+        foreach ($expectedFeatures as $featureMethod => $expectedSupported) {
             $this->assertEquals($expectedSupported, $subject->$featureMethod());
         }
     }

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace qtismtest\runtime\storage\binary;
+
+use qtism\common\datatypes\files\FileSystemFileManager;
+use qtism\common\storage\MemoryStream;
+use qtism\runtime\storage\binary\QtiBinaryStreamAccess;
+use qtism\runtime\storage\binary\QtiBinaryVersion;
+use qtismtest\QtiSmTestCase;
+
+class QtiBinaryVersionTest extends QtiSmTestCase
+{
+    public function testPersist()
+    {
+        $stream = new MemoryStream();
+        $stream->open();
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+
+        $subject = new QtiBinaryVersion();
+        $subject->persist($access);
+
+        // Persist must alwas persist the current version and the current branch.
+        $this->assertEquals(chr(QtiBinaryVersion::CURRENT_VERSION) . pack('S', 1) . 'M', $stream->getBinary());
+    }
+
+    public function testRetrieveCurrentLegacy()
+    {
+        $access = $this->createAccessMock(QtiBinaryVersion::CURRENT_VERSION, 'L');
+
+        $subject = new QtiBinaryVersion();
+        $subject->retrieve($access);
+
+        $this->assertEquals(QtiBinaryVersion::CURRENT_VERSION, $subject->isCurrentVersion());
+        $this->assertTrue($subject->isLegacy());
+        $this->assertFalse($subject->isMaster());
+    }
+
+    public function testRetrieveCurrentMaster()
+    {
+        $access = $this->createAccessMock(QtiBinaryVersion::CURRENT_VERSION, 'M');
+
+        $subject = new QtiBinaryVersion();
+        $subject->retrieve($access);
+
+        $this->assertEquals(QtiBinaryVersion::CURRENT_VERSION, $subject->isCurrentVersion());
+        $this->assertFalse($subject->isLegacy());
+        $this->assertTrue($subject->isMaster());
+    }
+
+    /**
+     * @dataProvider legacyFeaturesToTest
+     * @param int $versionNumber
+     * @throws \qtism\common\storage\BinaryStreamAccessException
+     */
+    public function testLegacyFeatures(int $versionNumber, array $expectedFeatures)
+    {
+        $access = $this->createAccessMock($versionNumber, 'L');
+
+        $subject = new QtiBinaryVersion();
+        $subject->retrieve($access);
+
+        $this->assertTrue($subject->isLegacy());
+        $this->assertFalse($subject->isMaster());
+        
+        foreach($expectedFeatures as $featureMethod => $expectedSupported) {
+            $this->assertEquals($expectedSupported, $subject->$featureMethod());
+        }
+    }
+
+    public function legacyFeaturesToTest(): array
+    {
+        return $this->createFeatureArray(
+            [
+                QtiBinaryVersion::VERSION_ATTEMPTING => 'storesAttempting',
+                QtiBinaryVersion::VERSION_MULTIPLE_SECTIONS => 'storesMultipleSections',
+                QtiBinaryVersion::VERSION_DURATIONS => 'storesDurations',
+                QtiBinaryVersion::VERSION_LAST_ACTION => 'storesLastAction',
+                QtiBinaryVersion::VERSION_FORCE_BRANCHING_PRECONDITIONS => 'storesForceBranchingAndPreconditions',
+                QtiBinaryVersion::VERSION_ALWAYS_ALLOW_JUMPS => 'storesAlwaysAllowJumps',
+                QtiBinaryVersion::VERSION_TRACK_PATH => 'storesTrackPath',
+                QtiBinaryVersion::VERSION_POSITION_INTEGER => 'storesPositionAndRouteCountAsInteger',
+                QtiBinaryVersion::VERSION_FIRST_MASTER => 'isInBothBranches',
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider masterFeaturesToTest
+     */
+    public function testMasterFeatures(int $versionNumber, array $expectedFeatures)
+    {
+        $access = $this->createAccessMock($versionNumber, 'M');
+
+        $subject = new QtiBinaryVersion();
+        $subject->retrieve($access);
+
+        $this->assertFalse($subject->isLegacy());
+        $this->assertTrue($subject->isMaster());
+
+        foreach($expectedFeatures as $featureMethod => $expectedSupported) {
+            $this->assertEquals($expectedSupported, $subject->$featureMethod());
+        }
+    }
+
+    public function masterFeaturesToTest(): array
+    {
+        return $this->createFeatureArray(
+            [
+                QtiBinaryVersion::VERSION_FIRST_MASTER => 'isInBothBranches',
+            ]
+        );
+    }
+
+    private function createFeatureArray(array $features): array
+    {
+        $return = [];
+
+        foreach ($features as $versionNumber => $featureMethod) {
+            $selectedFeatures = [];
+            foreach ($features as $selectedVersionNumber => $selectedFeatureMethod) {
+                $selectedFeatures [$selectedFeatureMethod] = $versionNumber >= $selectedVersionNumber;
+            }
+            $return[] = [$versionNumber, $selectedFeatures];
+        }
+
+        return $return;
+    }
+
+    public function createAccessMock(int $versionNumber, string $branch): QtiBinaryStreamAccess
+    {
+        $binary = chr($versionNumber);
+        if ($versionNumber >= QtiBinaryVersion::VERSION_FIRST_MASTER) {
+            $binary .= pack('S', 1) . $branch;
+        }
+        $stream = new MemoryStream($binary);
+        $stream->open();
+        return new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+    }
+}


### PR DESCRIPTION
This PR sets up a versioning for test session binary storage compatible with legacy branch, so that we can discriminate between master and legacy logic in retrieving test session.
A letter `M` for master and `L` for legacy is added after the version number, starting from version 10.
All versions below 10 are considered legacy version.
Also, detection of version by feature name is more readable.
