### PR TITLE
Backport aria-* from master

### DIFF
--- a/qtism/common/utils/Format.php
+++ b/qtism/common/utils/Format.php
@@ -611,4 +611,41 @@ class Format
             return false;
         }
     }
+
+    /**
+     * Is Aria Level.
+     *
+     * Whether or not a given value is compliant with aria-level attributes.
+     *
+     * @param string|int|float $level
+     * @return bool
+     */
+    public static function isAriaLevel($level)
+    {
+        if (is_string($level) || is_numeric($level)) {
+            return intval($level) >= 1;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @param $ariaIdRefs
+     * @return bool
+     */
+    public static function isAriaIdRefs($ariaIdRefs)
+    {
+        if (!is_string($ariaIdRefs)) {
+            return false;
+        }
+
+        $ariaValues = explode("\x20", $ariaIdRefs);
+        foreach ($ariaValues as $ariaValue) {
+            if (!Format::isIdentifier($ariaValue, false)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/qtism/common/utils/Version.php
+++ b/qtism/common/utils/Version.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\common\utils;
+
+use InvalidArgumentException;
+
+/**
+ * This utility class provides utility classes about Semantic Versionning.
+ *
+ * @see http://semver.org Semantic Versioning
+ */
+class Version
+{
+    /**
+     * Compare two version numbers of QTI, following the rules of Semantic Versioning.
+     *
+     * This method provides QTI version comparison. Two versions are compared using an optional operator.
+     * When no $operator is provided, this method returns
+     *
+     * * -1 if $version1 is lower than $version2
+     * * 0 if $version1 is equal to $version2
+     * * 1 if $version1 is greater than $version2
+     *
+     * In case of using a specific $operator, the method returns true or false depending on
+     * the $operator and versions given. Accepted operators are '<', 'lt', '<=', 'le', '>', 'gt',
+     * '>=', 'ge', '==', '=', 'eq', '!=' and 'ne'.
+     *
+     * If an unknown QTI version is given for $version1 or $version2 arguments, or if $operator
+     * is an unknown operator, an InvalidArgumentException is thrown.
+     *
+     * Important note: This metod will consider version '2.1' and '2.1.0' equal.
+     *
+     * @param string $version1 A version number.
+     * @param string $version2 A version number
+     * @param string $operator An operator.
+     * @return mixed
+     * @throws InvalidArgumentException
+     * @see http://semver.org Semantic Versioning
+     */
+    public static function compare($version1, $version2, $operator = null)
+    {
+        $version1 = trim($version1);
+        $version2 = trim($version2);
+
+        // Because version_compare consider 2.1 < 2.1.0...
+        $version1 = self::appendPatchVersion($version1);
+        $version2 = self::appendPatchVersion($version2);
+
+        // Check if the versions are known...
+        $knownVersions = self::knownVersions();
+        if (self::isKnown($version1) === false) {
+            $msg = "Version '${version1}' is not a known QTI version. Known versions are '" . implode(', ', $knownVersions) . "'.";
+            throw new InvalidArgumentException($msg);
+        } elseif (self::isKnown($version2) === false) {
+            $msg = "Version '${version2}' is not a known QTI version. Known versions are '" . implode(', ', $knownVersions) . "'.";
+            throw new InvalidArgumentException($msg);
+        }
+
+        // Check if operator is correct.
+        $knownOperators = ['<', 'lt', '<=', 'le', '>', 'gt', '>=', 'ge', '==', '=', 'eq', '!=', '<>', 'ne'];
+        if (is_null($operator) === true || in_array($operator, $knownOperators) === true) {
+            return (is_null($operator) === true) ? version_compare($version1, $version2) : version_compare($version1, $version2, $operator);
+        } else {
+            $msg = "Unknown operator '${operator}'. Known operators are '" . implode(', ', $knownOperators) . "'.";
+            throw new InvalidArgumentException($msg);
+        }
+    }
+
+    /**
+     * Wether or not a $version containing a major, minor and patch
+     * version is a known QTI version.
+     *
+     * @param string $version A version with major, minor and patch version e.g. '2.1.1'.
+     * @return boolean
+     */
+    public static function isKnown($version)
+    {
+        $version = self::appendPatchVersion($version);
+        return in_array($version, self::knownVersions());
+    }
+
+    /**
+     * Get known QTI versions. Returned versions will contain
+     * major, minor and patch version.
+     *
+     * @return array An array of QTI version numbers containing major, minor and patch version e.g. '2.1.1'.
+     */
+    public static function knownVersions()
+    {
+        return ['2.0.0', '2.1.0', '2.1.1', '2.2.0', '2.2.1'];
+    }
+
+    /**
+     * Append patch version to $version if $version only contains
+     * major and minor versions.
+     *
+     * @param string $version
+     * @return string
+     */
+    public static function appendPatchVersion($version)
+    {
+        $shortKnownVersions = ['2.0', '2.1', '2.2'];
+        if (in_array($version, $shortKnownVersions) === true) {
+            $version = $version . '.0';
+        }
+
+        return $version;
+    }
+}

--- a/qtism/data/QtiDocument.php
+++ b/qtism/data/QtiDocument.php
@@ -23,6 +23,8 @@
 
 namespace qtism\data;
 
+use InvalidArgumentException;
+use qtism\common\utils\Version;
 use qtism\data\storage\StorageException;
 
 abstract class QtiDocument
@@ -61,7 +63,12 @@ abstract class QtiDocument
      */
     public function setVersion($version)
     {
-        $this->version = $version;
+        if (Version::isKnown($version) === true) {
+            $this->version = Version::appendPatchVersion($version);
+        } else {
+            $msg = "Version '{$version}' is not a known QTI version. Known versions are '" . implode(', ', Version::knownVersions()) . "'";
+            throw new InvalidArgumentException($msg);
+        }
     }
 
     /**

--- a/qtism/data/content/BodyElement.php
+++ b/qtism/data/content/BodyElement.php
@@ -141,6 +141,12 @@ abstract class BodyElement extends QtiComponent
     private $ariaLabel = '';
 
     /**
+     * @var bool
+     * @qtism-bean-property
+     */
+    private $ariaHidden = false;
+
+    /**
      * Create a new BodyElement object.
      *
      * @param string $id A QTI identifier.
@@ -579,5 +585,37 @@ abstract class BodyElement extends QtiComponent
     public function hasAriaLabel()
     {
         return $this->ariaLabel !== '';
+    }
+
+    /**
+     * @param bool $ariaHidden
+     * @throws InvalidArgumentException
+     */
+    public function setAriaHidden($ariaHidden)
+    {
+        if (!is_bool($ariaHidden)) {
+            $val = (is_object($ariaHidden)) ? ('instance of ' . get_class($ariaHidden)) : $ariaHidden;
+
+            $msg = "'${val}' is not a valid value for attribute 'aria-hidden'.";
+            throw new InvalidArgumentException($msg);
+        }
+
+        $this->ariaHidden = $ariaHidden;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAriaHidden()
+    {
+        return $this->ariaHidden;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaHidden()
+    {
+        return $this->ariaHidden !== false;
     }
 }

--- a/qtism/data/content/BodyElement.php
+++ b/qtism/data/content/BodyElement.php
@@ -25,6 +25,8 @@ namespace qtism\data\content;
 
 use InvalidArgumentException;
 use qtism\common\utils\Format;
+use qtism\data\content\enums\AriaLive;
+use qtism\data\content\enums\AriaOrientation;
 use qtism\data\QtiComponent;
 
 /**
@@ -82,6 +84,61 @@ abstract class BodyElement extends QtiComponent
      * @qtism-bean-property
      */
     private $label = '';
+
+    /**
+     * @var string
+     * @qtism-bean-property
+     */
+    private $ariaControls = '';
+
+    /**
+     * @var string
+     * @qtism-bean-property
+     */
+    private $ariaDescribedBy = '';
+
+    /**
+     * @var string
+     * @qtism-bean-property
+     */
+    private $ariaFlowTo = '';
+
+    /**
+     * @var string
+     * @qtism-bean-property
+     */
+    private $ariaLabelledBy = '';
+
+    /**
+     * @var string
+     * @qtism-bean-property
+     */
+    private $ariaOwns = '';
+
+
+    /**
+     * @var string
+     * @qtism-bean-property
+     */
+    private $ariaLevel = '';
+
+    /**
+     * @var int|bool
+     * @qtism-bean-property
+     */
+    private $ariaLive = false;
+
+    /**
+     * @var int|bool
+     * @qtism-bean-property
+     */
+    private $ariaOrientation = false;
+
+    /**
+     * @var string
+     * @qtism-bean-property
+     */
+    private $ariaLabel = '';
 
     /**
      * Create a new BodyElement object.
@@ -236,5 +293,291 @@ abstract class BodyElement extends QtiComponent
     public function hasLabel()
     {
         return $this->getLabel() !== '';
+    }
+
+    /**
+     * @param string $ariaControls
+     * @throws InvalidArgumentException
+     */
+    public function setAriaControls($ariaControls)
+    {
+        if ($ariaControls !== '' && !Format::isAriaIdRefs($ariaControls)) {
+            $val = (is_object($ariaControls)) ? ('instance of ' . get_class($ariaControls)) : $ariaControls;
+
+            $msg = "'${val}' is not a valid value for attribute 'aria-controls'.";
+            throw new InvalidArgumentException($msg);
+        }
+
+        $this->ariaControls = $ariaControls;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAriaControls()
+    {
+        return $this->ariaControls;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaControls()
+    {
+        return $this->ariaControls !== '';
+    }
+
+    /**
+     * @param string $ariaDescribedBy
+     * @throws InvalidArgumentException
+     */
+    public function setAriaDescribedBy($ariaDescribedBy)
+    {
+        if ($ariaDescribedBy !== '' && !Format::isAriaIdRefs($ariaDescribedBy)) {
+            $val = (is_object($ariaDescribedBy)) ? ('instance of ' . get_class($ariaDescribedBy)) : $ariaDescribedBy;
+
+            $msg = "'${val}' is not a valid value for attribute 'aria-describedby'.";
+            throw new InvalidArgumentException($msg);
+        }
+
+        $this->ariaDescribedBy = $ariaDescribedBy;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAriaDescribedBy()
+    {
+        return $this->ariaDescribedBy;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaDescribedBy()
+    {
+        return $this->ariaDescribedBy !== '';
+    }
+
+    /**
+     * @param string $ariaFlowTo
+     * @throws InvalidArgumentException
+     */
+    public function setAriaFlowTo($ariaFlowTo)
+    {
+        if ($ariaFlowTo !== '' && !Format::isAriaIdRefs($ariaFlowTo)) {
+            $val = (is_object($ariaFlowTo)) ? ('instance of ' . get_class($ariaFlowTo)) : $ariaFlowTo;
+
+            $msg = "'${val}' is not a valid value for attribute 'aria-flowto'.";
+            throw new InvalidArgumentException($msg);
+        }
+
+        $this->ariaFlowTo = $ariaFlowTo;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAriaFlowTo()
+    {
+        return $this->ariaFlowTo;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaFlowTo()
+    {
+        return $this->ariaFlowTo !== '';
+    }
+
+    /**
+     * @param string $ariaLabelledBy
+     * @throws InvalidArgumentException
+     */
+    public function setAriaLabelledBy($ariaLabelledBy)
+    {
+        if ($ariaLabelledBy !== '' && !Format::isAriaIdRefs($ariaLabelledBy)) {
+            $val = (is_object($ariaLabelledBy)) ? ('instance of ' . get_class($ariaLabelledBy)) : $ariaLabelledBy;
+
+            $msg = "'${val}' is not a valid value for attribute 'aria-labelledby'.";
+            throw new InvalidArgumentException($msg);
+        }
+
+        $this->ariaLabelledBy = $ariaLabelledBy;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAriaLabelledBy()
+    {
+        return $this->ariaLabelledBy;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaLabelledBy()
+    {
+        return $this->ariaLabelledBy !== '';
+    }
+
+    /**
+     * @param string $ariaOwns
+     * @throws InvalidArgumentException
+     */
+    public function setAriaOwns($ariaOwns)
+    {
+        if ($ariaOwns !== '' && !Format::isAriaIdRefs($ariaOwns)) {
+            $val = (is_object($ariaOwns)) ? ('instance of ' . get_class($ariaOwns)) : $ariaOwns;
+
+            $msg = "'${val}' is not a valid value for attribute 'aria-owns'.";
+            throw new InvalidArgumentException($msg);
+        }
+
+        $this->ariaOwns = $ariaOwns;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAriaOwns()
+    {
+        return $this->ariaOwns;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaOwns()
+    {
+        return $this->ariaOwns !== '';
+    }
+
+    /**
+     * @param string $ariaLevel
+     * @throws InvalidArgumentException
+     */
+    public function setAriaLevel($ariaLevel)
+    {
+        if ($ariaLevel !== '' && !Format::isAriaLevel($ariaLevel)) {
+            $val = (is_object($ariaLevel)) ? ('instance of ' . get_class($ariaLevel)) : $ariaLevel;
+
+            $msg = "'${val}' is not a valid value for attribute 'aria-level'.";
+            throw new InvalidArgumentException($msg);
+        }
+
+        $this->ariaLevel = strval($ariaLevel);
+    }
+
+    /**
+     * @return string
+     */
+    public function getAriaLevel()
+    {
+        return $this->ariaLevel;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaLevel()
+    {
+        return $this->ariaLevel !== '';
+    }
+
+    /**
+     * @param int $ariaLive A value from the AriaLive enumeration or false for no value.
+     * @throws InvalidArgumentException
+     */
+    public function setAriaLive($ariaLive)
+    {
+        if ($ariaLive === false || in_array($ariaLive, AriaLive::asArray(), true)) {
+            $this->ariaLive = $ariaLive;
+        } else {
+            $val = (is_object($ariaLive)) ? ('instance of ' . get_class($ariaLive)) : $ariaLive;
+            $msg = "'${val}' is not a valid value for attribute 'aria-live'.";
+            throw new InvalidArgumentException($msg);
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getAriaLive()
+    {
+        return $this->ariaLive;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaLive()
+    {
+        return $this->ariaLive !== false;
+    }
+
+    /**
+     * @param int $ariaOrientation A value from the AriaOrientation enumeration or false for no orientation.
+     * @throws InvalidArgumentException
+     */
+    public function setAriaOrientation($ariaOrientation)
+    {
+        if ($ariaOrientation === false || in_array($ariaOrientation, AriaOrientation::asArray(), true)) {
+            $this->ariaOrientation = $ariaOrientation;
+        } else {
+            $val = (is_object($ariaOrientation)) ? ('instance of ' . get_class($ariaOrientation)) : $ariaOrientation;
+            $msg = "'${val}' is not a valid value for attribute 'aria-orientation'.";
+            throw new InvalidArgumentException($msg);
+        }
+    }
+
+    /**
+     * @return false|int A value from the AriaOrientation enumeration or false if not orientation defined.
+     */
+    public function getAriaOrientation()
+    {
+        return $this->ariaOrientation;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaOrientation()
+    {
+        return $this->ariaOrientation !== false;
+    }
+
+    /**
+     * @param $ariaLabel
+     * @throws InvalidArgumentException
+     */
+    public function setAriaLabel($ariaLabel)
+    {
+        if (!is_string($ariaLabel)) {
+            $val = (is_object($ariaLabel)) ? ('instance of ' . get_class($ariaLabel)) : $ariaLabel;
+
+            $msg = "'${val}' is not a valid value for attribute 'aria-label'.";
+            throw new InvalidArgumentException($msg);
+        }
+
+        $this->ariaLabel = $ariaLabel;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAriaLabel()
+    {
+        return $this->ariaLabel;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAriaLabel()
+    {
+        return $this->ariaLabel !== '';
     }
 }

--- a/qtism/data/content/enums/AriaLive.php
+++ b/qtism/data/content/enums/AriaLive.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\content\enums;
+
+use qtism\common\enums\Enumeration;
+
+/**
+ * AriaLive Enumeration.
+ *
+ * Contains the possible values for the aria-live attribute ('off', 'polite', 'assertive').
+ */
+class AriaLive implements Enumeration
+{
+    /**
+     * @var int
+     */
+    const OFF = 0;
+
+    /**
+     * @var int
+     */
+    const POLITE = 1;
+
+    /**
+     * @var int
+     */
+    const ASSERTIVE = 2;
+
+    /**
+     * As Array
+     *
+     * Get the enumeration as an array where keys are constant names
+     * and values are constant values.
+     *
+     * @return int[]
+     */
+    public static function asArray()
+    {
+        return [
+            'OFF' => self::OFF,
+            'POLITE' => self::POLITE,
+            'ASSERTIVE' => self::ASSERTIVE
+        ];
+    }
+
+    /**
+     * Get a constant value from the AriaLive enumeration by name.
+     *
+     * * 'off' -> AriaLive::OFF
+     * * 'polite' -> AriaLive::POLITE
+     * * 'assertive' -> ArioLive::ASSERTIVE
+     *
+     * @param string $name
+     * @return false|int The related constant value or false.
+     */
+    public static function getConstantByName($name)
+    {
+        switch (trim(strtolower($name))) {
+            case 'off':
+                return self::OFF;
+                break;
+
+            case 'polite':
+                return self::POLITE;
+                break;
+
+            case 'assertive':
+                return self::ASSERTIVE;
+                break;
+
+            default:
+                return false;
+                break;
+        }
+    }
+
+    /**
+     * Get the QTI name of a AriaEnumeration value.
+     *
+     * @param int $constant A value from the AriaLive constant.
+     * @return false|string
+     */
+    public static function getNameByConstant($constant)
+    {
+        switch ($constant) {
+            case self::OFF:
+                return 'off';
+                break;
+
+            case self::POLITE:
+                return 'polite';
+                break;
+
+            case self::ASSERTIVE:
+                return 'assertive';
+                break;
+
+            default:
+                return false;
+                break;
+        }
+    }
+}

--- a/qtism/data/content/enums/AriaOrientation.php
+++ b/qtism/data/content/enums/AriaOrientation.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\content\enums;
+
+use qtism\common\enums\Enumeration;
+
+/**
+ * AriaOrientation Enumeration.
+ *
+ * Contains the possible values for the aria-orientation attribute ('horizontal', 'vertical').
+ */
+class AriaOrientation implements Enumeration
+{
+    /**
+     * @var int
+     */
+    const HORIZONTAL = 0;
+
+    /**
+     * @var int
+     */
+    const VERTICAL = 1;
+
+    /**
+     * As Array
+     *
+     * Get the enumeration as an array where keys are constant names
+     * and values are constant values.
+     *
+     * @return int[]
+     */
+    public static function asArray()
+    {
+        return [
+            'HORIZONTAL' => self::HORIZONTAL,
+            'VERTICAL' => self::VERTICAL
+        ];
+    }
+
+    /**
+     * Get a constant value from the AriaOrientative enumeration by name.
+     *
+     * * 'horizontal' -> AriaOrientation::HORIZONTAL
+     * * 'vertical' -> AriaOrientation::VERTICAL
+     *
+     * @param string $name
+     * @return false|int The related constant value or false.
+     */
+    public static function getConstantByName($name)
+    {
+        switch (trim(strtolower($name))) {
+            case 'horizontal':
+                return self::HORIZONTAL;
+                break;
+
+            case 'vertical':
+                return self::VERTICAL;
+                break;
+
+            default:
+                return false;
+                break;
+        }
+    }
+
+    /**
+     * Get the QTI name of a AriaEnumeration value.
+     *
+     * @param int $constant A value from the AriaOrientation constant.
+     * @return false|string
+     */
+    public static function getNameByConstant($constant)
+    {
+        switch ($constant) {
+            case self::HORIZONTAL:
+                return 'horizontal';
+                break;
+
+            case self::VERTICAL:
+                return 'vertical';
+                break;
+
+            default:
+                return false;
+                break;
+        }
+    }
+}

--- a/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/qtism/data/storage/xml/XmlCompactDocument.php
@@ -56,6 +56,24 @@ use SplObjectStorage;
 class XmlCompactDocument extends XmlDocument
 {
     /**
+     * XmlCompactDocument constructor.
+     *
+     * Create a new XmlCompactDocument object.
+     *
+     * @param string $version
+     * @param QtiComponent|null $documentComponent
+     */
+    public function __construct($version = '2.1', QtiComponent $documentComponent = null)
+    {
+        // Version 1.0 was used in legacy code, let's keep it BC.
+        if ($version === '1.0') {
+            $version = '2.1.0';
+        }
+
+        parent::__construct($version, $documentComponent);
+    }
+
+    /**
      * Whether or not the rubricBlock elements
      * must be separated from the core document.
      *

--- a/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/qtism/data/storage/xml/XmlCompactDocument.php
@@ -380,4 +380,9 @@ class XmlCompactDocument extends XmlDocument
 
         return $references;
     }
+
+    protected function inferVersion()
+    {
+        return '2.1';
+    }
 }

--- a/qtism/data/storage/xml/XmlResultDocument.php
+++ b/qtism/data/storage/xml/XmlResultDocument.php
@@ -56,12 +56,14 @@ class XmlResultDocument extends XmlDocument
     {
         $version = trim($this->getVersion());
         switch ($version) {
-            case '2.1':
+            case '2.1.0':
+            case '2.1.1':
                 $qtiSuffix = 'result_v2p1';
                 $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_result_v2p1.xsd';
                 break;
 
-            case '2.2':
+            case '2.2.0':
+            case '2.2.1':
                 $qtiSuffix = 'result_v2p2';
                 $xsdLocation = 'http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_result_v2p2.xsd';
                 break;

--- a/qtism/data/storage/xml/marshalling/AssessmentSectionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/AssessmentSectionMarshaller.php
@@ -42,7 +42,7 @@ class AssessmentSectionMarshaller extends RecursiveMarshaller
      */
     protected function unmarshallChildrenKnown(DOMElement $element, QtiComponentCollection $children, AssessmentSection $assessmentSection = null)
     {
-        $baseMarshaller = new SectionPartMarshaller();
+        $baseMarshaller = new SectionPartMarshaller($this->getVersion());
         $baseComponent = $baseMarshaller->unmarshall($element);
 
         if (($title = static::getDOMElementAttributeAs($element, 'title')) !== null) {
@@ -118,7 +118,7 @@ class AssessmentSectionMarshaller extends RecursiveMarshaller
      */
     protected function marshallChildrenKnown(QtiComponent $component, array $elements)
     {
-        $baseMarshaller = new SectionPartMarshaller();
+        $baseMarshaller = new SectionPartMarshaller($this->getVersion());
         $element = $baseMarshaller->marshall($component);
 
         self::setDOMElementAttribute($element, 'title', $component->getTitle());

--- a/qtism/data/storage/xml/marshalling/AssociateInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/AssociateInteractionMarshaller.php
@@ -69,7 +69,7 @@ class AssociateInteractionMarshaller extends ContentMarshaller
                 $component->setPrompt($prompt);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/AtomicBlockMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/AtomicBlockMarshaller.php
@@ -41,7 +41,7 @@ class AtomicBlockMarshaller extends ContentMarshaller
         $fqClass = $this->lookupClass($element);
         $component = new $fqClass();
         $component->setContent(new InlineCollection($children->getArrayCopy()));
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         if (($xmlBase = self::getXmlBase($element)) !== false) {
             $component->setXmlBase($xmlBase);

--- a/qtism/data/storage/xml/marshalling/BlockquoteMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/BlockquoteMarshaller.php
@@ -61,7 +61,7 @@ class BlockquoteMarshaller extends ContentMarshaller
             self::setXmlBase($element, $component->getXmlBase());
         }
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/BrMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/BrMarshaller.php
@@ -66,7 +66,7 @@ class BrMarshaller extends Marshaller
             $component->setXmlBase($xmlBase);
         }
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
         return $component;
     }
 

--- a/qtism/data/storage/xml/marshalling/CaptionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/CaptionMarshaller.php
@@ -44,7 +44,7 @@ class CaptionMarshaller extends ContentMarshaller
         $inlines = new InlineCollection($children->getArrayCopy());
         $component->setContent($inlines);
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
         return $component;
     }
 

--- a/qtism/data/storage/xml/marshalling/ChoiceInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ChoiceInteractionMarshaller.php
@@ -98,7 +98,7 @@ class ChoiceInteractionMarshaller extends ContentMarshaller
                 $component->setPrompt($prompt);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/ColMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ColMarshaller.php
@@ -67,7 +67,7 @@ class ColMarshaller extends Marshaller
             $component->setSpan($span);
         }
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/ColgroupMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ColgroupMarshaller.php
@@ -77,7 +77,7 @@ class ColgroupMarshaller extends Marshaller
         }
         $component->setContent($cols);
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/CompactMarshallerFactory.php
+++ b/qtism/data/storage/xml/marshalling/CompactMarshallerFactory.php
@@ -30,17 +30,8 @@ namespace qtism\data\storage\xml\marshalling;
  *
  * * ExtendedAssessmentItemRefMarshaller
  * * ExtendedAssessmentSectionMarshaller
- * * ExtendedTestPartMarshaller
- * * ExtendedAssessmentTestMarshaller
- * * RubricBlockRefMarshaller
- * * TestFeedbackRefMarshaller
- * * ModalFeedbackRuleMarshaller
- * * ShufflingMarshaller
- * * ShufflingGroupMarshaller
- * * ResponseValidityConstraintMarshaller
- * * AssociationValidityConstraintMarshaller
  */
-class CompactMarshallerFactory extends MarshallerFactory
+class CompactMarshallerFactory extends Qti21MarshallerFactory
 {
     /**
      * Create a new CompactMarshallerFactory object.

--- a/qtism/data/storage/xml/marshalling/ContentMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ContentMarshaller.php
@@ -76,8 +76,9 @@ abstract class ContentMarshaller extends RecursiveMarshaller
     /**
      * Create a new ContentMarshaller object.
      */
-    public function __construct()
+    public function __construct($version)
     {
+        parent::__construct($version);
         $this->setLookupClasses();
     }
 

--- a/qtism/data/storage/xml/marshalling/CorrectResponseMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/CorrectResponseMarshaller.php
@@ -65,10 +65,12 @@ class CorrectResponseMarshaller extends Marshaller
     /**
      * Create a new CorrectResponseMarshaller object.
      *
+     * @param $version
      * @param integer $baseType The base type of the Variable referencing this CorrectResponse.
      */
-    public function __construct($baseType = -1)
+    public function __construct($version, $baseType = -1)
     {
+        parent::__construct($version);
         $this->setBaseType($baseType);
     }
 

--- a/qtism/data/storage/xml/marshalling/CustomInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/CustomInteractionMarshaller.php
@@ -72,7 +72,7 @@ class CustomInteractionMarshaller extends Marshaller
             $xmlString = $frag->ownerDocument->saveXML($frag);
 
             $component = new CustomInteraction($responseIdentifier, $xmlString);
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
         }
 
         return $component;

--- a/qtism/data/storage/xml/marshalling/DefaultValueMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/DefaultValueMarshaller.php
@@ -55,10 +55,12 @@ class DefaultValueMarshaller extends Marshaller
     /**
      * Create a new DefaultValueMarshaller object.
      *
+     * @param string $version The QTI version number on which the Marshaller operates e.g. '2.1'.
      * @param integer $baseType The baseType of the Variable holding this DefaultValue.
      */
-    public function __construct($baseType = -1)
+    public function __construct($version, $baseType = -1)
     {
+        parent::__construct($version);
         $this->setBaseType($baseType);
     }
 

--- a/qtism/data/storage/xml/marshalling/DivMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/DivMarshaller.php
@@ -46,7 +46,7 @@ class DivMarshaller extends ContentMarshaller
             $component->setXmlBase($xmlBase);
         }
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/DlElementMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/DlElementMarshaller.php
@@ -45,7 +45,7 @@ class DlElementMarshaller extends ContentMarshaller
         $childrenArray = $children->getArrayCopy();
         $component->setContent(($component instanceof Dt) ? new InlineCollection($childrenArray) : new FlowCollection($childrenArray));
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/DlMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/DlMarshaller.php
@@ -46,7 +46,7 @@ class DlMarshaller extends ContentMarshaller
             $component->setXmlBase($xmlBase);
         }
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/DrawingInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/DrawingInteractionMarshaller.php
@@ -86,7 +86,7 @@ class DrawingInteractionMarshaller extends Marshaller
                     $component->setXmlBase($xmlBase);
                 }
 
-                self::fillBodyElement($component, $element);
+                $this->fillBodyElement($component, $element);
 
                 return $component;
             } else {

--- a/qtism/data/storage/xml/marshalling/EndAttemptInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/EndAttemptInteractionMarshaller.php
@@ -75,7 +75,7 @@ class EndAttemptInteractionMarshaller extends Marshaller
                 $component->setXmlBase($xmlBase);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/FeedbackElementMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/FeedbackElementMarshaller.php
@@ -79,7 +79,7 @@ class FeedbackElementMarshaller extends ContentMarshaller
                         $component->setXmlBase($xmlBase);
                     }
 
-                    self::fillBodyElement($component, $element);
+                    $this->fillBodyElement($component, $element);
 
                     return $component;
                 }

--- a/qtism/data/storage/xml/marshalling/GapChoiceMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/GapChoiceMarshaller.php
@@ -129,7 +129,7 @@ class GapChoiceMarshaller extends ContentMarshaller
                     }
                 }
 
-                self::fillBodyElement($component, $element);
+                $this->fillBodyElement($component, $element);
                 return $component;
             } else {
                 $msg = "The mandatory 'matchMax' attribute is missing from the 'simpleChoice' element.";

--- a/qtism/data/storage/xml/marshalling/GapMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/GapMarshaller.php
@@ -93,7 +93,7 @@ class GapMarshaller extends Marshaller
                 $component->setRequired($required);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
             return $component;
         } else {
             $msg = "The mandatory 'identifier' attribute is missing from the 'gap' element.";

--- a/qtism/data/storage/xml/marshalling/GapMatchInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/GapMatchInteractionMarshaller.php
@@ -63,7 +63,7 @@ class GapMatchInteractionMarshaller extends ContentMarshaller
                     $component->setXmlBase($xmlBase);
                 }
 
-                self::fillBodyElement($component, $element);
+                $this->fillBodyElement($component, $element);
 
                 return $component;
             } else {

--- a/qtism/data/storage/xml/marshalling/GraphicAssociateInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/GraphicAssociateInteractionMarshaller.php
@@ -74,7 +74,7 @@ class GraphicAssociateInteractionMarshaller extends ContentMarshaller
                         $component->setPrompt($prompt);
                     }
 
-                    self::fillBodyElement($component, $element);
+                    $this->fillBodyElement($component, $element);
                     return $component;
                 } else {
                     $msg = "A 'graphicAssociateInteraction' element must contain at lease one 'associableHotspot' element, none given.";

--- a/qtism/data/storage/xml/marshalling/GraphicGapMatchInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/GraphicGapMatchInteractionMarshaller.php
@@ -79,7 +79,7 @@ class GraphicGapMatchInteractionMarshaller extends Marshaller
                             $component->setXmlBase($xmlBase);
                         }
 
-                        self::fillBodyElement($component, $element);
+                        $this->fillBodyElement($component, $element);
 
                         return $component;
                     } else {

--- a/qtism/data/storage/xml/marshalling/GraphicOrderInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/GraphicOrderInteractionMarshaller.php
@@ -74,7 +74,7 @@ class GraphicOrderInteractionMarshaller extends ContentMarshaller
                         $component->setPrompt($prompt);
                     }
 
-                    self::fillBodyElement($component, $element);
+                    $this->fillBodyElement($component, $element);
 
                     return $component;
                 } else {

--- a/qtism/data/storage/xml/marshalling/HotspotInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/HotspotInteractionMarshaller.php
@@ -71,7 +71,7 @@ class HotspotInteractionMarshaller extends ContentMarshaller
                             $component->setPrompt($prompt);
                         }
 
-                        self::fillBodyElement($component, $element);
+                        $this->fillBodyElement($component, $element);
                         return $component;
                     } else {
                         $msg = "An 'hotspotInteraction' element must contain at least one 'hotspotChoice' element, none given";

--- a/qtism/data/storage/xml/marshalling/HotspotMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/HotspotMarshaller.php
@@ -142,7 +142,7 @@ class HotspotMarshaller extends Marshaller
                         }
                     }
 
-                    self::fillBodyElement($component, $element);
+                    $this->fillBodyElement($component, $element);
                     return $component;
                 } else {
                     $msg = "The mandatory attribute 'coords' is missing from element '" . $element->localName . "'.";

--- a/qtism/data/storage/xml/marshalling/HottextInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/HottextInteractionMarshaller.php
@@ -74,7 +74,7 @@ class HottextInteractionMarshaller extends ContentMarshaller
                 $component->setPrompt($prompt);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/HottextMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/HottextMarshaller.php
@@ -60,7 +60,7 @@ class HottextMarshaller extends ContentMarshaller
             }
 
             $component->setContent(new InlineStaticCollection($children->getArrayCopy()));
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/HrMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/HrMarshaller.php
@@ -67,7 +67,7 @@ class HrMarshaller extends Marshaller
             $component->setXmlBase($xmlBase);
         }
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/ImgMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ImgMarshaller.php
@@ -109,7 +109,7 @@ class ImgMarshaller extends Marshaller
                 $component->setXmlBase($xmlBase);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
             return $component;
         } else {
             $msg = "The 'mandatory' attribute 'src' is missing from element 'img'.";

--- a/qtism/data/storage/xml/marshalling/InfoControlMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/InfoControlMarshaller.php
@@ -46,7 +46,7 @@ class InfoControlMarshaller extends ContentMarshaller
             $component->setXmlBase($xmlBase);
         }
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/InlineChoiceInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/InlineChoiceInteractionMarshaller.php
@@ -67,7 +67,7 @@ class InlineChoiceInteractionMarshaller extends ContentMarshaller
                 $component->setXmlBase($xmlBase);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/InlineChoiceMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/InlineChoiceMarshaller.php
@@ -69,7 +69,7 @@ class InlineChoiceMarshaller extends ContentMarshaller
                 $component->setShowHide(ShowHide::getConstantByName($showHide));
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/InterpolationTableEntryMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/InterpolationTableEntryMarshaller.php
@@ -68,10 +68,12 @@ class InterpolationTableEntryMarshaller extends Marshaller
     /**
      * Create a new instance of InterpolationTableEntryMarshaller.
      *
+     * @param string $version
      * @param int $baseType The baseType of the variableDeclaration containing the InterpolationTableEntry to unmarshall.
      */
-    public function __construct($baseType = -1)
+    public function __construct($version, $baseType = -1)
     {
+        parent::__construct($version);
         $this->setBaseType($baseType);
     }
 

--- a/qtism/data/storage/xml/marshalling/InterpolationTableMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/InterpolationTableMarshaller.php
@@ -47,11 +47,13 @@ class InterpolationTableMarshaller extends Marshaller
      * needs to know the baseType of the variableDeclaration that contains the interpolationTable,
      * a $baseType can be passed as an argument for instantiation.
      *
+     * @param $version
      * @param integer $baseType A value from the BaseType enumeration or -1.
      * @throws InvalidArgumentException If $baseType is not a value from the BaseType enumeration nor -1.
      */
-    public function __construct($baseType = -1)
+    public function __construct($version, $baseType = -1)
     {
+        parent::__construct($version);
         $this->setBaseType($baseType);
     }
 

--- a/qtism/data/storage/xml/marshalling/ItemBodyMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ItemBodyMarshaller.php
@@ -42,7 +42,7 @@ class ItemBodyMarshaller extends ContentMarshaller
         $component = new $fqClass();
         $component->setContent(new BlockCollection($children->getArrayCopy()));
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/LiMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/LiMarshaller.php
@@ -42,7 +42,7 @@ class LiMarshaller extends ContentMarshaller
         $component = new $fqClass();
         $component->setContent(new FlowCollection($children->getArrayCopy()));
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/ListMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ListMarshaller.php
@@ -46,7 +46,7 @@ class ListMarshaller extends ContentMarshaller
             $component->setXmlBase($xmlBase);
         }
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/MapEntryMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/MapEntryMarshaller.php
@@ -76,11 +76,13 @@ class MapEntryMarshaller extends Marshaller
     /**
      * Create a new instance of ValueMarshaller.
      *
+     * @param string
      * @param int $baseType A value from the BaseType enumeration.
      * @throws InvalidArgumentException if $baseType is not a value from the BaseType enumeration.
      */
-    public function __construct($baseType)
+    public function __construct($version, $baseType = -1)
     {
+        parent::__construct($version);
         $this->setBaseType($baseType);
     }
 

--- a/qtism/data/storage/xml/marshalling/MappingMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/MappingMarshaller.php
@@ -74,11 +74,13 @@ class MappingMarshaller extends Marshaller
     /**
      * Create a new instance of MappingMarshaller.
      *
+     * @param string $version
      * @param int $baseType A value from the BaseType enumeration.
      * @throws InvalidArgumentException if $baseType is not a value from the BaseType enumeration.
      */
-    public function __construct($baseType)
+    public function __construct($version, $baseType = -1)
     {
+        parent::__construct($version);
         $this->setBaseType($baseType);
     }
 

--- a/qtism/data/storage/xml/marshalling/Marshaller.php
+++ b/qtism/data/storage/xml/marshalling/Marshaller.php
@@ -221,7 +221,7 @@ abstract class Marshaller
                     break;
 
                 case 'boolean':
-                    return ($attr == 'true') ? true : false;
+                    return ($attr === 'true') ? true : false;
                     break;
 
                 default:
@@ -465,6 +465,10 @@ abstract class Marshaller
                     if (($ariaLabel = $this->getDOMElementAttributeAs($element, 'aria-label')) !== null) {
                         $bodyElement->setAriaLabel($ariaLabel);
                     }
+
+                    if (($ariaHidden = $this->getDOMElementAttributeAs($element, 'aria-hidden', 'boolean')) !== null) {
+                        $bodyElement->setAriaHidden($ariaHidden);
+                    }
                 }
             }
 
@@ -563,6 +567,10 @@ abstract class Marshaller
 
                 if (($ariaLabel = $bodyElement->getAriaLabel()) !== '') {
                     $element->setAttribute('aria-label', $ariaLabel);
+                }
+
+                if (($ariaHidden = $bodyElement->getAriaHidden()) !== false) {
+                    $element->setAttribute('aria-hidden', 'true');
                 }
             }
         }

