### PR TITLE
Allowed <a> in prompt for QTI 2.2.

### DIFF
--- a/src/qtism/data/storage/xml/marshalling/PromptMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/PromptMarshaller.php
@@ -25,6 +25,7 @@ namespace qtism\data\storage\xml\marshalling;
 
 use DOMElement;
 use InvalidArgumentException;
+use qtism\common\utils\Version;
 use qtism\data\content\FlowStaticCollection;
 use qtism\data\QtiComponent;
 use qtism\data\QtiComponentCollection;
@@ -44,8 +45,12 @@ class PromptMarshaller extends ContentMarshaller
 
         $content = new FlowStaticCollection();
         $error = false;
-        $exclusion = ['pre', 'hottext', 'printedVariable', 'templateBlock', 'templateInline', 'infoControl', 'feedbackBlock', 'rubricBlock', 'a', 'feedbackInline'];
+        $exclusion = ['pre', 'hottext', 'printedVariable', 'templateBlock', 'templateInline', 'infoControl', 'feedbackBlock', 'rubricBlock', 'feedbackInline'];
 
+        if (Version::compare($this->getVersion(), '2.2.0', '<')) {
+            $exclusion[] = 'a';
+        }
+        
         foreach ($children as $c) {
             if (in_array($c->getQtiClassName(), $exclusion) === true) {
                 $error = true;

--- a/test/qtismtest/data/storage/xml/marshalling/PromptMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/PromptMarshallerTest.php
@@ -4,8 +4,11 @@ namespace qtismtest\data\storage\xml\marshalling;
 
 use DOMDocument;
 use qtism\data\content\FlowStaticCollection;
+use qtism\data\content\InlineCollection;
 use qtism\data\content\interactions\Prompt;
 use qtism\data\content\TextRun;
+use qtism\data\content\xhtml\A;
+use qtism\data\storage\xml\marshalling\UnmarshallingException;
 use qtismtest\QtiSmTestCase;
 
 class PromptMarshallerTest extends QtiSmTestCase
@@ -67,5 +70,39 @@ class PromptMarshallerTest extends QtiSmTestCase
         );
 
         $this->getMarshallerFactory('2.1.0')->createMarshaller($element)->unmarshall($element);
+    }
+
+    public function testUnmarshallPromptWithAnchorInQti21ThrowsException()
+    {
+        $element = $this->createDOMElement('<prompt id="my-prompt" class="qti-prompt">This is an anchor: <a href="#">anchor text</a></prompt>');
+
+        $marshaller = $this->getMarshallerFactory('2.1')->createMarshaller($element);
+        $this->expectException(UnmarshallingException::class);
+        $this->expectExceptionMessage("A 'prompt' cannot contain 'a' elements.");
+        $marshaller->unmarshall($element);
+    }
+
+    public function testUnmarshallPromptWithAnchorInQti22Works()
+    {
+        $element = $this->createDOMElement('<prompt id="my-prompt" class="qti-prompt">This is an anchor: <a href="#">anchor text</a></prompt>');
+
+        $marshaller = $this->getMarshallerFactory('2.2')->createMarshaller($element);
+        $component = $marshaller->unmarshall($element);
+
+        $this->assertInstanceOf(Prompt::class, $component);
+        $this->assertEquals('my-prompt', $component->getId());
+        $this->assertEquals('qti-prompt', $component->getClass());
+
+        $content = $component->getContent();
+        $this->assertCount(2, $content);
+        $this->assertEquals('This is an anchor: ', $content[0]->getContent());
+
+        $this->assertInstanceOf(A::class, $content[1]);
+        $this->assertEquals('#', $content[1]->getHref());
+
+        $this->assertInstanceOf(InlineCollection::class, $content[1]->getContent());
+        $linkContent = $content[1]->getContent()[0];
+        $this->assertInstanceOf(TextRun::class, $linkContent);
+        $this->assertEquals('anchor text', $linkContent->getContent());
     }
 }


### PR DESCRIPTION
Anchors are allowed in <prompt> QTI element from QTI 2.2.
This PR allows the use of links in interaction prompts for QTI 2.2 and later.