### PR TITLE
Fixed test with two different messages.

### DIFF
--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -223,8 +223,17 @@ class XmlDocumentTest extends QtiSmTestCase
     {
         $doc = new XmlDocument('2.1');
 
-        $expectedMsg = "An internal error occured while parsing QTI-XML:\nFatal Error: Premature end of data in tag assessmentItem line 1 at 1:17.";
-        $this->setExpectedException('\\qtism\\data\\storage\\xml\\XmlStorageException', $expectedMsg, XmlStorageException::READ);
+        $this->expectException(XmlStorageException::class);
+        $this->expectExceptionCode(XmlStorageException::READ);
+
+        // libxml library on Travis produces another error message.
+        // Don't know how to find the version though.
+        $libMxl2_9_10_Message = 'Premature end of data in tag assessmentItem line 1';
+        $libMxl2_9_other_Message = 'EndTag\: \\\'<\\/\\\' not found';
+
+        $expectedMsg = '/^An internal error occured while parsing QTI-XML:' . "\n"
+            . 'Fatal Error: (' . $libMxl2_9_10_Message . '|' . $libMxl2_9_other_Message . ') at 1\\:17\\.$/';
+        $this->expectExceptionMessageRegExp($expectedMsg);
 
         $doc->loadFromString('<assessmentItem>');
     }


### PR DESCRIPTION
Travis has a version of libxml that delivers another message than the one developers have on their machine, creating one single failing test when running locally and not anyone in Travis.
This PR adds the local message to the test to avoid this burden.