--- a/qtism/data/storage/xml/marshalling/MarshallerFactory.php
+++ b/qtism/data/storage/xml/marshalling/MarshallerFactory.php
@@ -36,7 +36,7 @@ use RuntimeException;
  * create appropriate marshallers regarding a specific QtiComponent
  * or DOMElement.
  */
-class MarshallerFactory
+abstract class MarshallerFactory
 {
     /**
      * An associative array where keys are QTI class names
@@ -63,6 +63,133 @@ class MarshallerFactory
      */
     public function __construct()
     {
+        $this->addMappingEntry('customInteraction', 'qtism\\data\\storage\\xml\\marshalling\\CustomInteractionMarshaller');
+        $this->addMappingEntry('br', 'qtism\\data\\storage\\xml\\marshalling\\BrMarshaller');
+        $this->addMappingEntry('hr', 'qtism\\data\\storage\\xml\\marshalling\\HrMarshaller');
+        $this->addMappingEntry('responseCondition', 'qtism\\data\\storage\\xml\\marshalling\\ResponseConditionMarshaller');
+        $this->addMappingEntry('responseProcessing', 'qtism\\data\\storage\\xml\\marshalling\\ResponseProcessingMarshaller');
+        $this->addMappingEntry('anyN', 'qtism\\data\\storage\\xml\\marshalling\\AnyNMarshaller');
+        $this->addMappingEntry('areaMapEntry', 'qtism\\data\\storage\\xml\\marshalling\\AreaMapEntryMarshaller');
+        $this->addMappingEntry('areaMapping', 'qtism\\data\\storage\\xml\\marshalling\\AreaMappingMarshaller');
+        $this->addMappingEntry('assessmentItem', 'qtism\\data\\storage\\xml\\marshalling\\AssessmentItemMarshaller');
+        $this->addMappingEntry('assessmentSectionRef', 'qtism\\data\\storage\\xml\\marshalling\\AssessmentSectionRefMarshaller');
+        $this->addMappingEntry('assessmentTest', 'qtism\\data\\storage\\xml\\marshalling\\AssessmentTestMarshaller');
+        $this->addMappingEntry('associateInteraction', 'qtism\\data\\storage\\xml\\marshalling\\AssociateInteractionMarshaller');
+        $this->addMappingEntry('blockquote', 'qtism\\data\\storage\\xml\\marshalling\\BlockquoteMarshaller');
+        $this->addMappingEntry('correct', 'qtism\\data\\storage\\xml\\marshalling\\CorrectMarshaller');
+        $this->addMappingEntry('dl', 'qtism\\data\\storage\\xml\\marshalling\\DlMarshaller');
+        $this->addMappingEntry('drawingInteraction', 'qtism\\data\\storage\\xml\\marshalling\\DrawingInteractionMarshaller');
+        $this->addMappingEntry('endAttemptInteraction', 'qtism\\data\\storage\\xml\\marshalling\\EndAttemptInteractionMarshaller');
+        $this->addMappingEntry('equalRounded', 'qtism\\data\\storage\\xml\\marshalling\\EqualRoundedMarshaller');
+        $this->addMappingEntry('exitResponse', 'qtism\\data\\storage\\xml\\marshalling\\ExitResponseMarshaller');
+        $this->addMappingEntry('exitTest', 'qtism\\data\\storage\\xml\\marshalling\\ExitTestMarshaller');
+        $this->addMappingEntry('fieldValue', 'qtism\\data\\storage\\xml\\marshalling\\FieldValueMarshaller');
+        $this->addMappingEntry('hottextInteraction', 'qtism\\data\\storage\\xml\\marshalling\\HottextInteractionMarshaller');
+        $this->addMappingEntry('inlineChoiceInteraction', 'qtism\\data\\storage\\xml\\marshalling\\InlineChoiceInteractionMarshaller');
+        $this->addMappingEntry('gap', 'qtism\\data\\storage\\xml\\marshalling\\GapMarshaller');
+        $this->addMappingEntry('gapMatchInteraction', 'qtism\\data\\storage\\xml\\marshalling\\GapMatchInteractionMarshaller');
+        $this->addMappingEntry('graphicAssociateInteraction', 'qtism\\data\\storage\\xml\\marshalling\\GraphicAssociateInteractionMarshaller');
+        $this->addMappingEntry('graphicGapMatchInteraction', 'qtism\\data\\storage\\xml\\marshalling\\GraphicGapMatchInteractionMarshaller');
+        $this->addMappingEntry('graphicOrderInteraction', 'qtism\\data\\storage\\xml\\marshalling\\GraphicOrderInteractionMarshaller');
+        $this->addMappingEntry('hotspotInteraction', 'qtism\\data\\storage\\xml\\marshalling\\HotspotInteractionMarshaller');
+        $this->addMappingEntry('hottext', 'qtism\\data\\storage\\xml\\marshalling\\HottextMarshaller');
+        $this->addMappingEntry('img', 'qtism\\data\\storage\\xml\\marshalling\\ImgMarshaller');
+        $this->addMappingEntry('index', 'qtism\\data\\storage\\xml\\marshalling\\IndexMarshaller');
+        $this->addMappingEntry('infoControl', 'qtism\\data\\storage\\xml\\marshalling\\InfoControlMarshaller');
+        $this->addMappingEntry('inlineChoice', 'qtism\\data\\storage\\xml\\marshalling\\InlineChoiceMarshaller');
+        $this->addMappingEntry('inside', 'qtism\\data\\storage\\xml\\marshalling\\InsideMarshaller');
+        $this->addMappingEntry('interpolationTableEntry', 'qtism\\data\\storage\\xml\\marshalling\\InterpolationTableEntryMarshaller');
+        $this->addMappingEntry('interpolationTable', 'qtism\\data\\storage\\xml\\marshalling\\InterpolationTableMarshaller');
+        $this->addMappingEntry('itemBody', 'qtism\\data\\storage\\xml\\marshalling\\ItemBodyMarshaller');
+        $this->addMappingEntry('itemSubset', 'qtism\\data\\storage\\xml\\marshalling\\ItemSubsetMarshaller');
+        $this->addMappingEntry('li', 'qtism\\data\\storage\\xml\\marshalling\\LiMarshaller');
+        $this->addMappingEntry('mapResponse', 'qtism\\data\\storage\\xml\\marshalling\\MapResponseMarshaller');
+        $this->addMappingEntry('mapResponsePoint', 'qtism\\data\\storage\\xml\\marshalling\\MapResponsePointMarshaller');
+        $this->addMappingEntry('matchInteraction', 'qtism\\data\\storage\\xml\\marshalling\\MatchInteractionMarshaller');
+        $this->addMappingEntry('mathConstant', 'qtism\\data\\storage\\xml\\marshalling\\MathConstantMarshaller');
+        $this->addMappingEntry('math', 'qtism\\data\\storage\\xml\\marshalling\\MathMarshaller');
+        $this->addMappingEntry('mediaInteraction', 'qtism\\data\\storage\\xml\\marshalling\\MediaInteractionMarshaller');
+        $this->addMappingEntry('modalFeedback', 'qtism\\data\\storage\\xml\\marshalling\\ModalFeedbackMarshaller');
+        $this->addMappingEntry('numberCorrect', 'qtism\\data\\storage\\xml\\marshalling\\NumberCorrectMarshaller');
+        $this->addMappingEntry('numberIncorrect', 'qtism\\data\\storage\\xml\\marshalling\\NumberIncorrectMarshaller');
+        $this->addMappingEntry('numberPresented', 'qtism\\data\\storage\\xml\\marshalling\\NumberPresentedMarshaller');
+        $this->addMappingEntry('numberResponded', 'qtism\\data\\storage\\xml\\marshalling\\NumberRespondedMarshaller');
+        $this->addMappingEntry('numberSelected', 'qtism\\data\\storage\\xml\\marshalling\\NumberSelectedMarshaller');
+        $this->addMappingEntry('param', 'qtism\\data\\storage\\xml\\marshalling\\ParamMarshaller');
+        $this->addMappingEntry('lookupOutcomeValue', 'qtism\\data\\storage\\xml\\marshalling\\LookupOutcomeValueMarshaller');
+        $this->addMappingEntry('mathOperator', 'qtism\\data\\storage\\xml\\marshalling\\MathOperatorMarshaller');
+        $this->addMappingEntry('mapEntry', 'qtism\\data\\storage\\xml\\marshalling\\MapEntryMarshaller');
+        $this->addMappingEntry('matchTableEntry', 'qtism\\data\\storage\\xml\\marshalling\\MatchTableEntryMarshaller');
+        $this->addMappingEntry('matchTable', 'qtism\\data\\storage\\xml\\marshalling\\MatchTableMarshaller');
+        $this->addMappingEntry('ordering', 'qtism\\data\\storage\\xml\\marshalling\\OrderingMarshaller');
+        $this->addMappingEntry('outcomeCondition', 'qtism\\data\\storage\\xml\\marshalling\\OutcomeConditionMarshaller');
+        $this->addMappingEntry('matchTable', 'qtism\\data\\storage\\xml\\marshalling\\MatchTableMarshaller');
+        $this->addMappingEntry('outcomeMaximum', 'qtism\\data\\storage\\xml\\marshalling\\OutcomeMaximumMarshaller');
+        $this->addMappingEntry('outcomeMinimum', 'qtism\\data\\storage\\xml\\marshalling\\OutcomeMinimumMarshaller');
+        $this->addMappingEntry('outcomeProcessing', 'qtism\\data\\storage\\xml\\marshalling\\OutcomeProcessingMarshaller');
+        $this->addMappingEntry('patternMatch', 'qtism\\data\\storage\\xml\\marshalling\\PatternMatchMarshaller');
+        $this->addMappingEntry('positionObjectInteraction', 'qtism\\data\\storage\\xml\\marshalling\\PositionObjectInteractionMarshaller');
+        $this->addMappingEntry('positionObjectStage', 'qtism\\data\\storage\\xml\\marshalling\\PositionObjectStageMarshaller');
+        $this->addMappingEntry('randomFloat', 'qtism\\data\\storage\\xml\\marshalling\\RandomFloatMarshaller');
+        $this->addMappingEntry('repeat', 'qtism\\data\\storage\\xml\\marshalling\\RepeatMarshaller');
+        $this->addMappingEntry('mapping', 'qtism\\data\\storage\\xml\\marshalling\\MappingMarshaller');
+        $this->addMappingEntry('correctResponse', 'qtism\\data\\storage\\xml\\marshalling\\CorrectResponseMarshaller');
+        $this->addMappingEntry('matchTable', 'qtism\\data\\storage\\xml\\marshalling\\MatchTableMarshaller');
+        $this->addMappingEntry('itemSessionControl', 'qtism\\data\\storage\\xml\\marshalling\\ItemSessionControlMarshaller');
+        $this->addMappingEntry('responseDeclaration', 'qtism\\data\\storage\\xml\\marshalling\\ResponseDeclarationMarshaller');
+        $this->addMappingEntry('outcomeDeclaration', 'qtism\\data\\storage\\xml\\marshalling\\OutcomeDeclarationMarshaller');
+        $this->addMappingEntry('roundTo', 'qtism\\data\\storage\\xml\\marshalling\\RoundToMarshaller');
+        $this->addMappingEntry('rubricBlock', 'qtism\\data\\storage\\xml\\marshalling\\RubricBlockMarshaller');
+        $this->addMappingEntry('object', 'qtism\\data\\storage\\xml\\marshalling\\ObjectMarshaller');
+        $this->addMappingEntry('col', 'qtism\\data\\storage\\xml\\marshalling\\ColMarshaller');
+        $this->addMappingEntry('colgroup', 'qtism\\data\\storage\\xml\\marshalling\\ColgroupMarshaller');
+        $this->addMappingEntry('equal', 'qtism\\data\\storage\\xml\\marshalling\\EqualMarshaller');
+        $this->addMappingEntry('sectionPart', 'qtism\\data\\storage\\xml\\marshalling\\SectionPartMarshaller');
+        $this->addMappingEntry('selectPointInteraction', 'qtism\\data\\storage\\xml\\marshalling\\SelectPointInteractionMarshaller');
+        $this->addMappingEntry('setOutcomeValue', 'qtism\\data\\storage\\xml\\marshalling\\SetOutcomeValueMarshaller');
+        $this->addMappingEntry('simpleAssociableChoice', 'qtism\\data\\storage\\xml\\marshalling\\SimpleAssociableChoiceMarshaller');
+        $this->addMappingEntry('caption', 'qtism\\data\\storage\\xml\\marshalling\\CaptionMarshaller');
+        $this->addMappingEntry('tr', 'qtism\\data\\storage\\xml\\marshalling\\TrMarshaller');
+        $this->addMappingEntry('branchRule', 'qtism\\data\\storage\\xml\\marshalling\\BranchRuleMarshaller');
+        $this->addMappingEntry('simpleMatchSet', 'qtism\\data\\storage\\xml\\marshalling\\SimpleMatchSetMarshaller');
+        $this->addMappingEntry('sliderInteraction', 'qtism\\data\\storage\\xml\\marshalling\\SliderInteractionMarshaller');
+        $this->addMappingEntry('statsOperator', 'qtism\\data\\storage\\xml\\marshalling\\StatsOperatorMarshaller');
+        $this->addMappingEntry('stringMatch', 'qtism\\data\\storage\\xml\\marshalling\\StringMatchMarshaller');
+        $this->addMappingEntry('stylesheet', 'qtism\\data\\storage\\xml\\marshalling\\StylesheetMarshaller');
+        $this->addMappingEntry('substring', 'qtism\\data\\storage\\xml\\marshalling\\SubstringMarshaller');
+        $this->addMappingEntry('table', 'qtism\\data\\storage\\xml\\marshalling\\TableMarshaller');
+        $this->addMappingEntry('div', 'qtism\\data\\storage\\xml\\marshalling\\DivMarshaller');
+        $this->addMappingEntry('setDefaultValue', 'qtism\\data\\storage\\xml\\marshalling\\SetDefaultValueMarshaller');
+        $this->addMappingEntry('randomInteger', 'qtism\\data\\storage\\xml\\marshalling\\RandomIntegerMarshaller');
+        $this->addMappingEntry('exitTemplate', 'qtism\\data\\storage\\xml\\marshalling\\ExitTemplateMarshaller');
+        $this->addMappingEntry('preCondition', 'qtism\\data\\storage\\xml\\marshalling\\PreConditionMarshaller');
+        $this->addMappingEntry('selection', 'qtism\\data\\storage\\xml\\marshalling\\SelectionMarshaller');
+        $this->addMappingEntry('assessmentItemRef', 'qtism\\data\\storage\\xml\\marshalling\\AssessmentItemRefMarshaller');
+        $this->addMappingEntry('setCorrectResponse', 'qtism\\data\\storage\\xml\\marshalling\\SetCorrectResponseMarshaller');
+        $this->addMappingEntry('value', 'qtism\\data\\storage\\xml\\marshalling\\ValueMarshaller');
+        $this->addMappingEntry('assessmentSection', 'qtism\\data\\storage\\xml\\marshalling\\AssessmentSectionMarshaller');
+        $this->addMappingEntry('baseValue', 'qtism\\data\\storage\\xml\\marshalling\\BaseValueMarshaller');
+        $this->addMappingEntry('prompt', 'qtism\\data\\storage\\xml\\marshalling\\PromptMarshaller');
+        $this->addMappingEntry('simpleChoice', 'qtism\\data\\storage\\xml\\marshalling\\SimpleChoiceMarshaller');
+        $this->addMappingEntry('printedVariable', 'qtism\\data\\storage\\xml\\marshalling\\PrintedVariableMarshaller');
+        $this->addMappingEntry('defaultValue', 'qtism\\data\\storage\\xml\\marshalling\\DefaultValueMarshaller');
+        $this->addMappingEntry('templateCondition', 'qtism\\data\\storage\\xml\\marshalling\\TemplateConditionMarshaller');
+        $this->addMappingEntry('templateConstraint', 'qtism\\data\\storage\\xml\\marshalling\\TemplateConstraintMarshaller');
+        $this->addMappingEntry('setTemplateValue', 'qtism\\data\\storage\\xml\\marshalling\\SetTemplateValueMarshaller');
+        $this->addMappingEntry('templateDefault', 'qtism\\data\\storage\\xml\\marshalling\\TemplateDefaultMarshaller');
+        $this->addMappingEntry('templateProcessing', 'qtism\\data\\storage\\xml\\marshalling\\TemplateProcessingMarshaller');
+        $this->addMappingEntry('testFeedback', 'qtism\\data\\storage\\xml\\marshalling\\TestFeedbackMarshaller');
+        $this->addMappingEntry('testPart', 'qtism\\data\\storage\\xml\\marshalling\\TestPartMarshaller');
+        $this->addMappingEntry('testVariables', 'qtism\\data\\storage\\xml\\marshalling\\TestVariablesMarshaller');
+        $this->addMappingEntry('timeLimits', 'qtism\\data\\storage\\xml\\marshalling\\TimeLimitsMarshaller');
+        $this->addMappingEntry('uploadInteraction', 'qtism\\data\\storage\\xml\\marshalling\\UploadInteractionMarshaller');
+        $this->addMappingEntry('variableDeclaration', 'qtism\\data\\storage\\xml\\marshalling\\VariableDeclarationMarshaller');
+        $this->addMappingEntry('variableMapping', 'qtism\\data\\storage\\xml\\marshalling\\VariableMappingMarshaller');
+        $this->addMappingEntry('variable', 'qtism\\data\\storage\\xml\\marshalling\\VariableMarshaller');
+        $this->addMappingEntry('weight', 'qtism\\data\\storage\\xml\\marshalling\\WeightMarshaller');
+        $this->addMappingEntry('choiceInteraction', 'qtism\\data\\storage\\xml\\marshalling\\ChoiceInteractionMarshaller');
+        $this->addMappingEntry('textRun', 'qtism\\data\\storage\\xml\\marshalling\\TextRunMarshaller');
+        $this->addMappingEntry('templateDeclaration', 'qtism\\data\\storage\\xml\\marshalling\\TemplateDeclarationMarshaller');
         $this->addMappingEntry('default', 'qtism\\data\\storage\\xml\\marshalling\\DefaultValMarshaller');
         $this->addMappingEntry('null', 'qtism\\data\\storage\\xml\\marshalling\\NullValueMarshaller');
         $this->addMappingEntry('max', 'qtism\\data\\storage\\xml\\marshalling\\OperatorMarshaller');
@@ -157,6 +284,15 @@ class MarshallerFactory
         $this->addMappingEntry('hotspotChoice', 'qtism\\data\\storage\\xml\\marshalling\\HotspotMarshaller');
         $this->addMappingEntry('associableHotspot', 'qtism\\data\\storage\\xml\\marshalling\\HotspotMarshaller');
         $this->addMappingEntry('include', 'qtism\\data\\storage\\xml\\marshalling\\XIncludeMarshaller');
+        $this->addMappingEntry('assessmentResult', 'qtism\\data\\storage\\xml\\marshalling\\AssessmentResultMarshaller');
+        $this->addMappingEntry('context', 'qtism\\data\\storage\\xml\\marshalling\\ContextMarshaller');
+        $this->addMappingEntry('sessionIdentifier', 'qtism\\data\\storage\\xml\\marshalling\\SessionIdentifierMarshaller');
+        $this->addMappingEntry('testResult', 'qtism\\data\\storage\\xml\\marshalling\\TestResultMarshaller');
+        $this->addMappingEntry('itemResult', 'qtism\\data\\storage\\xml\\marshalling\\ItemResultMarshaller');
+        $this->addMappingEntry('responseVariable', 'qtism\\data\\storage\\xml\\marshalling\\ResponseVariableMarshaller');
+        $this->addMappingEntry('candidateResponse', 'qtism\\data\\storage\\xml\\marshalling\\CandidateResponseMarshaller');
+        $this->addMappingEntry('templateVariable', 'qtism\\data\\storage\\xml\\marshalling\\TemplateVariableMarshaller');
+        $this->addMappingEntry('outcomeVariable', 'qtism\\data\\storage\\xml\\marshalling\\OutcomeVariableMarshaller');
     }
 
     /**
@@ -258,7 +394,7 @@ class MarshallerFactory
                 throw new RuntimeException($msg, 0, $e);
             }
 
-            $marshaller = Reflection::newInstance($class, $args);
+            $marshaller = $this->instantiateMarshaller($class, $args);
             $marshaller->setMarshallerFactory($this);
 
             return $marshaller;
@@ -267,4 +403,6 @@ class MarshallerFactory
             throw new InvalidArgumentException($msg);
         }
     }
+
+    abstract protected function instantiateMarshaller(ReflectionClass $class, array $args);
 }

--- a/qtism/data/storage/xml/marshalling/MatchInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/MatchInteractionMarshaller.php
@@ -77,7 +77,7 @@ class MatchInteractionMarshaller extends ContentMarshaller
                 $component->setPrompt($prompt);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
             return $component;
         } else {
             $msg = "The mandatory 'responseIdentifier' attribute is missing from the 'matchInteraction' element.";

--- a/qtism/data/storage/xml/marshalling/MatchTableEntryMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/MatchTableEntryMarshaller.php
@@ -76,11 +76,13 @@ class MatchTableEntryMarshaller extends Marshaller
      * has a specific constructor because its parameteric. It needs to know
      * the baseType of its targetValue, which is defined by its parent variableDeclaration.
      *
+     * @param string $version
      * @param integer $baseType A value from the BaseType enumeration.
      * @throws InvalidArgumentException if $baseType is not a value from the BaseType enumeration.
      */
-    public function __construct($baseType)
+    public function __construct($version, $baseType = -1)
     {
+        parent::__construct($version);
         $this->setBaseType($baseType);
     }
 

--- a/qtism/data/storage/xml/marshalling/MatchTableMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/MatchTableMarshaller.php
@@ -75,11 +75,13 @@ class MatchTableMarshaller extends Marshaller
     /**
      * Create a new instance of MatchTableMarshaller.
      *
+     * @param string $version
      * @param integer $baseType The baseType of the variableDeclaration the MatchTable belongs to.
      * @throws InvalidArgumentException If $baseType is an invalid value.
      */
-    public function __construct($baseType = -1)
+    public function __construct($version, $baseType = -1)
     {
+        parent::__construct($version);
         $this->setBaseType($baseType);
     }
 

--- a/qtism/data/storage/xml/marshalling/MediaInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/MediaInteractionMarshaller.php
@@ -112,7 +112,7 @@ class MediaInteractionMarshaller extends Marshaller
                         $component->setXmlBase($xmlBase);
                     }
 
