### PR TITLE
Actual correct response area is not ellipse in Graphic Select Point Interaction when ellipse selected

### DIFF
--- a/qtism/common/datatypes/QtiCoords.php
+++ b/qtism/common/datatypes/QtiCoords.php
@@ -131,6 +131,10 @@ class QtiCoords extends IntegerCollection implements QtiDatatype, Comparable
             return pow($point->getX() - $this[0], 2) + pow($point->getY() - $this[1], 2) < pow($this[2], 2);
         }
 
+        if ($this->getShape() === QtiShape::ELLIPSE) {
+            return pow($point->getX() - $this[0], 2) / pow($this[2], 2) + pow($point->getY() - $this[1], 2) / pow($this[3], 2) <= 1;
+        }
+
         // we consider it is a polygon.
         // - Transform coordinates in vertices.
         // -- Use of the "point in polygon" algorithm.

--- a/test/qtismtest/common/datatypes/CoordsTest.php
+++ b/test/qtismtest/common/datatypes/CoordsTest.php
@@ -35,6 +35,23 @@ class CoordsTest extends QtiSmTestCase
         $this->assertFalse($coords->inside($point));
     }
 
+    public function testInsideEllipse()
+    {
+        $coords = new QtiCoords(QtiShape::ELLIPSE, [10, 10, 3, 2]);
+
+        $point = new QtiPoint(1, 1); // 1,1 is outside
+        $this->assertFalse($coords->inside($point));
+
+        $point = new QtiPoint(3, 3); // 3,3 is outside
+        $this->assertFalse($coords->inside($point));
+
+        $point = new QtiPoint(8, 9); // 8,9 is inside
+        $this->assertTrue($coords->inside($point));
+
+        $point = new QtiPoint(10, 10); // 10,10 is inside
+        $this->assertTrue($coords->inside($point));
+    }
+
     public function testInsideRectangle()
     {
         // Do not forget (x1, y1) -> left top corner, (x2, y2) -> right bottom corner.


### PR DESCRIPTION
__task:__ https://oat-sa.atlassian.net/browse/TAO-9725
__description:__ Actual correct response area is not ellipse in Graphic Select Point Interaction when ellipse selected