### PR TITLE
Allowed parsing of xml text node bigger than 10 mb.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 	],
 	"require" : {
 		"php" : "~7.0",
-		"oat-sa/lib-tao-dtms" :  "1.0.0"
+		"oat-sa/lib-tao-dtms" :  "1.0.0",
+		"ext-libxml": "*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "<6.0.0",

--- a/qtism/data/storage/xml/XmlDocument.php
+++ b/qtism/data/storage/xml/XmlDocument.php
@@ -145,7 +145,7 @@ class XmlDocument extends QtiDocument
 
             $doc = $this->getDomDocument();
 
-            if (call_user_func_array([$doc, $loadMethod], [$data, LIBXML_COMPACT | LIBXML_NONET | LIBXML_XINCLUDE])) {
+            if (call_user_func_array([$doc, $loadMethod], [$data, LIBXML_COMPACT | LIBXML_NONET | LIBXML_XINCLUDE | LIBXML_PARSEHUGE])) {
                 // Infer the QTI version.
                 if (($version = XmlUtils::inferVersion($this->getDomDocument())) !== false) {
                     $this->setVersion($version);


### PR DESCRIPTION
Backport of https://github.com/oat-sa/qti-sdk/pull/211 to legacy