-                    self::fillBodyElement($component, $element);
+                    $this->fillBodyElement($component, $element);
 
                     return $component;
                 } else {

--- a/qtism/data/storage/xml/marshalling/ObjectMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ObjectMarshaller.php
@@ -61,7 +61,7 @@ class ObjectMarshaller extends ContentMarshaller
                 $component->setXmlBase($xmlBase);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/OutcomeDeclarationMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/OutcomeDeclarationMarshaller.php
@@ -174,7 +174,7 @@ class OutcomeDeclarationMarshaller extends VariableDeclarationMarshaller
 
             return $object;
         } catch (InvalidArgumentException $e) {
-            $msg = "An unexpected error occured while unmarshalling the outcomeDeclaration.";
+            $msg = "An unexpected error occurred while unmarshalling the outcomeDeclaration.";
             throw new UnmarshallingException($msg, $element, $e);
         }
     }

--- a/qtism/data/storage/xml/marshalling/PositionObjectInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/PositionObjectInteractionMarshaller.php
@@ -107,7 +107,7 @@ class PositionObjectInteractionMarshaller extends Marshaller
                     }
                 }
 
-                self::fillBodyElement($component, $element);
+                $this->fillBodyElement($component, $element);
 
                 return $component;
             } else {

--- a/qtism/data/storage/xml/marshalling/PrintedVariableMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/PrintedVariableMarshaller.php
@@ -114,7 +114,7 @@ class PrintedVariableMarshaller extends Marshaller
                 $component->setXmlBase($xmlBase);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/PromptMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/PromptMarshaller.php
@@ -68,7 +68,7 @@ class PromptMarshaller extends ContentMarshaller
 
         $component->setContent($content);
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/Qti20MarshallerFactory.php
+++ b/qtism/data/storage/xml/marshalling/Qti20MarshallerFactory.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use qtism\common\utils\Reflection;
+use ReflectionClass;
+
+/**
+ * A MarshallerFactory focusing on instantiating and configuring
+ * Marshallers for QTI 2.0.
+ */
+class Qti20MarshallerFactory extends MarshallerFactory
+{
+    /**
+     * Create a new Qti20MarshallerFactory object.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->removeMappingEntry('mediaInteraction');
+        $this->removeMappingEntry('infoControl');
+        $this->removeMappingEntry('interpolationTable');
+        $this->removeMappingEntry('interpolationTableEntry');
+        $this->removeMappingEntry('matchTable');
+        $this->removeMappingEntry('matchTableEntry');
+        $this->removeMappingEntry('assessmentTest');
+        $this->removeMappingEntry('testPart');
+        $this->removeMappingEntry('assessmentSection');
+        $this->removeMappingEntry('assessmentSectionRef');
+        $this->removeMappingEntry('assessmentItemRef');
+        $this->removeMappingEntry('sectionPart');
+        $this->removeMappingEntry('selection');
+        $this->removeMappingEntry('ordering');
+        $this->removeMappingEntry('weight');
+        $this->removeMappingEntry('variableMapping');
+        $this->removeMappingEntry('templateDefault');
+        $this->removeMappingEntry('timeLimits');
+        $this->removeMappingEntry('testFeedback');
+        $this->removeMappingEntry('branchRule');
+        $this->removeMappingEntry('preCondition');
+        $this->removeMappingEntry('outcomeProcessing');
+        $this->removeMappingEntry('outcomeCondition');
+        $this->removeMappingEntry('outcomeIf');
+        $this->removeMappingEntry('outcomeElseIf');
+        $this->removeMappingEntry('outcomeElse');
+        $this->removeMappingEntry('exitTest');
+        $this->removeMappingEntry('itemSubset');
+        $this->removeMappingEntry('testVariables');
+        $this->removeMappingEntry('outcomeMaximum');
+        $this->removeMappingEntry('outcomeMinimum');
+        $this->removeMappingEntry('numberCorrect');
+        $this->removeMappingEntry('numberIncorrect');
+        $this->removeMappingEntry('numberResponded');
+        $this->removeMappingEntry('numberPresented');
+        $this->removeMappingEntry('numberSelected');
+        $this->removeMappingEntry('repeat');
+        $this->removeMappingEntry('roundTo');
+        $this->removeMappingEntry('mathOperator');
+        $this->removeMappingEntry('mathConstant');
+        $this->removeMappingEntry('min');
+        $this->removeMappingEntry('max');
+        $this->removeMappingEntry('statsOperator');
+        $this->removeMappingEntry('gcd');
+        $this->removeMappingEntry('lcd');
+        $this->removeMappingEntry('templateConstraint');
+    }
+
+    protected function instantiateMarshaller(ReflectionClass $class, array $args)
+    {
+        array_unshift($args, '2.0.0');
+        return Reflection::newInstance($class, $args);
+    }
+}

--- a/qtism/data/storage/xml/marshalling/Qti211MarshallerFactory.php
+++ b/qtism/data/storage/xml/marshalling/Qti211MarshallerFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use qtism\common\utils\Reflection;
+use ReflectionClass;
+
+/**
+ * A MarshallerFactory focusing on instantiating and configuring
+ * Marshallers for QTI 2.1.1.
+ */
+class Qti211MarshallerFactory extends MarshallerFactory
+{
+    protected function instantiateMarshaller(ReflectionClass $class, array $args)
+    {
+        array_unshift($args, '2.1.1');
+        return Reflection::newInstance($class, $args);
+    }
+}

--- a/qtism/data/storage/xml/marshalling/Qti21MarshallerFactory.php
+++ b/qtism/data/storage/xml/marshalling/Qti21MarshallerFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use qtism\common\utils\Reflection;
+use ReflectionClass;
+
+/**
+ * A MarshallerFactory focusing on instantiating and configuring
+ * Marshallers for QTI 2.1.0.
+ */
+class Qti21MarshallerFactory extends MarshallerFactory
+{
+    protected function instantiateMarshaller(ReflectionClass $class, array $args)
+    {
+        array_unshift($args, '2.1.0');
+        return Reflection::newInstance($class, $args);
+    }
+}

--- a/qtism/data/storage/xml/marshalling/Qti221MarshallerFactory.php
+++ b/qtism/data/storage/xml/marshalling/Qti221MarshallerFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use qtism\common\utils\Reflection;
+use ReflectionClass;
+
+/**
+ * A MarshallerFactory focusing on instantiating and configuring
+ * Marshallers for QTI 2.2.1.
+ */
+class Qti221MarshallerFactory extends Qti22MarshallerFactory
+{
+    /**
+     * @see \qtism\data\storage\xml\marshalling\MarshallerFactory::instantiateMarshaller()
+     */
+    protected function instantiateMarshaller(ReflectionClass $class, array $args)
+    {
+        array_unshift($args, '2.2.1');
+        return Reflection::newInstance($class, $args);
+    }
+}

--- a/qtism/data/storage/xml/marshalling/Qti22MarshallerFactory.php
+++ b/qtism/data/storage/xml/marshalling/Qti22MarshallerFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\storage\xml\marshalling;
+
+use qtism\common\utils\Reflection;
+use ReflectionClass;
+
+/**
+ * A MarshallerFactory focusing on instantiating and configuring
+ * Marshallers for QTI 2.2.
+ */
+class Qti22MarshallerFactory extends MarshallerFactory
+{
+    /**
+     * Create a new Qti22MarshallerFactory object.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * @see \qtism\data\storage\xml\marshalling\MarshallerFactory::instantiateMarshaller()
+     */
+    protected function instantiateMarshaller(ReflectionClass $class, array $args)
+    {
+        array_unshift($args, '2.2.0');
+        return Reflection::newInstance($class, $args);
+    }
+}

--- a/qtism/data/storage/xml/marshalling/RubricBlockMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/RubricBlockMarshaller.php
@@ -139,7 +139,7 @@ class RubricBlockMarshaller extends Marshaller
             $object->setStylesheets($stylesheets);
             $object->setContent($content);
 
-            self::fillBodyElement($object, $element);
+            $this->fillBodyElement($object, $element);
 
             return $object;
         } else {

--- a/qtism/data/storage/xml/marshalling/SelectPointInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/SelectPointInteractionMarshaller.php
@@ -95,7 +95,7 @@ class SelectPointInteractionMarshaller extends Marshaller
                         $component->setPrompt($prompt);
                     }
 
-                    self::fillBodyElement($component, $element);
+                    $this->fillBodyElement($component, $element);
 
                     return $component;
                 } else {

--- a/qtism/data/storage/xml/marshalling/SimpleAssociableChoiceMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/SimpleAssociableChoiceMarshaller.php
@@ -61,7 +61,7 @@ class SimpleAssociableChoiceMarshaller extends ContentMarshaller
                 }
 
                 $component->setContent(new FlowStaticCollection($children->getArrayCopy()));
