### PR TITLE
avoid exception if QtiFile is provided

### DIFF
--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -433,6 +433,19 @@ abstract class Variable
     /**
      * Convenience method.
      *
+     * Whether the variable's value is file. If the variable's value is NULL, the method
+     * returns false.
+     *
+     * @return boolean
+     */
+    public function isFile()
+    {
+        return (!$this->isNull() && $this->getBaseType() === BaseType::FILE);
+    }
+
+    /**
+     * Convenience method.
+     *
      * Whether the variable's value is float. If the variable's value is NULL, the method
      * returns false.
      *
@@ -468,7 +481,11 @@ abstract class Variable
      */
     public function isPair()
     {
-        return (!$this->isNull() && ($this->getBaseType() === BaseType::PAIR) || $this->getBaseType() === BaseType::DIRECTED_PAIR);
+        return (!$this->isNull() 
+            && ($this->getBaseType() === BaseType::PAIR 
+                || $this->getBaseType() === BaseType::DIRECTED_PAIR
+            )
+        );
     }
 
     /**
@@ -544,7 +561,7 @@ abstract class Variable
 
     private function createValue(QtiDatatype $value): Value
     {
-        if (BaseType::FILE === $this->getBaseType() && $value instanceof QtiFile) {
+        if ($value instanceof QtiFile && $this->isFile()) {
             return new Value($value);
         }
 

--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -26,6 +26,7 @@ namespace qtism\runtime\common;
 use InvalidArgumentException;
 use qtism\common\collections\Container;
 use qtism\common\datatypes\QtiDatatype;
+use qtism\common\datatypes\QtiFile;
 use qtism\common\enums\BaseType;
 use qtism\common\enums\Cardinality;
 use qtism\data\state\Value;
@@ -543,6 +544,10 @@ abstract class Variable
 
     private function createValue(QtiDatatype $value): Value
     {
+        if (BaseType::FILE === $this->getBaseType() && $value instanceof QtiFile) {
+            return new Value($value);
+        }
+
         return new Value(StorageUtils::stringToDatatype(
             (string)$value,
             $this->getBaseType())

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -2,7 +2,9 @@
 
 namespace qtismtest\runtime\common;
 
+use qtism\common\datatypes\files\FileSystemFileManager;
 use qtism\common\datatypes\QtiCoords;
+use qtism\common\datatypes\QtiFile;
 use qtism\common\datatypes\QtiFloat;
 use qtism\common\datatypes\QtiInteger;
 use qtism\common\datatypes\QtiPair;
@@ -134,6 +136,24 @@ class ResponseVariableTest extends QtiSmTestCase
 
         $this->assertCount(1, $values);
         $this->assertTrue($qtiPoint->equals($values[0]->getValue()));
+
+        // QtiFile
+        $fileManager = new FileSystemFileManager();
+
+        $path = __FILE__;
+        $fileName = basename($path);
+        $mimeType = 'text/plain';
+        $qtiFile = $fileManager->createFromFile($path, $mimeType, $fileName);
+
+        $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::FILE, $qtiFile);
+        $values = $responseVariable->getDataModelValues();
+
+        $this->assertCount(1, $values);
+        $actual = $values[0]->getValue();
+        $this->assertInstanceOf(QtiFile::class, $actual);
+        $this->assertEquals($fileName, $actual->getFilename());
+        $this->assertEquals($mimeType, $actual->getMimeType());
+        $this->assertStringEqualsFile($path, $actual->getData());
     }
 
     public function testGetScalarDataModelValuesMultipleCardinality()


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEX-1753

`AbstractResultBuilder::buildVariables()` fails if QitFile is provided. 