### PR TITLE
Fixed non scalar data model values for multiple cardinality.

### DIFF
--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -517,19 +517,32 @@ abstract class Variable
      */
     public function getDataModelValues()
     {
-        $values = new ValueCollection();
+        if ($this->getValue() === null) {
+            return new ValueCollection();
+        }
 
-        if ($this->getValue() !== null) {
-            if ($this->getCardinality() === Cardinality::SINGLE) {
-                $values[] = new Value(\qtism\data\storage\Utils::stringToDatatype($this->getValue() . '', $this->getBaseType()));
-            } elseif ($this->getValue() !== null && ($this->getCardinality() === Cardinality::MULTIPLE || $this->getCardinality() === Cardinality::ORDERED)) {
+        $values = new ValueCollection();
+        $cardinality = $this->getCardinality();
+
+        switch ($cardinality) {
+            case Cardinality::SINGLE:
+                $values[] = $this->createValue($this->getValue());
+                break;
+
+            case Cardinality::MULTIPLE:
+            case Cardinality::ORDERED:
                 foreach ($this->getValue() as $v) {
-                    $values[] = new Value(\qtism\data\storage\Utils::stringToDatatype($v->getValue() . '', $this->getBaseType()));
+                    $values[] = $this->createValue($v);
                 }
-            }
+                break;
         }
 
         return $values;
+    }
+
+    private function createValue(QtiDatatype $value): Value
+    {
+        return new Value(\qtism\data\storage\Utils::stringToDatatype((string)$value, $this->getBaseType()));
     }
 
     /**

--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -31,6 +31,7 @@ use qtism\common\enums\Cardinality;
 use qtism\data\state\Value;
 use qtism\data\state\ValueCollection;
 use qtism\data\state\VariableDeclaration;
+use qtism\data\storage\Utils as StorageUtils;
 use qtism\runtime\common\Utils as RuntimeUtils;
 use UnexpectedValueException;
 
@@ -542,7 +543,10 @@ abstract class Variable
 
     private function createValue(QtiDatatype $value): Value
     {
-        return new Value(\qtism\data\storage\Utils::stringToDatatype((string)$value, $this->getBaseType()));
+        return new Value(StorageUtils::stringToDatatype(
+            (string)$value,
+            $this->getBaseType())
+        );
     }
 
     /**

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -8,6 +8,7 @@ use qtism\common\datatypes\QtiInteger;
 use qtism\common\datatypes\QtiPair;
 use qtism\common\enums\BaseType;
 use qtism\common\enums\Cardinality;
+use qtism\runtime\common\MultipleContainer;
 use qtism\runtime\common\OrderedContainer;
 use qtism\runtime\common\ResponseVariable;
 use qtismtest\QtiSmTestCase;
@@ -100,7 +101,7 @@ class ResponseVariableTest extends QtiSmTestCase
         $this->assertFalse($responseVariable->isCorrect());
     }
 
-    public function testGetDataModelValuesSingleCardinality()
+    public function testGetScalarDataModelValuesSingleCardinality()
     {
         $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::INTEGER, new QtiInteger(10));
         $values = $responseVariable->getDataModelValues();
@@ -113,6 +114,51 @@ class ResponseVariableTest extends QtiSmTestCase
 
         $this->assertCount(1, $values);
         $this->assertSame(10.1, $values[0]->getValue());
+    }
+
+    public function testGetNonScalarDataModelValuesSingleCardinality()
+    {
+        $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::PAIR, new QtiPair('A', 'B'));
+        $values = $responseVariable->getDataModelValues();
+
+        $this->assertCount(1, $values);
+        $this->assertEquals(new QtiPair('A', 'B'), $values[0]->getValue());
+    }
+
+    public function testGetScalarDataModelValuesMultipleCardinality()
+    {
+        $responseVariable = new ResponseVariable(
+            'MYVAR',
+            Cardinality::MULTIPLE,
+            BaseType::INTEGER,
+            new MultipleContainer(
+                BaseType::INTEGER,
+                [new QtiInteger(10), new QtiInteger(12)]
+            )
+        );
+        $values = $responseVariable->getDataModelValues();
+
+        $this->assertCount(2, $values);
+        $this->assertEquals(10, $values[0]->getValue());
+        $this->assertEquals(12, $values[1]->getValue());
+    }
+
+    public function testGetNonScalarDataModelValuesMultipleCardinality()
+    {
+        $responseVariable = new ResponseVariable(
+            'MYVAR', 
+            Cardinality::MULTIPLE, 
+            BaseType::PAIR,
+            new MultipleContainer(
+                BaseType::PAIR, 
+                [new QtiPair('A', 'B'), new QtiPair('C', 'D')]
+            )
+        );
+        $values = $responseVariable->getDataModelValues();
+
+        $this->assertCount(2, $values);
+        $this->assertEquals(new QtiPair('A', 'B'), $values[0]->getValue());
+        $this->assertEquals(new QtiPair('C', 'D'), $values[1]->getValue());
     }
 
     public function testClone()

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -6,6 +6,7 @@ use qtism\common\datatypes\QtiCoords;
 use qtism\common\datatypes\QtiFloat;
 use qtism\common\datatypes\QtiInteger;
 use qtism\common\datatypes\QtiPair;
+use qtism\common\datatypes\QtiPoint;
 use qtism\common\enums\BaseType;
 use qtism\common\enums\Cardinality;
 use qtism\runtime\common\MultipleContainer;
@@ -118,12 +119,21 @@ class ResponseVariableTest extends QtiSmTestCase
 
     public function testGetNonScalarDataModelValuesSingleCardinality()
     {
+        // QtiPair
         $qtiPair = new QtiPair('A', 'B');
         $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::PAIR, $qtiPair);
         $values = $responseVariable->getDataModelValues();
 
         $this->assertCount(1, $values);
         $this->assertTrue($qtiPair->equals($values[0]->getValue()));
+
+        // QtiPoint
+        $qtiPoint = new QtiPoint(1, 1);
+        $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::POINT, $qtiPoint);
+        $values = $responseVariable->getDataModelValues();
+
+        $this->assertCount(1, $values);
+        $this->assertTrue($qtiPoint->equals($values[0]->getValue()));
     }
 
     public function testGetScalarDataModelValuesMultipleCardinality()
@@ -146,15 +156,16 @@ class ResponseVariableTest extends QtiSmTestCase
 
     public function testGetNonScalarDataModelValuesMultipleCardinality()
     {
+        // QtiPair
         $qtiPair1 = new QtiPair('A', 'B');
         $qtiPair2 = new QtiPair('C', 'D');
-        
+
         $responseVariable = new ResponseVariable(
-            'MYVAR', 
-            Cardinality::MULTIPLE, 
+            'MYVAR',
+            Cardinality::MULTIPLE,
             BaseType::PAIR,
             new MultipleContainer(
-                BaseType::PAIR, 
+                BaseType::PAIR,
                 [$qtiPair1, $qtiPair2]
             )
         );
@@ -163,6 +174,25 @@ class ResponseVariableTest extends QtiSmTestCase
         $this->assertCount(2, $values);
         $this->assertTrue($qtiPair1->equals($values[0]->getValue()));
         $this->assertTrue($qtiPair2->equals($values[1]->getValue()));
+
+        // QtiPoint
+        $qtiPoint1 = new QtiPoint(0, 0);
+        $qtiPoint2 = new QtiPoint(1, 1);
+
+        $responseVariable = new ResponseVariable(
+            'MYVAR',
+            Cardinality::MULTIPLE,
+            BaseType::POINT,
+            new MultipleContainer(
+                BaseType::POINT,
+                [$qtiPoint1, $qtiPoint2]
+            )
+        );
+        $values = $responseVariable->getDataModelValues();
+
+        $this->assertCount(2, $values);
+        $this->assertTrue($qtiPoint1->equals($values[0]->getValue()));
+        $this->assertTrue($qtiPoint2->equals($values[1]->getValue()));
     }
 
     public function testClone()

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -118,11 +118,12 @@ class ResponseVariableTest extends QtiSmTestCase
 
     public function testGetNonScalarDataModelValuesSingleCardinality()
     {
-        $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::PAIR, new QtiPair('A', 'B'));
+        $qtiPair = new QtiPair('A', 'B');
+        $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::PAIR, $qtiPair);
         $values = $responseVariable->getDataModelValues();
 
         $this->assertCount(1, $values);
-        $this->assertEquals(new QtiPair('A', 'B'), $values[0]->getValue());
+        $this->assertTrue($qtiPair->equals($values[0]->getValue()));
     }
 
     public function testGetScalarDataModelValuesMultipleCardinality()
@@ -145,20 +146,23 @@ class ResponseVariableTest extends QtiSmTestCase
 
     public function testGetNonScalarDataModelValuesMultipleCardinality()
     {
+        $qtiPair1 = new QtiPair('A', 'B');
+        $qtiPair2 = new QtiPair('C', 'D');
+        
         $responseVariable = new ResponseVariable(
             'MYVAR', 
             Cardinality::MULTIPLE, 
             BaseType::PAIR,
             new MultipleContainer(
                 BaseType::PAIR, 
-                [new QtiPair('A', 'B'), new QtiPair('C', 'D')]
+                [$qtiPair1, $qtiPair2]
             )
         );
         $values = $responseVariable->getDataModelValues();
 
         $this->assertCount(2, $values);
-        $this->assertEquals(new QtiPair('A', 'B'), $values[0]->getValue());
-        $this->assertEquals(new QtiPair('C', 'D'), $values[1]->getValue());
+        $this->assertTrue($qtiPair1->equals($values[0]->getValue()));
+        $this->assertTrue($qtiPair2->equals($values[1]->getValue()));
     }
 
     public function testClone()


### PR DESCRIPTION
Added tests for single cardinality on non-scalar values and multiple cardinality.
This helped figure out what the return value for non scalar datatypes should be: QtiDatatype for multiple cardinality, not an attempt to create a scalar value from non-scalar (for example, QtiPair must be returned, not a conversion of the QTiPair to string
Fixed the value returned in getDataModelValue.