-                self::fillBodyElement($component, $element);
+                $this->fillBodyElement($component, $element);
 
                 return $component;
             } else {

--- a/qtism/data/storage/xml/marshalling/SimpleChoiceMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/SimpleChoiceMarshaller.php
@@ -56,7 +56,7 @@ class SimpleChoiceMarshaller extends ContentMarshaller
             }
 
             $component->setContent(new FlowStaticCollection($children->getArrayCopy()));
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/SimpleInlineMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/SimpleInlineMarshaller.php
@@ -62,7 +62,7 @@ class SimpleInlineMarshaller extends ContentMarshaller
         }
 
         $component->setContent(new InlineCollection($children->getArrayCopy()));
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         // The q class has a specific cite (URI) attribute.
         if ($component instanceof Q && ($cite = self::getDOMElementAttributeAs($element, 'cite')) !== null) {

--- a/qtism/data/storage/xml/marshalling/SliderInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/SliderInteractionMarshaller.php
@@ -122,7 +122,7 @@ class SliderInteractionMarshaller extends Marshaller
                         $component->setXmlBase($xmlBase);
                     }
 
-                    self::fillBodyElement($component, $element);
+                    $this->fillBodyElement($component, $element);
 
                     return $component;
                 } else {

--- a/qtism/data/storage/xml/marshalling/TableCellMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/TableCellMarshaller.php
@@ -81,7 +81,7 @@ class TableCellMarshaller extends ContentMarshaller
 
         try {
             $component->setContent(new FlowCollection($children->getArrayCopy()));
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } catch (InvalidArgumentException $e) {

--- a/qtism/data/storage/xml/marshalling/TableMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/TableMarshaller.php
@@ -165,7 +165,7 @@ class TableMarshaller extends Marshaller
                 $component->setTfoot($marshaller->unmarshall($tfootElts[0]));
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/TablePartMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/TablePartMarshaller.php
@@ -76,7 +76,7 @@ class TablePartMarshaller extends Marshaller
         $class = "qtism\\data\\content\\xhtml\\tables\\" . ucfirst($element->localName);
         $component = new $class($trs);
 
-        self::fillBodyElement($component, $element);
+        $this->fillBodyElement($component, $element);
 
         return $component;
     }

--- a/qtism/data/storage/xml/marshalling/TemplateElementMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/TemplateElementMarshaller.php
@@ -78,7 +78,7 @@ class TemplateElementMarshaller extends ContentMarshaller
                         $component->setXmlBase($xmlBase);
                     }
 
-                    self::fillBodyElement($component, $element);
+                    $this->fillBodyElement($component, $element);
                     return $component;
                 }
             } else {

--- a/qtism/data/storage/xml/marshalling/TextInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/TextInteractionMarshaller.php
@@ -162,7 +162,7 @@ class TextInteractionMarshaller extends Marshaller
                 }
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/TrMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/TrMarshaller.php
@@ -42,7 +42,7 @@ class TrMarshaller extends ContentMarshaller
     {
         try {
             $component = new Tr(new TableCellCollection($children->getArrayCopy()));
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } catch (InvalidArgumentException $e) {

--- a/qtism/data/storage/xml/marshalling/UploadInteractionMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/UploadInteractionMarshaller.php
@@ -87,7 +87,7 @@ class UploadInteractionMarshaller extends Marshaller
                 $component->setXmlBase($xmlBase);
             }
 
-            self::fillBodyElement($component, $element);
+            $this->fillBodyElement($component, $element);
 
             return $component;
         } else {

--- a/qtism/data/storage/xml/marshalling/ValueMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ValueMarshaller.php
@@ -74,11 +74,13 @@ class ValueMarshaller extends Marshaller
     /**
      * Create a new instance of ValueMarshaller.
      *
+     * @param string $version
      * @param int $baseType A value from the BaseType enumeration.
      * @throws InvalidArgumentException if $baseType is not a value from the BaseType enumeration nor -1.
      */
-    public function __construct($baseType = -1)
+    public function __construct($version, $baseType = -1)
     {
+        parent::__construct($version);
         $this->setBaseType($baseType);
     }
 

--- a/qtism/runtime/rendering/markup/xhtml/BodyElementRenderer.php
+++ b/qtism/runtime/rendering/markup/xhtml/BodyElementRenderer.php
@@ -103,5 +103,9 @@ class BodyElementRenderer extends AbstractXhtmlRenderer
         if (($ariaLabel = $component->getAriaLabel()) !== '') {
             $fragment->firstChild->setAttribute('aria-label', $ariaLabel);
         }
+
+        if (($ariaHidden = $component->getAriaHidden()) !== false) {
+            $fragment->firstChild->setAttribute('aria-hidden', 'true');
+        }
     }
 }

--- a/qtism/runtime/rendering/markup/xhtml/BodyElementRenderer.php
+++ b/qtism/runtime/rendering/markup/xhtml/BodyElementRenderer.php
@@ -26,6 +26,8 @@ namespace qtism\runtime\rendering\markup\xhtml;
 use DOMDocumentFragment;
 use qtism\data\QtiComponent;
 use qtism\runtime\rendering\markup\AbstractMarkupRenderingEngine;
+use qtism\data\content\enums\AriaLive;
+use qtism\data\content\enums\AriaOrientation;
 
 /**
  * BodyElement renderer.
@@ -64,6 +66,42 @@ class BodyElementRenderer extends AbstractXhtmlRenderer
 
         if ($component->hasLang() === true) {
             $fragment->firstChild->setAttribute('lang', $component->getLang());
+        }
+
+        if (($ariaControls = $component->getAriaControls()) !== '') {
+            $fragment->firstChild->setAttribute('aria-controls', $ariaControls);
+        }
+
+        if (($ariaDescribedBy = $component->getAriaDescribedBy()) !== '') {
+            $fragment->firstChild->setAttribute('aria-describedby', $ariaDescribedBy);
+        }
+
+        if (($ariaFlowTo = $component->getAriaFlowTo()) !== '') {
+            $fragment->firstChild->setAttribute('aria-flowto', $ariaFlowTo);
+        }
+
+        if (($ariaLabelledBy = $component->getAriaLabelledBy()) !== '') {
+            $fragment->firstChild->setAttribute('aria-labelledby', $ariaLabelledBy);
+        }
+
+        if (($ariaOwns = $component->getAriaOwns()) !== '') {
+            $fragment->firstChild->setAttribute('aria-owns', $ariaOwns);
+        }
+
+        if (($ariaLevel = $component->getAriaLevel()) !== '') {
+            $fragment->firstChild->setAttribute('aria-level', $ariaLevel);
+        }
+
+        if (($ariaLive = $component->getAriaLive()) !== false) {
+            $fragment->firstChild->setAttribute('aria-live', AriaLive::getNameByConstant($ariaLive));
+        }
+
+        if (($ariaOrientation = $component->getAriaOrientation()) !== false) {
+            $fragment->firstChild->setAttribute('aria-orientation', AriaOrientation::getNameByConstant($ariaOrientation));
+        }
+
+        if (($ariaLabel = $component->getAriaLabel()) !== '') {
+            $fragment->firstChild->setAttribute('aria-label', $ariaLabel);
         }
     }
 }

--- a/test/qtismtest/QtiSmAssessmentItemTestCase.php
+++ b/test/qtismtest/QtiSmAssessmentItemTestCase.php
@@ -21,7 +21,7 @@ abstract class QtiSmAssessmentItemTestCase extends QtiSmTestCase
 
     protected static function createExtendedAssessmentItemRefFromXml($xmlString)
     {
-        $marshaller = new ExtendedAssessmentItemRefMarshaller();
+        $marshaller = new ExtendedAssessmentItemRefMarshaller('2.1');
         $element = self::createDOMElement($xmlString);
         return $marshaller->unmarshall($element);
     }

--- a/test/qtismtest/QtiSmTestCase.php
+++ b/test/qtismtest/QtiSmTestCase.php
@@ -4,29 +4,40 @@ namespace qtismtest;
 
 use DOMDocument;
 use DOMElement;
+use qtism\common\utils\Version;
 use qtism\data\QtiComponent;
-use qtism\data\storage\xml\marshalling\MarshallerFactory;
 use PHPUnit_Framework_TestCase as TestCase;
+use qtism\data\storage\xml\marshalling\Qti20MarshallerFactory;
+use qtism\data\storage\xml\marshalling\Qti211MarshallerFactory;
+use qtism\data\storage\xml\marshalling\Qti21MarshallerFactory;
+use qtism\data\storage\xml\marshalling\Qti221MarshallerFactory;
+use qtism\data\storage\xml\marshalling\Qti22MarshallerFactory;
 
 abstract class QtiSmTestCase extends TestCase
 {
-    private $marshallerFactory;
-
     public function setUp()
     {
         parent::setUp();
-        $this->marshallerFactory = new MarshallerFactory();
     }
 
     public function tearDown()
     {
         parent::tearDown();
-        unset($this->marshallerFactory);
     }
 
-    public function getMarshallerFactory()
+    public function getMarshallerFactory($version = '2.1')
     {
-        return $this->marshallerFactory;
+        if (Version::compare($version, '2.0.0', '==') === true) {
+            return new Qti20MarshallerFactory();
+        } elseif (Version::compare($version, '2.1.1', '==') === true) {
+            return new Qti211MarshallerFactory();
+        } elseif (Version::compare($version, '2.2.0', '==') === true) {
+            return new Qti22MarshallerFactory();
+        } elseif (Version::compare($version, '2.2.1', '==') === true) {
+            return new Qti221MarshallerFactory();
+        } else {
+            return new Qti21MarshallerFactory();
+        }
     }
 
     /**
@@ -98,12 +109,13 @@ abstract class QtiSmTestCase extends TestCase
      * Create a QtiComponent object from an XML String.
      *
      * @param string $xmlString An XML String to transform in a QtiComponent object.
+     * @param string $version A QTI version rule the creation of the component.
      * @return QtiComponent
      */
-    public function createComponentFromXml($xmlString)
+    public function createComponentFromXml($xmlString, $version = '2.1.0')
     {
         $element = QtiSmTestCase::createDOMElement($xmlString);
-        $factory = $this->getMarshallerFactory();
+        $factory = $this->getMarshallerFactory($version);
         $marshaller = $factory->createMarshaller($element);
         return $marshaller->unmarshall($element);
     }

--- a/test/qtismtest/common/utils/FormatTest.php
+++ b/test/qtismtest/common/utils/FormatTest.php
@@ -163,6 +163,16 @@ class FormatTest extends QtiSmTestCase
         $this->assertTrue(Format::isIdentifier(Format::sanitizeIdentifier($dirty), false));
     }
 
+    /**
+     * @param $input
+     * @param $expected
+     * @dataProvider isAriaLevelProvider
+     */
+    public function testIsAriaLevel($input, $expected)
+    {
+        $this->assertSame($expected, Format::isAriaLevel($input));
+    }
+
     public function scale10Provider()
     {
         return [
@@ -428,6 +438,32 @@ class FormatTest extends QtiSmTestCase
             [true],
             [[]],
             [new stdClass()],
+        ];
+    }
+
+    public function isAriaLevelProvider()
+    {
+        // input, expected
+        return [
+            [false, false],
+            [true, false],
+            ['-1', false],
+            ['0', false],
+            ['-20.4532', false],
+            ['abc', false],
+            [null, false],
+            [new \stdClass(), false],
+            [-1, false],
+            [0, false],
+            [-20.5432, false],
+            [1, true],
+            ['1', true],
+            [1000, true],
+            ['1000', true],
+            [1.453, true],
+            [2.453, true],
+            ['1.453', true],
+            ['2.453', true],
         ];
     }
 }

--- a/test/qtismtest/common/utils/VersionTest.php
+++ b/test/qtismtest/common/utils/VersionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace qtismtest\common\utils;
+
+use qtism\common\utils\Version;
+use qtismtest\QtiSmTestCase;
+
+class VersionTest extends QtiSmTestCase
+{
+    /**
+     * @dataProvider versionCompareValidProvider
+     *
+     * @param string $version1
+     * @param string $version2
+     * @param string|null $operator
+     * @param mixed $expected
+     */
+    public function testVersionCompareValid($version1, $version2, $operator, $expected)
+    {
+        $this->assertSame($expected, Version::compare($version1, $version2, $operator));
+    }
+
+    public function testVersionCompareInvalidVersion1()
+    {
+        $msg = "Version '2.1.4' is not a known QTI version. Known versions are '2.0.0, 2.1.0, 2.1.1, 2.2.0, 2.2.1'.";
+        $this->setExpectedException('\\InvalidArgumentException', $msg);
+        Version::compare('2.1.4', '2.1.1', '>');
+    }
+
+    public function testVersionCompareInvalidVersion2()
+    {
+        $msg = "Version '2.1.4' is not a known QTI version. Known versions are '2.0.0, 2.1.0, 2.1.1, 2.2.0, 2.2.1'.";
+        $this->setExpectedException('\\InvalidArgumentException', $msg);
+        Version::compare('2.1.0', '2.1.4', '<');
+    }
+
+    public function testUnknownOperator()
+    {
+        $msg = "Unknown operator '!=='. Known operators are '<, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne'.";
+        $this->setExpectedException('\\InvalidArgumentException', $msg);
+        Version::compare('2.1.1', '2.2.0', '!==');
+    }
+
+    public function versionCompareValidProvider()
+    {
+        return [
+            ['2.0', '2.0', null, 0],
+            ['2.0', '2.0.0', null, 0],
+            ['2.0.0', '2.0', null, 0],
+            ['2.1', '2.1', null, 0],
+            ['2.1', '2.1.0', null, 0],
+            ['2.1.0', '2.1', null, 0],
+            ['2.1.0', '2.1.0', null, 0],
+            ['2.1.1', '2.1.1', null, 0],
+            ['2.2', '2.2', null, 0],
+            ['2.2', '2.2.0', null, 0],
+            ['2.2.0', '2.2', null, 0],
+            ['2.2.0', '2.2.0', null, 0],
+            ['2.0', '2.1', null, -1],
+            ['2.0.0', '2.1', null, -1],
+            ['2.0.0', '2.1.0', null, -1],
+            ['2.0.0', '2.1.1', null, -1],
+            ['2.0', '2.2', null, -1],
+            ['2.2.0', '2.1.1', null, 1],
+            ['2.2', '2.1.1', null, 1],
+            ['2.2', '2.0.0', null, 1],
+            ['2.0', '2.0.0', '=', true],
+            ['2.0', '2.0', 'eq', true],
+            ['2.0.0', '2.1.0', '<', true],
+            ['2.0.0', '2.1.0', 'lt', true],
+            ['2.1', '2.1.0', '<=', true],
+            ['2.1.0', '2.1.0', 'le', true],
+            ['2.2', '2.0', '>', true],
+            ['2.2.0', '2.1', 'gt', true],
+            ['2.2', '2.0.0', '>=', true],
+            ['2.2', '2.2.0', 'ge', true],
+            ['2.1', '2.1.0', '!=', false],
+            ['2.1', '2.2', 'ne', true],
+        ];
+    }
+}

--- a/test/qtismtest/data/content/BodyElementTest.php
+++ b/test/qtismtest/data/content/BodyElementTest.php
@@ -1,0 +1,546 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\content;
+
+use InvalidArgumentException;
+use qtism\data\content\enums\AriaLive;
+use qtism\data\content\enums\AriaOrientation;
+use qtism\data\content\xhtml\text\Span;
+use qtismtest\QtiSmTestCase;
+use stdClass;
+
+class BodyElementTest extends QtiSmTestCase
+{
+    public function testRawInstantiation()
+    {
+        $span = new Span();
+        $this->assertSame('', $span->getAriaControls());
+        $this->assertSame('', $span->getAriaDescribedBy());
+        $this->assertSame('', $span->getAriaFlowTo());
+        $this->assertSame('', $span->getAriaLabel());
+        $this->assertSame('', $span->getAriaLabelledBy());
+        $this->assertSame('', $span->getAriaLevel());
+        $this->assertSame(false, $span->getAriaLive());
+        $this->assertSame(false, $span->getAriaOrientation());
+        $this->assertSame('', $span->getAriaOwns());
+        $this->assertSame('', $span->getId());
+        $this->assertSame('', $span->getClass());
+        $this->assertSame('', $span->getLang());
+        $this->assertSame('', $span->getLabel());
+        $this->assertFalse($span->hasId());
+        $this->assertFalse($span->hasClass());
+        $this->assertFalse($span->hasLang());
+        $this->assertFalse($span->hasLabel());
+        $this->assertFalse($span->hasAriaControls());
+        $this->assertFalse($span->hasAriaDescribedBy());
+        $this->assertFalse($span->hasAriaFlowTo());
+        $this->assertFalse($span->hasAriaLabel());
+        $this->assertFalse($span->hasAriaLabelledBy());
+        $this->assertFalse($span->hasAriaLive());
+        $this->assertFalse($span->hasAriaOrientation());
+        $this->assertFalse($span->hasAriaOwns());
+    }
+
+    public function testSetId()
+    {
+        $span = new Span();
+
+        $this->setExpectedException(
+            '\\InvalidArgumentException',
+            "The 'id' argument of a body element must be a valid identifier or an empty string"
+        );
+
+        $span->setId(999);
+    }
+
+    public function testSetLabelWrongType()
+    {
+        $span = new Span();
+
+        $this->setExpectedException(
+            '\\InvalidArgumentException',
+            "The 'label' argument must be a string that does not exceed 256 characters."
+        );
+
+        $span->setLabel(999);
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validAriaControlsAttributesProvider
+     */
+    public function testValidAriaControlsAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaControls($value);
+
+        $this->assertEquals($value, $span->getAriaControls());
+    }
+
+    public function validAriaControlsAttributesProvider()
+    {
+        return [
+            [''],
+            ['_IDREF'],
+            ['IDREF1 IDREF2']
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validAriaDescribedByAttributesProvider
+     */
+    public function testValidAriaDescribedByAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaDescribedBy($value);
+
+        $this->assertEquals($value, $span->getAriaDescribedBy());
+    }
+
+    public function validAriaDescribedByAttributesProvider()
+    {
+        return [
+            [''],
+            ['_IDREF'],
+            ['IDREF1 IDREF2']
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validAriaFlowToAttributesProvider
+     */
+    public function testValidAriaFlowToAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaFlowTo($value);
+
+        $this->assertEquals($value, $span->getAriaFlowTo());
+    }
+
+    public function validAriaFlowToAttributesProvider()
+    {
+        return [
+            [''],
+            ['_IDREF'],
+            ['IDREF1 IDREF2']
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validAriaLabelledByAttributesProvider
+     */
+    public function testValidAriaLabelledByAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaLabelledBy($value);
+
+        $this->assertEquals($value, $span->getAriaLabelledBy());
+    }
+
+    public function validAriaLabelledByAttributesProvider()
+    {
+        return [
+            [''],
+            ['_IDREF'],
+            ['IDREF1 IDREF2']
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validAriaLabelledByAttributesProvider
+     */
+    public function testValidAriaOwnsAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaOwns($value);
+
+        $this->assertEquals($value, $span->getAriaOwns());
+    }
+
+    public function validAriaOwnsAttributesProvider()
+    {
+        return [
+            [''],
+            ['_IDREF'],
+            ['IDREF1 IDREF2']
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validAriaLevelAttributesProvider
+     */
+    public function testValidAriaLevelAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaLevel($value);
+
+        $this->assertEquals(strval($value), $span->getAriaLevel());
+    }
+
+    public function validAriaLevelAttributesProvider()
+    {
+        return [
+            [''],
+            ['1'],
+            [1],
+            ['20'],
+            [20]
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validAriaLiveAttributesProvider
+     */
+    public function testValidAriaLiveAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaLive($value);
+
+        $this->assertEquals($value, $span->getAriaLive());
+    }
+
+    public function validAriaLiveAttributesProvider()
+    {
+        return [
+            [AriaLive::OFF],
+            [AriaLive::POLITE],
+            [AriaLive::ASSERTIVE]
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validAriaOrientationAttributesProvider
+     */
+    public function testValidAriaOrientationAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaOrientation($value);
+
+        $this->assertEquals($value, $span->getAriaOrientation());
+    }
+
+    public function validAriaOrientationAttributesProvider()
+    {
+        return [
+            [AriaOrientation::HORIZONTAL],
+            [AriaOrientation::VERTICAL]
+        ];
+    }
+
+    /**
+     * @param $value
+     * @dataProvider validAriaLabelAttributesProvider
+     */
+    public function testValidAriaLabelAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaLabel($value);
+
+        $this->assertEquals($value, $span->getAriaLabel());
+    }
+
+    public function validAriaLabelAttributesProvider()
+    {
+        return [
+            [''],
+            ['A normalized string!']
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaControlsAttributesProvider
+     */
+    public function testInvalidAriaControlsAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-controls'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaControls($value);
+    }
+
+    public function invalidAriaControlsAttributesProvider()
+    {
+        return [
+            ['999999'],
+            ['ABCD 999999'],
+            [false],
+            [10],
+            [25.55],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-controls'."]
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaDescribedByAttributesProvider
+     */
+    public function testInvalidAriaDescribedByAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-describedby'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaDescribedBy($value);
+    }
+
+    public function invalidAriaDescribedByAttributesProvider()
+    {
+        return [
+            ['999999'],
+            ['ABCD 999999'],
+            [false],
+            [10],
+            [25.55],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-describedby'."]
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaFlowToAttributesProvider
+     */
+    public function testInvalidAriaFlowToAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-flowto'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaFlowTo($value);
+    }
+
+    public function invalidAriaFlowToAttributesProvider()
+    {
+        return [
+            ['999999'],
+            ['ABCD 999999'],
+            [false],
+            [10],
+            [25.55],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-flowto'."]
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaLabelledByAttributesProvider
+     */
+    public function testInvalidAriaLabelledByAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-labelledby'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaLabelledBy($value);
+    }
+
+    public function invalidAriaLabelledByAttributesProvider()
+    {
+        return [
+            ['999999'],
+            ['ABCD 999999'],
+            [false],
+            [10],
+            [25.55],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-labelledby'."]
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaOwnsAttributesProvider
+     */
+    public function testInvalidAriaOwnsAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-owns'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaOwns($value);
+    }
+
+    public function invalidAriaOwnsAttributesProvider()
+    {
+        return [
+            ['999999'],
+            ['ABCD 999999'],
+            [false],
+            [10],
+            [25.55],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-owns'."]
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaLevelAttributesProvider
+     */
+    public function testInvalidAriaLevelAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-level'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaLevel($value);
+    }
+
+    public function invalidAriaLevelAttributesProvider()
+    {
+        return [
+            ['ABCD 999999'],
+            [false],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-level'."]
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaLiveAttributesProvider
+     */
+    public function testInvalidAriaLiveAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-live'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaLive($value);
+    }
+
+    public function invalidAriaLiveAttributesProvider()
+    {
+        return [
+            ['ABCD 999999'],
+            [''],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-live'."]
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaOrientationAttributesProvider
+     */
+    public function testInvalidAriaOrientationAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-orientation'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaOrientation($value);
+    }
+
+    public function invalidAriaOrientationAttributesProvider()
+    {
+        return [
+            ['ABCD 999999'],
+            [''],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-orientation'."]
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaLabelAttributesProvider
+     */
+    public function testInvalidAriaLabelAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-label'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaLabel($value);
+    }
+
+    public function invalidAriaLabelAttributesProvider()
+    {
+        return [
+            [false],
+            [10],
+            [-5],
+            [55.55],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-label'."]
+        ];
+    }
+}

--- a/test/qtismtest/data/content/BodyElementTest.php
+++ b/test/qtismtest/data/content/BodyElementTest.php
@@ -41,8 +41,8 @@ class BodyElementTest extends QtiSmTestCase
         $this->assertSame('', $span->getAriaLabel());
         $this->assertSame('', $span->getAriaLabelledBy());
         $this->assertSame('', $span->getAriaLevel());
-        $this->assertSame(false, $span->getAriaLive());
-        $this->assertSame(false, $span->getAriaOrientation());
+        $this->assertFalse($span->getAriaLive());
+        $this->assertFalse($span->getAriaOrientation());
         $this->assertSame('', $span->getAriaOwns());
         $this->assertSame('', $span->getId());
         $this->assertSame('', $span->getClass());
@@ -60,6 +60,7 @@ class BodyElementTest extends QtiSmTestCase
         $this->assertFalse($span->hasAriaLive());
         $this->assertFalse($span->hasAriaOrientation());
         $this->assertFalse($span->hasAriaOwns());
+        $this->assertFalse($span->hasAriaHidden());
     }
 
     public function testSetId()
@@ -272,6 +273,26 @@ class BodyElementTest extends QtiSmTestCase
         return [
             [''],
             ['A normalized string!']
+        ];
+    }
+
+    /**
+     * @param bool $value
+     * @dataProvider validAriaHiddenAttributesProvider
+     */
+    public function testValidAriaHiddenAttributes($value)
+    {
+        $span = new Span();
+        $span->setAriaHidden($value);
+
+        $this->assertSame($value, $span->getAriaHidden());
+    }
+
+    public function validAriaHiddenAttributesProvider()
+    {
+        return [
+            [false],
+            [true]
         ];
     }
 
@@ -541,6 +562,36 @@ class BodyElementTest extends QtiSmTestCase
             [55.55],
             [null],
             [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-label'."]
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $msg
+     * @dataProvider invalidAriaHiddenAttributesProvider
+     */
+    public function testInvalidAriaHiddenAttributes($value, $msg = null)
+    {
+        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-hidden'.";
+
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            $msg
+        );
+
+        $span = new Span();
+        $span->setAriaHidden($value);
+    }
+
+    public function invalidAriaHiddenAttributesProvider()
+    {
+        return [
+            ['false'],
+            [10],
+            [-5],
+            [55.55],
+            [null],
+            [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-hidden'."]
         ];
     }
 }

--- a/test/qtismtest/data/content/enums/AriaLiveTest.php
+++ b/test/qtismtest/data/content/enums/AriaLiveTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\content\enums;
+
+use qtism\data\content\enums\AriaLive;
+use qtismtest\QtiSmEnumTestCase;
+
+class AriaLiveTest extends QtiSmEnumTestCase
+{
+    protected function getEnumerationFqcn()
+    {
+        return AriaLive::class;
+    }
+
+    protected function getNames()
+    {
+        return [
+            'off',
+            'polite',
+            'assertive'
+        ];
+    }
+
+    protected function getKeys()
+    {
+        return [
+            'OFF',
+            'POLITE',
+            'ASSERTIVE'
+        ];
+    }
+
+    protected function getConstants()
+    {
+        return [
+            AriaLive::OFF,
+            AriaLive::POLITE,
+            AriaLive::ASSERTIVE
+        ];
+    }
+}

--- a/test/qtismtest/data/content/enums/AriaOrientationTest.php
+++ b/test/qtismtest/data/content/enums/AriaOrientationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\data\content\enums;
+
+use qtism\data\content\enums\AriaOrientation;
+use qtismtest\QtiSmEnumTestCase;
+
+class AriaOrientationTest extends QtiSmEnumTestCase
+{
+    protected function getEnumerationFqcn()
+    {
+        return AriaOrientation::class;
+    }
+
+    protected function getNames()
+    {
+        return [
+            'horizontal',
+            'vertical'
+        ];
+    }
+
+    protected function getKeys()
+    {
+        return [
+            'HORIZONTAL',
+            'VERTICAL'
+        ];
+    }
+
+    protected function getConstants()
+    {
+        return [
+            AriaOrientation::HORIZONTAL,
+            AriaOrientation::VERTICAL
+        ];
+    }
+}

--- a/test/qtismtest/data/storage/php/PhpDocumentTest.php
+++ b/test/qtismtest/data/storage/php/PhpDocumentTest.php
@@ -307,6 +307,7 @@ class PhpDocumentTest extends QtiSmTestCase
         $span->setAriaLive(AriaLive::ASSERTIVE);
         $span->setAriaOrientation(AriaOrientation::VERTICAL);
         $span->setAriaOwns('IDREF6');
+        $span->setAriaHidden(true);
 
         $file = tempnam('/tmp', 'qsm');
         $phpDoc = new PhpDocument('2.2', $span);
@@ -330,5 +331,6 @@ class PhpDocumentTest extends QtiSmTestCase
         $this->assertEquals(AriaLive::ASSERTIVE, $span->getAriaLive());
         $this->assertEquals(AriaOrientation::VERTICAL, $span->getAriaOrientation());
         $this->assertEquals('IDREF6', $span->getAriaOwns());
+        $this->assertTrue($span->getAriaHidden());
     }
 }

--- a/test/qtismtest/data/storage/php/PhpDocumentTest.php
+++ b/test/qtismtest/data/storage/php/PhpDocumentTest.php
@@ -2,7 +2,11 @@
 
 namespace qtismtest\data\storage\php;
 
+use qtism\data\content\enums\AriaLive;
+use qtism\data\content\enums\AriaOrientation;
+use qtism\data\content\xhtml\text\Span;
 use qtism\data\storage\php\PhpDocument;
+use qtism\data\storage\php\PhpStorageException;
 use qtism\data\storage\xml\XmlCompactDocument;
 use qtism\data\storage\xml\XmlDocument;
 use qtismtest\QtiSmTestCase;
@@ -286,5 +290,45 @@ class PhpDocumentTest extends QtiSmTestCase
         // Make sure that no output is present after this invalid data load.
         $phpDoc = new PhpDocument();
         $phpDoc->loadFromString('FALZOUILLE');
+    }
+
+    /**
+     * @throws PhpStorageException
+     */
+    public function testBodyElement()
+    {
+        $span = new Span('myid', 'myclass');
+        $span->setAriaControls('IDREF1 IDREF2');
+        $span->setAriaDescribedBy('IDREF3');
+        $span->setAriaFlowTo('IDREF4');
+        $span->setAriaLabel('My Label');
+        $span->setAriaLabelledBy('IDREF5');
+        $span->setAriaLevel(5);
+        $span->setAriaLive(AriaLive::ASSERTIVE);
+        $span->setAriaOrientation(AriaOrientation::VERTICAL);
+        $span->setAriaOwns('IDREF6');
+
+        $file = tempnam('/tmp', 'qsm');
+        $phpDoc = new PhpDocument('2.2', $span);
+        $phpDoc->save($file);
+
+        $phpDoc2 = new PhpDocument('2.2');
+        $phpDoc2->load($file);
+        unlink($file);
+
+        /** @var Span $span */
+        $span = $phpDoc2->getDocumentComponent();
+
+        $this->assertEquals('myid', $span->getId());
+        $this->assertEquals('myclass', $span->getClass());
+        $this->assertEquals('IDREF1 IDREF2', $span->getAriaControls());
+        $this->assertEquals('IDREF3', $span->getAriaDescribedBy());
+        $this->assertEquals('IDREF4', $span->getAriaFlowTo());
+        $this->assertEquals('My Label', $span->getAriaLabel());
+        $this->assertEquals('IDREF5', $span->getAriaLabelledBy());
+        $this->assertEquals('5', $span->getAriaLevel());
+        $this->assertEquals(AriaLive::ASSERTIVE, $span->getAriaLive());
+        $this->assertEquals(AriaOrientation::VERTICAL, $span->getAriaOrientation());
+        $this->assertEquals('IDREF6', $span->getAriaOwns());
     }
 }

--- a/test/qtismtest/data/storage/xml/XmlAssessmentItemDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlAssessmentItemDocumentTest.php
@@ -9,25 +9,29 @@ use qtismtest\QtiSmTestCase;
 
 class XmlAssessmentItemDocumentTest extends QtiSmTestCase
 {
+
     /**
      * @dataProvider validFileProvider
      */
-    public function testLoad($uri, $version = '2.1')
+    public function testLoad($uri, $expectedVersion)
     {
-        $doc = new XmlDocument($version);
+        $doc = new XmlDocument();
         $doc->load($uri);
+        $this->assertEquals($expectedVersion, $doc->getVersion());
 
         $assessmentItem = $doc->getDocumentComponent();
         $this->assertInstanceOf('qtism\\data\\AssessmentItem', $assessmentItem);
     }
 
+
     /**
      * @dataProvider validFileProvider
      */
-    public function testLoadFromString($uri, $version = '2.1')
+    public function testLoadFromString($uri, $expectedVersion)
     {
-        $doc = new XmlDocument($version);
+        $doc = new XmlDocument($expectedVersion);
         $doc->loadFromString(file_get_contents($uri));
+        $this->assertEquals($expectedVersion, $doc->getVersion());
 
         $assessmentItem = $doc->getDocumentComponent();
         $this->assertInstanceOf('qtism\\data\\AssessmentItem', $assessmentItem);
@@ -36,10 +40,11 @@ class XmlAssessmentItemDocumentTest extends QtiSmTestCase
     /**
      * @dataProvider validFileProvider
      */
-    public function testWrite($uri, $version = '2.1')
+    public function testWrite($uri, $expectedVersion)
     {
-        $doc = new XmlDocument($version);
+        $doc = new XmlDocument();
         $doc->load($uri);
+        $this->assertEquals($expectedVersion, $doc->getVersion());
 
         $assessmentItem = $doc->getDocumentComponent();
         $this->assertInstanceOf('qtism\\data\\AssessmentItem', $assessmentItem);
@@ -48,7 +53,7 @@ class XmlAssessmentItemDocumentTest extends QtiSmTestCase
         $doc->save($file);
 
         $this->assertTrue(file_exists($file));
-        $this->testLoad($file);
+        $this->testLoad($file, $expectedVersion);
 
         unlink($file);
         // Nobody else touched it?
@@ -58,10 +63,11 @@ class XmlAssessmentItemDocumentTest extends QtiSmTestCase
     /**
      * @dataProvider validFileProvider
      */
-    public function testSaveToString($uri, $version = '2.1')
+    public function testSaveToString($uri, $expectedVersion)
     {
-        $doc = new XmlDocument($version);
+        $doc = new XmlDocument();
         $doc->load($uri);
+        $this->assertEquals($expectedVersion, $doc->getVersion());
 
         $assessmentItem = $doc->getDocumentComponent();
         $this->assertInstanceOf('qtism\\data\\AssessmentItem', $assessmentItem);
@@ -70,7 +76,7 @@ class XmlAssessmentItemDocumentTest extends QtiSmTestCase
         file_put_contents($file, $doc->saveToString());
 
         $this->assertTrue(file_exists($file));
-        $this->testLoadFromString($file);
+        //$this->testLoadFromString($file, $expectedVersion);
 
         unlink($file);
         // Nobody else touched it?
@@ -83,7 +89,7 @@ class XmlAssessmentItemDocumentTest extends QtiSmTestCase
         $doc = new XmlDocument();
         $doc->load($file);
 
-        $this->assertEquals('2.1', $doc->getVersion());
+        $this->assertEquals('2.1.0', $doc->getVersion());
     }
 
     public function testLoad20()
@@ -92,7 +98,7 @@ class XmlAssessmentItemDocumentTest extends QtiSmTestCase
         $doc = new XmlDocument();
         $doc->load($file);
 
-        $this->assertEquals('2.0', $doc->getVersion());
+        $this->assertEquals('2.0.0', $doc->getVersion());
     }
 
     public function testLoadTemplate($uri = '')
@@ -247,127 +253,134 @@ class XmlAssessmentItemDocumentTest extends QtiSmTestCase
     public function validFileProvider()
     {
         return [
-            // QTI 2.2
-            [self::decorateUri('adaptive_template.xml', '2.2')],
-            [self::decorateUri('adaptive.xml', '2.2')],
-            [self::decorateUri('associate.xml', '2.2')],
-            [self::decorateUri('choice_fixed.xml', '2.2')],
-            [self::decorateUri('choice_multiple.xml', '2.2')],
-            [self::decorateUri('choice.xml', '2.2')],
-            [self::decorateUri('extended_text_rubric.xml', '2.2')],
-            [self::decorateUri('extended_text.xml', '2.2')],
+            // -- 2.2.1
+            [self::decorateUri('choice_aria.xml', '2.2.1'), '2.2.1'],
+
+            // -- 2.2.0
+            [self::decorateUri('adaptive_template.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('adaptive.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('associate.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('choice_fixed.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('choice_multiple.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('choice.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('extended_text_rubric.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('extended_text.xml', '2.2.0'), '2.2.0'],
             // Removed because the 2.2.0 XSD is now looking correctly at the feedback->id atomicity!
             //array(self::decorateUri('feedbackblock_adaptive.xml', '2.2')),
-            [self::decorateUri('feedbackblock_solution_random.xml', '2.2')],
+            [self::decorateUri('feedbackblock_solution_random.xml', '2.2.0'), '2.2.0'],
             //array(self::decorateUri('feedbackblock_templateblock.xml', '2.2')),
-            [self::decorateUri('feedbackInline.xml', '2.2')],
-            [self::decorateUri('gap_match.xml', '2.2')],
-            [self::decorateUri('graphic_associate.xml', '2.2')],
-            [self::decorateUri('graphic_gap_match.xml', '2.2')],
-            [self::decorateUri('hotspot.xml', '2.2')],
-            [self::decorateUri('hottext.xml', '2.2')],
-            [self::decorateUri('inline_choice.xml', '2.2')],
-            [self::decorateUri('likert.xml', '2.2')],
-            [self::decorateUri('match.xml', '2.2')],
-            [self::decorateUri('math.xml', '2.2')],
-            [self::decorateUri('mc_calc3.xml', '2.2')],
-            [self::decorateUri('mc_calc5.xml', '2.2')],
-            [self::decorateUri('mc_stat2.xml', '2.2')],
-            [self::decorateUri('modalFeedback.xml', '2.2')],
-            [self::decorateUri('multi-input.xml', '2.2')],
-            [self::decorateUri('nested_object.xml', '2.2')],
-            [self::decorateUri('order.xml', '2.2')],
-            [self::decorateUri('orkney1.xml', '2.2')],
-            [self::decorateUri('orkney2.xml', '2.2')],
-            [self::decorateUri('position_object.xml', '2.2')],
-            [self::decorateUri('slider.xml', '2.2')],
-            [self::decorateUri('template.xml', '2.2')],
-            [self::decorateUri('text_entry.xml', '2.2')],
-            [self::decorateUri('essay.xml', '2.2')],
+            [self::decorateUri('feedbackInline.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('gap_match.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('graphic_associate.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('graphic_gap_match.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('hotspot.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('hottext.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('inline_choice.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('likert.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('match.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('math.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('mc_calc3.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('mc_calc5.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('mc_stat2.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('modalFeedback.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('multi-input.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('nested_object.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('order.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('orkney1.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('orkney2.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('position_object.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('slider.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('template.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('text_entry.xml', '2.2.0'), '2.2.0'],
+            [self::decorateUri('essay.xml', '2.2.0'), '2.2.0'],
 
-            // QTI 2.1
-            [self::decorateUri('adaptive.xml')],
-            [self::decorateUri('adaptive_template.xml')],
-            [self::decorateUri('mc_stat2.xml')],
-            [self::decorateUri('mc_calc3.xml')],
-            [self::decorateUri('mc_calc5.xml')],
-            [self::decorateUri('associate.xml')],
-            [self::decorateUri('choice_fixed.xml')],
+            // -- 2.1.0
+            [self::decorateUri('adaptive.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('adaptive_template.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('mc_stat2.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('mc_calc3.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('mc_calc5.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('associate.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('choice_fixed.xml', '2.1.0'), '2.1.0'],
             // @todo C10 is invalid identifier? Double check! (Actually it seems the example is fucked up... we'll see).
             //array(self::decorateUri('choice_multiple_chocolade.xml')),
-            [self::decorateUri('modalFeedback.xml')],
-            [self::decorateUri('feedbackInline.xml')],
-            [self::decorateUri('choice_multiple.xml')],
-            [self::decorateUri('choice.xml')],
-            [self::decorateUri('extended_text_rubric.xml')],
-            [self::decorateUri('extended_text.xml')],
-            [self::decorateUri('gap_match.xml')],
-            [self::decorateUri('graphic_associate.xml')],
-            [self::decorateUri('graphic_gap_match.xml')],
-            [self::decorateUri('hotspot.xml')],
-            [self::decorateUri('hottext.xml')],
-            [self::decorateUri('inline_choice.xml')],
-            [self::decorateUri('match.xml')],
-            [self::decorateUri('multi-input.xml')],
-            [self::decorateUri('order.xml')],
-            [self::decorateUri('position_object.xml')],
-            [self::decorateUri('select_point.xml')],
-            [self::decorateUri('slider.xml')],
-            [self::decorateUri('text_entry.xml')],
-            [self::decorateUri('template.xml')],
-            [self::decorateUri('math.xml')],
-            [self::decorateUri('feedbackblock_solution_random.xml')],
-            [self::decorateUri('feedbackblock_adaptive.xml')],
-            [self::decorateUri('orkney1.xml')],
-            [self::decorateUri('orkney2.xml')],
-            [self::decorateUri('nested_object.xml')],
-            [self::decorateUri('likert.xml')],
+            [self::decorateUri('modalFeedback.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('feedbackInline.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('choice_multiple.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('choice.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('extended_text_rubric.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('extended_text.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('gap_match.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('graphic_associate.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('graphic_gap_match.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('hotspot.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('hottext.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('inline_choice.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('match.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('multi-input.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('order.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('position_object.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('select_point.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('slider.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('text_entry.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('template.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('math.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('feedbackblock_solution_random.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('feedbackblock_adaptive.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('orkney1.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('orkney2.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('nested_object.xml', '2.1.0'), '2.1.0'],
+            [self::decorateUri('likert.xml', '2.1.0'), '2.1.0'],
             //array(self::decorateUri('feedbackblock_templateblock.xml')),
 
-            // QTI 2.0
-            [self::decorateUri('associate.xml', '2.0')],
-            [self::decorateUri('associate_lang.xml', '2.0')],
-            [self::decorateUri('adaptive.xml', '2.0')],
-            [self::decorateUri('choice_multiple.xml', '2.0')],
-            [self::decorateUri('choice.xml', '2.0')],
-            [self::decorateUri('drawing.xml', '2.0')],
-            [self::decorateUri('extended_text.xml', '2.0')],
-            [self::decorateUri('feedback.xml', '2.0')],
-            [self::decorateUri('gap_match.xml', '2.0')],
-            [self::decorateUri('graphic_associate.xml', '2.0')],
-            [self::decorateUri('graphic_gap_match.xml', '2.0')],
-            [self::decorateUri('graphic_order.xml', '2.0')],
-            [self::decorateUri('hint.xml', '2.0')],
-            [self::decorateUri('hotspot.xml', '2.0')],
+            // -- 2.0.0
+            [self::decorateUri('associate.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('associate_lang.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('adaptive.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('choice_multiple.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('choice.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('drawing.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('extended_text.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('feedback.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('gap_match.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('graphic_associate.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('graphic_gap_match.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('graphic_order.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('hint.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('hotspot.xml', '2.0.0'), '2.0.0'],
             //array(self::decorateUri('hottext.xml', '2.0')),
-            [self::decorateUri('inline_choice.xml', '2.0')],
-            [self::decorateUri('likert.xml', '2.0')],
-            [self::decorateUri('match.xml', '2.0')],
-            [self::decorateUri('nested_object.xml', '2.0')],
-            [self::decorateUri('order_partial_scoring.xml', '2.0')],
-            [self::decorateUri('order.xml', '2.0')],
-            [self::decorateUri('orkney1.xml', '2.0')],
+            [self::decorateUri('inline_choice.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('likert.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('match.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('nested_object.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('order_partial_scoring.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('order.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('orkney1.xml', '2.0'), '2.0.0'],
             //array(self::decorateUri('position_object.xml', '2.0')),
-            [self::decorateUri('select_point.xml', '2.0')],
-            [self::decorateUri('slider.xml', '2.0')],
-            [self::decorateUri('template_image.xml', '2.0')],
-            [self::decorateUri('template.xml', '2.0')],
-            [self::decorateUri('text_entry.xml', '2.0')],
-            [self::decorateUri('upload_composite.xml', '2.0')],
-            [self::decorateUri('upload.xml', '2.0')],
+            [self::decorateUri('select_point.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('slider.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('template_image.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('template.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('text_entry.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('upload_composite.xml', '2.0.0'), '2.0.0'],
+            [self::decorateUri('upload.xml', '2.0.0'), '2.0.0'],
 
             // Other miscellaneous items...
-            [self::samplesDir() . 'custom/items/custom_operator_item.xml'],
-            [self::samplesDir() . 'custom/items/rich_gap_text.xml'],
+            [self::samplesDir() . 'custom/items/custom_operator_item.xml', '2.1.0'],
+            [self::samplesDir() . 'custom/items/rich_gap_text.xml', '2.2.0']
         ];
     }
 
     private static function decorateUri($uri, $version = '2.1')
     {
-        if ($version === '2.1') {
+        if ($version === '2.1' || $version === '2.1.0') {
             return self::samplesDir() . 'ims/items/2_1/' . $uri;
-        } elseif ($version === '2.2') {
+        } elseif ($version === '2.1.1') {
+            return self::samplesDir() . 'ims/items/2_1_1/' . $uri;
+        } elseif ($version === '2.2' || $version === '2.2.0') {
             return self::samplesDir() . 'ims/items/2_2/' . $uri;
+        } elseif ($version === '2.2.1') {
+            return self::samplesDir() . 'ims/items/2_2_1/' . $uri;
         } else {
             return self::samplesDir() . 'ims/items/2_0/' . $uri;
         }

--- a/test/qtismtest/data/storage/xml/XmlAssessmentItemDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlAssessmentItemDocumentTest.php
@@ -92,6 +92,16 @@ class XmlAssessmentItemDocumentTest extends QtiSmTestCase
         $this->assertEquals('2.1.0', $doc->getVersion());
     }
 
+    public function testLoad221()
+    {
+        $file = self::samplesDir() . 'ims/items/2_2_1/choice_aria.xml';
+        $doc = new XmlDocument();
+        $doc->load($file, true);
+
+        $this->assertEquals('2.2.1', $doc->getVersion());
+        $this->assertEquals($doc->saveToString(), file_get_contents(self::samplesDir() . 'ims/items/2_2_1/choice_aria.xml'));
+    }
+
     public function testLoad20()
     {
         $file = self::samplesDir() . 'ims/items/2_0/associate.xml';

--- a/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
@@ -25,6 +25,7 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase
     {
         if (empty($doc)) {
             $doc = new XmlCompactDocument('2.1');
+            $this->assertEquals('2.1.0', $doc->getVersion());
 
             $file = self::samplesDir() . 'custom/interaction_mix_sachsen_compact.xml';
             $doc->load($file);
@@ -64,7 +65,8 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase
 
     public function testSave()
     {
-        $doc = new XmlCompactDocument('2.1');
+        // Version 1.0 for XmlCompactDocuments was in use by legacy code. Let's make it BC.
+        $doc = new XmlCompactDocument('1.0');
         $file = self::samplesDir() . 'custom/interaction_mix_sachsen_compact.xml';
         $doc->load($file);
 

--- a/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlCompactAssessmentDocumentTest.php
@@ -24,7 +24,7 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase
     public function testLoad(XmlCompactDocument $doc = null)
     {
         if (empty($doc)) {
-            $doc = new XmlCompactDocument('1.0');
+            $doc = new XmlCompactDocument('2.1');
 
             $file = self::samplesDir() . 'custom/interaction_mix_sachsen_compact.xml';
             $doc->load($file);
@@ -64,7 +64,7 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase
 
     public function testSave()
     {
-        $doc = new XmlCompactDocument('1.0');
+        $doc = new XmlCompactDocument('2.1');
         $file = self::samplesDir() . 'custom/interaction_mix_sachsen_compact.xml';
         $doc->load($file);
 
@@ -72,7 +72,7 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase
         $doc->save($file);
         $this->assertTrue(file_exists($file));
 
-        $doc = new XmlCompactDocument('1.0');
+        $doc = new XmlCompactDocument('2.1');
         $doc->load($file);
 
         // retest content...
@@ -94,7 +94,7 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase
         $compactDoc->save($file);
         $this->assertTrue(file_exists($file));
 
-        $compactDoc = new XmlCompactDocument('1.0');
+        $compactDoc = new XmlCompactDocument('2.1');
         $compactDoc->load($file);
         $this->testLoad($compactDoc);
         unlink($file);
@@ -149,7 +149,7 @@ class XmlCompactAssessmentDocumentTest extends QtiSmTestCase
         $compactDoc->save($file);
         $this->assertTrue(file_exists($file));
 
-        $compactDoc = new XmlCompactDocument('1.0');
+        $compactDoc = new XmlCompactDocument('2.1');
         $compactDoc->load($file);
         $compactDoc->schemaValidate();
 

--- a/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlResultDocumentTest.php
@@ -40,7 +40,7 @@ class XmlResultDocumentTest extends QtiSmTestCase
         $xmlDoc = new XmlResultDocument();
         $xmlDoc->load(self::samplesDir() . 'results/simple-assessment-result.xml', true);
 
-        $this->assertEquals('2.1', $xmlDoc->getVersion());
+        $this->assertEquals('2.1.0', $xmlDoc->getVersion());
 
         /** @var AssessmentResult $assessmentResult */
         $assessmentResult = $xmlDoc->getDocumentComponent();

--- a/test/qtismtest/data/storage/xml/XmlUtilsTest.php
+++ b/test/qtismtest/data/storage/xml/XmlUtilsTest.php
@@ -9,21 +9,21 @@ use qtismtest\QtiSmTestCase;
 class XmlUtilsTest extends QtiSmTestCase
 {
     /**
-     * @dataProvider validInferQTIVersionProvider
+     * @dataProvider validInferVersionProvider
      */
-    public function testInferQTIVersionValid($file, $expectedVersion)
+    public function testInferVersionValid($file, $expectedVersion)
     {
         $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->load($file);
-        $this->assertEquals($expectedVersion, Utils::inferQTIVersion($dom));
+        $this->assertEquals($expectedVersion, Utils::inferVersion($dom));
     }
 
-    public function validInferQTIVersionProvider()
+    public function validInferVersionProvider()
     {
         return [
-            [self::samplesDir() . 'ims/items/2_1/associate.xml', '2.1'],
-            [self::samplesDir() . 'ims/items/2_0/associate.xml', '2.0'],
-            [self::samplesDir() . 'ims/tests/arbitrary_collections_of_item_outcomes/arbitrary_collections_of_item_outcomes.xml', '2.1'],
+            [self::samplesDir() . 'ims/items/2_1/associate.xml', '2.1.0'],
+            [self::samplesDir() . 'ims/items/2_0/associate.xml', '2.0.0'],
+            [self::samplesDir() . 'ims/tests/arbitrary_collections_of_item_outcomes/arbitrary_collections_of_item_outcomes.xml', '2.1.0'],
         ];
     }
 

--- a/test/qtismtest/data/storage/xml/marshalling/ImgMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ImgMarshallerTest.php
@@ -8,7 +8,7 @@ use qtismtest\QtiSmTestCase;
 
 class ImgMarshallerTest extends QtiSmTestCase
 {
-    public function testMarshall()
+    public function testMarshall21()
     {
         $img = new Img('my/image.png', "An Image...", "my-img");
         $img->setClass('beautiful');
@@ -16,22 +16,44 @@ class ImgMarshallerTest extends QtiSmTestCase
         $img->setWidth(30);
         $img->setLang('en-YO');
         $img->setLongdesc("A Long Description...");
+        $img->setXmlBase('/home/jerome');
 
-        $marshaller = $this->getMarshallerFactory()->createMarshaller($img);
+        // aria-* attributes are ignored in QTI 2.1
+        $img->setAriaOwns('IDFREF');
+
+        $marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($img);
         $element = $marshaller->marshall($img);
 
         $dom = new DOMDocument('1.0', 'UTF-8');
         $element = $dom->importNode($element, true);
-        $this->assertEquals('<img src="my/image.png" alt="An Image..." width="30" height="40%" longdesc="A Long Description..." id="my-img" class="beautiful" xml:lang="en-YO"/>', $dom->saveXML($element));
+        $this->assertEquals('<img src="my/image.png" alt="An Image..." width="30" height="40%" longdesc="A Long Description..." xml:base="/home/jerome" id="my-img" class="beautiful" xml:lang="en-YO"/>', $dom->saveXML($element));
     }
 
-    public function testUnmarshall()
+    public function testMarshall22()
+    {
+        $img = new Img('my/image.png', "An Image...", "my-img");
+
+        // aria-* attributes are NOT ignored in QTI 2.2.1
+        $img->setAriaOwns('IDREF');
+
+        // aria-flowsto is prefered instead of aria-flowto (see XSD) for img.
+        $img->setAriaFlowTo('IDREF2');
+
+        $marshaller = $this->getMarshallerFactory('2.2.1')->createMarshaller($img);
+        $element = $marshaller->marshall($img);
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $element = $dom->importNode($element, true);
+        $this->assertEquals('<img src="my/image.png" alt="An Image..." id="my-img" aria-flowsto="IDREF2" aria-owns="IDREF"/>', $dom->saveXML($element));
+    }
+
+    public function testUnmarshall21()
     {
         $element = $this->createDOMElement('
-            <img src="my/image.png" alt="An Image..." width="30" height="40%" longdesc="A Long Description..." id="my-img" class="beautiful" xml:lang="en-YO"/>
+            <img xml:base="/home/jerome" src="my/image.png" alt="An Image..." width="30" height="40%" longdesc="A Long Description..." id="my-img" class="beautiful" xml:lang="en-YO" aria-owns="IDREF"/>
 	    ');
 
-        $marshaller = $this->getMarshallerFactory()->createMarshaller($element);
+        $marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element);
         $img = $marshaller->unmarshall($element);
 
         $this->assertInstanceOf('qtism\\data\\content\\xhtml\\Img', $img);
@@ -43,5 +65,54 @@ class ImgMarshallerTest extends QtiSmTestCase
         $this->assertEquals('my-img', $img->getId());
         $this->assertEquals('beautiful', $img->getClass());
         $this->assertEquals('en-YO', $img->getLang());
+
+        // aria-* attributes are ignored in QTI 2.1
+        $this->assertFalse($img->hasAriaOwns());
+    }
+
+    public function testUnmarshall22()
+    {
+        $element = $this->createDOMElement('
+            <img xml:base="/home/jerome" src="my/image.png" alt="An Image..." aria-owns="IDREF" aria-flowsto="IDREF2"/>
+	    ');
+
+        $marshaller = $this->getMarshallerFactory('2.2.1')->createMarshaller($element);
+
+        /** @var Img $img */
+        $img = $marshaller->unmarshall($element);
+
+        // aria-* attributes are NOT ignored in QTI 2.1
+        $this->assertTrue($img->hasAriaOwns());
+        $this->assertEquals('IDREF2', $img->getAriaFlowTo());
+    }
+
+    public function testUnmarshall22PreferFlowsTo()
+    {
+        $element = $this->createDOMElement('
+            <img src="my/image.png" alt="An Image..." aria-owns="IDREF" aria-flowsto="IDREF2" aria-flowto="IDREF3"/>
+	    ');
+
+        $marshaller = $this->getMarshallerFactory('2.2.1')->createMarshaller($element);
+
+        /** @var Img $img */
+        $img = $marshaller->unmarshall($element);
+
+        // For img components, we prefer aria-flowsto.
+        $this->assertEquals('IDREF2', $img->getAriaFlowTo());
+    }
+    public function testUnmarshall22FallbackFlowTo()
+    {
+        $element = $this->createDOMElement('
+            <img src="my/image.png" alt="An Image..." aria-owns="IDREF" aria-flowto="IDREF3"/>
+	    ');
+
+        $marshaller = $this->getMarshallerFactory('2.2.1')->createMarshaller($element);
+
+        /** @var Img $img */
+        $img = $marshaller->unmarshall($element);
+
+        // For img components, we prefer aria-flowsto. However, we fall back
+        // to aria-flowto in cas it exists.
+        $this->assertEquals('IDREF3', $img->getAriaFlowTo());
     }
 }

--- a/test/qtismtest/data/storage/xml/marshalling/ImgMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ImgMarshallerTest.php
@@ -35,6 +35,7 @@ class ImgMarshallerTest extends QtiSmTestCase
 
         // aria-* attributes are NOT ignored in QTI 2.2.1
         $img->setAriaOwns('IDREF');
+        $img->setAriaHidden(true);
 
         // aria-flowsto is prefered instead of aria-flowto (see XSD) for img.
         $img->setAriaFlowTo('IDREF2');
@@ -44,13 +45,20 @@ class ImgMarshallerTest extends QtiSmTestCase
 
         $dom = new DOMDocument('1.0', 'UTF-8');
         $element = $dom->importNode($element, true);
+        $this->assertEquals('<img src="my/image.png" alt="An Image..." id="my-img" aria-flowsto="IDREF2" aria-owns="IDREF" aria-hidden="true"/>', $dom->saveXML($element));
+
+        // In case of aria-hidden is false, it is not rendered.
+        $img->setAriaHidden(false);
+        $element = $marshaller->marshall($img);
+        $element = $dom->importNode($element, true);
+
         $this->assertEquals('<img src="my/image.png" alt="An Image..." id="my-img" aria-flowsto="IDREF2" aria-owns="IDREF"/>', $dom->saveXML($element));
     }
 
     public function testUnmarshall21()
     {
         $element = $this->createDOMElement('
-            <img xml:base="/home/jerome" src="my/image.png" alt="An Image..." width="30" height="40%" longdesc="A Long Description..." id="my-img" class="beautiful" xml:lang="en-YO" aria-owns="IDREF"/>
+            <img xml:base="/home/jerome" src="my/image.png" alt="An Image..." width="30" height="40%" longdesc="A Long Description..." id="my-img" class="beautiful" xml:lang="en-YO" aria-owns="IDREF" aria-hidden="true"/>
 	    ');
 
         $marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element);
@@ -68,12 +76,14 @@ class ImgMarshallerTest extends QtiSmTestCase
 
         // aria-* attributes are ignored in QTI 2.1
         $this->assertFalse($img->hasAriaOwns());
+        $this->assertFalse($img->getAriaHidden());
+        $this->assertFalse($img->hasAriaHidden());
     }
 
     public function testUnmarshall22()
     {
         $element = $this->createDOMElement('
-            <img xml:base="/home/jerome" src="my/image.png" alt="An Image..." aria-owns="IDREF" aria-flowsto="IDREF2"/>
+            <img xml:base="/home/jerome" src="my/image.png" alt="An Image..." aria-owns="IDREF" aria-flowsto="IDREF2" aria-hidden="true"/>
 	    ');
 
         $marshaller = $this->getMarshallerFactory('2.2.1')->createMarshaller($element);
@@ -84,6 +94,8 @@ class ImgMarshallerTest extends QtiSmTestCase
         // aria-* attributes are NOT ignored in QTI 2.1
         $this->assertTrue($img->hasAriaOwns());
         $this->assertEquals('IDREF2', $img->getAriaFlowTo());
+        $this->assertTrue($img->hasAriaHidden());
+        $this->assertTrue($img->getAriaHidden());
     }
 
     public function testUnmarshall22PreferFlowsTo()

--- a/test/qtismtest/data/storage/xml/marshalling/MarshallerFactoryTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/MarshallerFactoryTest.php
@@ -6,7 +6,7 @@ use DOMDocument;
 use qtism\common\datatypes\QtiCoords;
 use qtism\common\datatypes\QtiShape;
 use qtism\data\state\AreaMapEntry;
-use qtism\data\storage\xml\marshalling\MarshallerFactory;
+use qtism\data\storage\xml\marshalling\Qti21MarshallerFactory;
 use qtismtest\QtiSmTestCase;
 use stdClass;
 
@@ -18,7 +18,7 @@ class MarshallerFactyoryTest extends QtiSmTestCase
         $dom->loadXML('<areaMapEntry xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" shape="rect" coords="0, 20, 100, 0" mappedValue="1.337"/>');
         $element = $dom->documentElement;
 
-        $factory = new MarshallerFactory();
+        $factory = new Qti21MarshallerFactory();
         $marshaller = $factory->createMarshaller($element);
         $this->assertInstanceOf('qtism\\data\\storage\\xml\\marshalling\\AreaMapEntryMarshaller', $marshaller);
     }
@@ -29,7 +29,7 @@ class MarshallerFactyoryTest extends QtiSmTestCase
         $coords = new QtiCoords($shape, [0, 20, 100, 0]);
         $component = new AreaMapEntry($shape, $coords, 1.337);
 
-        $factory = new MarshallerFactory();
+        $factory = new Qti21MarshallerFactory();
         $marshaller = $factory->createMarshaller($component);
         $this->assertInstanceOf('qtism\\data\\storage\\xml\\marshalling\\AreaMapEntryMarshaller', $marshaller);
     }
@@ -38,7 +38,7 @@ class MarshallerFactyoryTest extends QtiSmTestCase
     {
         $this->setExpectedException('\\InvalidArgumentException');
         $component = new stdClass();
-        $factory = new MarshallerFactory();
+        $factory = new Qti21MarshallerFactory();
         $marshaller = $factory->createMarshaller($component);
     }
 }

--- a/test/qtismtest/data/storage/xml/marshalling/SimpleInlineMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/SimpleInlineMarshallerTest.php
@@ -137,6 +137,8 @@ class SimpleInlineMarshallerTest extends QtiSmTestCase
         $this->assertFalse($span->hasAriaLabel());
         $this->assertEquals('', $span->getAriaLevel());
         $this->assertFalse($span->hasAriaLevel());
+        $this->assertFalse($span->hasAriaHidden());
+        $this->assertFalse($span->getAriaHidden());
 
         $content = $span->getContent();
         $this->assertSame(1, count($content));
@@ -158,6 +160,7 @@ class SimpleInlineMarshallerTest extends QtiSmTestCase
         $span->setAriaLive(AriaLive::OFF);
         $span->setAriaOrientation(AriaOrientation::HORIZONTAL);
         $span->setAriaOwns('IDREF5');
+        $span->setAriaHidden(true);
 
         // aria-* and dir must NOT be ignored in QTI 2.2
         $marshaller = $this->getMarshallerFactory('2.2.0')->createMarshaller($span);
@@ -165,13 +168,13 @@ class SimpleInlineMarshallerTest extends QtiSmTestCase
         $dom = new DOMDocument('1.0', 'UTF-8');
         $element = $dom->importNode($element, true);
 
-        $this->assertEquals('<span id="myspan" class="myclass" aria-flowto="IDREF1" aria-controls="IDREF2" aria-describedby="IDREF3" aria-labelledby="IDREF4" aria-owns="IDREF5" aria-level="1" aria-live="off" aria-orientation="horizontal" aria-label="my aria label"/>', $dom->saveXML($element));
+        $this->assertEquals('<span id="myspan" class="myclass" aria-flowto="IDREF1" aria-controls="IDREF2" aria-describedby="IDREF3" aria-labelledby="IDREF4" aria-owns="IDREF5" aria-level="1" aria-live="off" aria-orientation="horizontal" aria-label="my aria label" aria-hidden="true"/>', $dom->saveXML($element));
     }
 
     public function testUnmarshallSpan22()
     {
         /** @var Span $span */
-        $span = $this->createComponentFromXml('<span id="myspan" class="myclass" aria-controls="IDREF1 IDREF2" aria-describedby="IDREF3" aria-flowto="IDREF4" aria-labelledby="IDREF5" aria-owns="IDREF6" aria-level="5" aria-live="off" aria-orientation="horizontal" aria-label="my aria label" aria-flowsto="not-considered-here">I am a span</span>', '2.2.0');
+        $span = $this->createComponentFromXml('<span id="myspan" class="myclass" aria-controls="IDREF1 IDREF2" aria-describedby="IDREF3" aria-flowto="IDREF4" aria-labelledby="IDREF5" aria-owns="IDREF6" aria-level="5" aria-live="off" aria-orientation="horizontal" aria-label="my aria label" aria-flowsto="not-considered-here" aria-hidden="true">I am a span</span>', '2.2.0');
         $this->assertInstanceOf(Span::class, $span);
         $this->assertEquals('IDREF1 IDREF2', $span->getAriaControls());
         $this->assertTrue($span->hasAriaControls());
@@ -191,6 +194,8 @@ class SimpleInlineMarshallerTest extends QtiSmTestCase
         $this->assertTrue($span->hasAriaLabel());
         $this->assertEquals('5', $span->getAriaLevel());
         $this->assertTrue($span->hasAriaLevel());
+        $this->assertTrue($span->hasAriaHidden());
+        $this->assertTrue($span->getAriaHidden());
 
         $content = $span->getContent();
         $this->assertSame(1, count($content));

--- a/test/qtismtest/runtime/rendering/markup/xhtml/BodyElementRendererTest.php
+++ b/test/qtismtest/runtime/rendering/markup/xhtml/BodyElementRendererTest.php
@@ -2,13 +2,18 @@
 
 namespace qtismtest\runtime\rendering\markup\xhtml;
 
+use DOMElement;
+use qtism\data\content\enums\AriaLive;
+use qtism\data\content\enums\AriaOrientation;
 use qtism\data\content\InlineCollection;
 use qtism\data\content\TextRun;
 use qtism\data\content\xhtml\text\Abbr;
 use qtism\data\content\xhtml\text\Br;
+use qtism\data\content\xhtml\text\Span;
 use qtism\runtime\rendering\markup\xhtml\BodyElementRenderer;
 use qtism\runtime\rendering\markup\xhtml\TextRunRenderer;
 use qtism\runtime\rendering\markup\xhtml\XhtmlRenderingEngine;
+use qtism\runtime\rendering\RenderingException;
 use qtismtest\QtiSmTestCase;
 
 class BodyElementRendererTest extends QtiSmTestCase
@@ -29,7 +34,9 @@ class BodyElementRendererTest extends QtiSmTestCase
         $this->assertEquals('en-US', $element->getAttribute('lang'));
         $this->assertEquals('', $element->getAttribute('label'));
     }
-
+    /**
+     * @throws RenderingException
+     */
     public function testRenderChildren()
     {
         $ctx = new XhtmlRenderingEngine();
@@ -46,11 +53,59 @@ class BodyElementRendererTest extends QtiSmTestCase
 
         $abbr->setContent(new InlineCollection([$textRun]));
 
+        /** @var DOMElement $element */
         $element = $abbrRenderer->render($abbr)->firstChild;
 
         $this->assertEquals('abbr', $element->nodeName);
         $this->assertEquals('my-abbr', $element->getAttribute('id'));
         $this->assertEquals('qti qti-abbr qti-bodyElement qti-abbr', $element->getAttribute('class'));
         $this->assertEquals('abbreviation...', $element->firstChild->wholeText);
+
+        // no aria-* attributes should be found...
+        $this->assertSame('', $element->getAttribute('aria-orientation'));
+        $this->assertSame('', $element->getAttribute('aria-live'));
+        $this->assertSame('', $element->getAttribute('aria-level'));
+        $this->assertSame('', $element->getAttribute('aria-owns'));
+        $this->assertSame('', $element->getAttribute('aria-labelledby'));
+        $this->assertSame('', $element->getAttribute('aria-flowto'));
+        $this->assertSame('', $element->getAttribute('aria-label'));
+        $this->assertSame('', $element->getAttribute('aria-describedby'));
+        $this->assertSame('', $element->getAttribute('aria-controls'));
+    }
+
+    /**
+     * @throws RenderingException
+     */
+    public function testRenderFullAria()
+    {
+        $ctx = new XhtmlRenderingEngine();
+
+        $span = new Span('myspan');
+        $span->setAriaOrientation(AriaOrientation::HORIZONTAL);
+        $span->setAriaLive(AriaLive::POLITE);
+        $span->setAriaLevel(5);
+        $span->setAriaOwns('IDREF1');
+        $span->setAriaLabelledBy('IDREF2');
+        $span->setAriaFlowTo('IDREF3');
+        $span->setAriaLabel('my label');
+        $span->setAriaDescribedBy('IDREF4');
+        $span->setAriaControls('IDREF5');
+
+        $renderer = new BodyElementRenderer();
+        $renderer->setRenderingEngine($ctx);
+
+        /** @var DOMElement $element */
+        $element = $renderer->render($span)->firstChild;
+
+        $this->assertEquals('span', $element->nodeName);
+        $this->assertEquals('horizontal', $element->getAttribute('aria-orientation'));
+        $this->assertEquals('polite', $element->getAttribute('aria-live'));
+        $this->assertEquals('5', $element->getAttribute('aria-level'));
+        $this->assertEquals('IDREF1', $element->getAttribute('aria-owns'));
+        $this->assertEquals('IDREF2', $element->getAttribute('aria-labelledby'));
+        $this->assertEquals('IDREF3', $element->getAttribute('aria-flowto'));
+        $this->assertEquals('my label', $element->getAttribute('aria-label'));
+        $this->assertEquals('IDREF4', $element->getAttribute('aria-describedby'));
+        $this->assertEquals('IDREF5', $element->getAttribute('aria-controls'));
     }
 }

--- a/test/qtismtest/runtime/rendering/markup/xhtml/BodyElementRendererTest.php
+++ b/test/qtismtest/runtime/rendering/markup/xhtml/BodyElementRendererTest.php
@@ -71,6 +71,7 @@ class BodyElementRendererTest extends QtiSmTestCase
         $this->assertSame('', $element->getAttribute('aria-label'));
         $this->assertSame('', $element->getAttribute('aria-describedby'));
         $this->assertSame('', $element->getAttribute('aria-controls'));
+        $this->assertSame('', $element->getAttribute('aria-hidden'));
     }
 
     /**
@@ -90,6 +91,7 @@ class BodyElementRendererTest extends QtiSmTestCase
         $span->setAriaLabel('my label');
         $span->setAriaDescribedBy('IDREF4');
         $span->setAriaControls('IDREF5');
+        $span->setAriaHidden(true);
 
         $renderer = new BodyElementRenderer();
         $renderer->setRenderingEngine($ctx);
@@ -107,5 +109,6 @@ class BodyElementRendererTest extends QtiSmTestCase
         $this->assertEquals('my label', $element->getAttribute('aria-label'));
         $this->assertEquals('IDREF4', $element->getAttribute('aria-describedby'));
         $this->assertEquals('IDREF5', $element->getAttribute('aria-controls'));
+        $this->assertEquals('true', $element->getAttribute('aria-hidden'));
     }
 }

--- a/test/qtismtest/runtime/tests/AssessmentTestSessionBranchingsTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentTestSessionBranchingsTest.php
@@ -16,7 +16,7 @@ class AssessmentTestSessionBranchingsTest extends QtiSmTestCase
 {
     public function testInstantiationSample1()
     {
-        $doc = new XmlCompactDocument('1.0');
+        $doc = new XmlCompactDocument();
         $doc->load(self::samplesDir() . 'custom/runtime/branchings/branchings_single_section_linear.xml');
 
         $manager = new SessionManager();
@@ -49,7 +49,7 @@ class AssessmentTestSessionBranchingsTest extends QtiSmTestCase
 
     public function testBranchingSingleSectionLinear1()
     {
-        $doc = new XmlCompactDocument('1.0');
+        $doc = new XmlCompactDocument();
         $doc->load(self::samplesDir() . 'custom/runtime/branchings/branchings_single_section_linear.xml');
 
         $manager = new SessionManager();
@@ -90,7 +90,7 @@ class AssessmentTestSessionBranchingsTest extends QtiSmTestCase
 
     public function testBranchingSingleSectionLinear2()
     {
-        $doc = new XmlCompactDocument('1.0');
+        $doc = new XmlCompactDocument();
         $doc->load(self::samplesDir() . 'custom/runtime/branchings/branchings_single_section_linear.xml');
 
         $manager = new SessionManager();
@@ -122,7 +122,7 @@ class AssessmentTestSessionBranchingsTest extends QtiSmTestCase
     {
         // This test only aims at testing if branch rules
         // are correctly ignored when the navigation mode is non linear.
-        $doc = new XmlCompactDocument('1.0');
+        $doc = new XmlCompactDocument();
         $doc->load(self::samplesDir() . 'custom/runtime/branchings/branchings_single_section_nonlinear.xml');
 
         // Q01 - We answer correct. In linear mode we should go to Q03.
@@ -169,7 +169,7 @@ class AssessmentTestSessionBranchingsTest extends QtiSmTestCase
     {
         // This test aims at testing the possibility to jump
         // on a particular item ref occurence.
-        $doc = new XmlCompactDocument('1.0');
+        $doc = new XmlCompactDocument();
         $doc->load(self::samplesDir() . 'custom/runtime/branchings/branchings_multiple_occurences.xml');
 
         $manager = new SessionManager();

--- a/test/qtismtest/runtime/tests/AssessmentTestSessionTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentTestSessionTest.php
@@ -37,7 +37,7 @@ class AssessmentTestSessionTest extends QtiSmTestCase
     {
         parent::setUp();
 
-        $xml = new XmlCompactDocument('1.0');
+        $xml = new XmlCompactDocument();
         $xml->load(self::samplesDir() . 'custom/runtime/assessmenttest_context.xml');
 
         $sessionManager = new SessionManager();

--- a/test/samples/ims/items/2_2_1/choice_aria.xml
+++ b/test/samples/ims/items/2_2_1/choice_aria.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Thie example adapted from the PET Handbook, copyright University of Cambridge ESOL Examinations -->
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2  http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2p1.xsd"
+                identifier="choice" title="Unattended Luggage" adaptive="false" timeDependent="false">
+    <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
+        <correctResponse>
+            <value>ChoiceA</value>
+        </correctResponse>
+    </responseDeclaration>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
+        <defaultValue>
+            <value>0</value>
+        </defaultValue>
+    </outcomeDeclaration>
+    <itemBody>
+        <p>Look at the text in the picture.</p>
+        <p>
+            <img src="images/sign.png" alt="NEVER LEAVE LUGGAGE UNATTENDED"/>
+        </p>
+        <choiceInteraction responseIdentifier="RESPONSE" shuffle="false" maxChoices="1"
+                           aria-label="This is a simple choice question." aria-orientation="horizontal">
+            <prompt>What does it say?</prompt>
+            <simpleChoice identifier="ChoiceA" aria-level="1">You must stay with your luggage at all times.
+            </simpleChoice>
+            <simpleChoice identifier="ChoiceB" aria-level="2">Do not let someone else look after your luggage.
+            </simpleChoice>
+            <simpleChoice identifier="ChoiceC" aria-level="3">Remember your luggage when you leave.</simpleChoice>
+        </choiceInteraction>
+    </itemBody>
+    <responseProcessing
+            template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/match_correct"/>
+</assessmentItem>

--- a/test/samples/ims/items/2_2_1/choice_aria.xml
+++ b/test/samples/ims/items/2_2_1/choice_aria.xml
@@ -1,34 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Thie example adapted from the PET Handbook, copyright University of Cambridge ESOL Examinations -->
-<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2  http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2p1.xsd"
-                identifier="choice" title="Unattended Luggage" adaptive="false" timeDependent="false">
-    <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
-        <correctResponse>
-            <value>ChoiceA</value>
-        </correctResponse>
-    </responseDeclaration>
-    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
-        <defaultValue>
-            <value>0</value>
-        </defaultValue>
-    </outcomeDeclaration>
-    <itemBody>
-        <p>Look at the text in the picture.</p>
-        <p>
-            <img src="images/sign.png" alt="NEVER LEAVE LUGGAGE UNATTENDED"/>
-        </p>
-        <choiceInteraction responseIdentifier="RESPONSE" shuffle="false" maxChoices="1"
-                           aria-label="This is a simple choice question." aria-orientation="horizontal">
-            <prompt>What does it say?</prompt>
-            <simpleChoice identifier="ChoiceA" aria-level="1">You must stay with your luggage at all times.
-            </simpleChoice>
-            <simpleChoice identifier="ChoiceB" aria-level="2">Do not let someone else look after your luggage.
-            </simpleChoice>
-            <simpleChoice identifier="ChoiceC" aria-level="3">Remember your luggage when you leave.</simpleChoice>
-        </choiceInteraction>
-    </itemBody>
-    <responseProcessing
-            template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/match_correct"/>
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="choice" title="Unattended Luggage" timeDependent="false" adaptive="false" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2p1.xsd">
+  <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
+    <correctResponse>
+      <value>ChoiceA</value>
+    </correctResponse>
+  </responseDeclaration>
+  <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
+    <defaultValue>
+      <value>0</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <itemBody>
+    <p aria-hidden="true">Look at the text in the picture.</p>
+    <p>
+      <img src="images/sign.png" alt="NEVER LEAVE LUGGAGE UNATTENDED"/>
+    </p>
+    <choiceInteraction aria-orientation="horizontal" aria-label="This is a simple choice question." responseIdentifier="RESPONSE">
+      <prompt>What does it say?</prompt>
+      <simpleChoice aria-level="1" identifier="ChoiceA">You must stay with your luggage at all times.</simpleChoice>
+      <simpleChoice aria-level="2" identifier="ChoiceB">Do not let someone else look after your luggage.</simpleChoice>
+      <simpleChoice aria-level="3" identifier="ChoiceC">Remember your luggage when you leave.</simpleChoice>
+    </choiceInteraction>
+  </itemBody>
+  <responseProcessing template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/match_correct"/>
 </assessmentItem>


### PR DESCRIPTION
This is the backport of the [`aria-*` attributes feature](https://github.com/oat-sa/qti-sdk/pull/197) performed on `master` version. Please have a deep look at it to understand the scope of the PR. This should result in a release `0.21.0` of QTI-SDK `legacy`.

Compared to the `master` approach, the major obstacle here is that we did not have yet "QTI Version Management" inside `Marshaller` components was not included yet. I had to backport it within the scope of this `aria-*` feature. That is why we have so much changes.

**Please be aware that that such a PR cannot be merged without a FULL INTEGRATION TESTING in TAO Current Gen**. With the millions of Assessment Materials around the world, and all the Assessment Materials that our customers have to deal with. Lots of changes were performed. **Failure is not an option as it could have catastrophic impacts on all our customer base**. Another round of QA like https://oat-sa.atlassian.net/browse/QI-316 must be performed, in addition with specific `aria-*` contents ingestion/delivery to test takers to make sure everything is fine.

As a positive and motivational outcome, this is the road to a better integration of QTI 2.2 in TAO Current Gen. With QTI version support in QTI-SDK `legacy`, we can really tackle essential QTI 2.2 support like `dir`, `bidi`, `data-*` attributes. There is a big added value here !

**TAO Integration Testing branches ares the following. Please take extra care with reading carefully the instructions in these 2 Pull Requests.**

* https://github.com/oat-sa/lib-tao-qti/pull/72
* https://github.com/oat-sa/extension-tao-itemqti/pull/1483