### PR TITLE
Allowed 0 as an expectedLength value.

### DIFF
--- a/src/qtism/data/content/interactions/ExtendedTextInteraction.php
+++ b/src/qtism/data/content/interactions/ExtendedTextInteraction.php
@@ -71,10 +71,10 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * use the value of this attribute to set the size of the response box, where applicable.
      * This is not a validity constraint.
      *
-     * @var integer
+     * @var integer|null
      * @qtism-bean-property
      */
-    private $expectedLength = -1;
+    private $expectedLength;
 
     /**
      * From IMS QTI:
@@ -245,20 +245,25 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     }
 
     /**
-     * Set the hint to the candidate about the expected overall length of its response. If $expectedLength
-     * is -1, it means that no value is defined for the expectedLength attribute.
+     * Set the hint to the candidate about the expected overall length of its
+     * response. A null value unsets expectedLength.
      *
-     * @param integer $expectedLength A strictly positive (> 0) integer or -1.
+     * @param integer|null $expectedLength A non-negative integer (>=0) or null to unset expectedLength.
      * @throws InvalidArgumentException If $expectedLength is not a strictly positive integer nor -1.
      */
     public function setExpectedLength($expectedLength)
     {
-        if (is_int($expectedLength) && ($expectedLength > 0 || $expectedLength === -1)) {
-            $this->expectedLength = $expectedLength;
-        } else {
-            $msg = "The 'expectedLength' argument must be a strictly positive (> 0) integer or -1, '" . gettype($expectedLength) . "' given.";
+        if ($expectedLength !== null && (!is_int($expectedLength) || $expectedLength < 0)) {
+            $given = is_int($expectedLength)
+                ? $expectedLength
+                : gettype($expectedLength);
+
+
+            $msg = 'The "expectedLength" argument must be a non-negative integer (>= 0), "' . $given . '" given.';
             throw new InvalidArgumentException($msg);
         }
+
+        $this->expectedLength = $expectedLength;
     }
 
     /**
@@ -279,7 +284,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function hasExpectedLength()
     {
-        return $this->getExpectedLength() !== -1;
+        return $this->getExpectedLength() !== null;
     }
 
     /**

--- a/src/qtism/data/content/interactions/TextEntryInteraction.php
+++ b/src/qtism/data/content/interactions/TextEntryInteraction.php
@@ -71,10 +71,10 @@ class TextEntryInteraction extends InlineInteraction implements StringInteractio
      * use the value of this attribute to set the size of the response box, where applicable.
      * This is not a validity constraint.
      *
-     * @var integer
+     * @var integer|null
      * @qtism-bean-property
      */
-    private $expectedLength = -1;
+    private $expectedLength;
 
     /**
      * From IMS QTI:
@@ -121,7 +121,6 @@ class TextEntryInteraction extends InlineInteraction implements StringInteractio
         parent::__construct($responseIdentifier, $id, $class, $lang, $label);
         $this->setBase(10);
         $this->setStringIdentifier('');
-        $this->setExpectedLength(-1);
         $this->setPatternMask('');
         $this->setPlaceholderText('');
     }
@@ -195,20 +194,25 @@ class TextEntryInteraction extends InlineInteraction implements StringInteractio
     }
 
     /**
-     * Set the hint to the candidate about the expected overall length of its response. If $expectedLength
-     * is -1, it means that no value is defined for the expectedLength attribute.
+     * Set the hint to the candidate about the expected overall length of its
+     * response. A null value unsets expectedLength.
      *
-     * @param integer $expectedLength A strictly positive (> 0) integer or -1.
+     * @param integer|null $expectedLength A non-negative integer (>=0) or null to unset expectedLength.
      * @throws InvalidArgumentException If $expectedLength is not a strictly positive integer nor -1.
      */
     public function setExpectedLength($expectedLength)
     {
-        if (is_int($expectedLength) && ($expectedLength > 0 || $expectedLength === -1)) {
-            $this->expectedLength = $expectedLength;
-        } else {
-            $msg = "The 'expectedLength' argument must be a strictly positive (> 0) integer or -1, '" . gettype($expectedLength) . "' given.";
+        if ($expectedLength !== null && (!is_int($expectedLength) || $expectedLength < 0)) {
+            $given = is_int($expectedLength)
+                ? $expectedLength
+                : gettype($expectedLength);
+
+
+            $msg = 'The "expectedLength" argument must be a non-negative integer (>= 0), "' . $given . '" given.';
             throw new InvalidArgumentException($msg);
         }
+
+        $this->expectedLength = $expectedLength;
     }
 
     /**
@@ -229,7 +233,7 @@ class TextEntryInteraction extends InlineInteraction implements StringInteractio
      */
     public function hasExpectedLength()
     {
-        return $this->getExpectedLength() !== -1;
+        return $this->getExpectedLength() !== null;
     }
 
     /**

--- a/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
@@ -2,6 +2,7 @@
 
 namespace qtismtest\data\content\interactions;
 
+use InvalidArgumentException;
 use qtism\data\content\interactions\ExtendedTextInteraction;
 use qtismtest\QtiSmTestCase;
 
@@ -35,10 +36,8 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
     {
         $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
 
-        $this->setExpectedException(
-            '\\InvalidArgumentException',
-            "The 'expectedLength' argument must be a strictly positive (> 0) integer or -1, 'boolean' given."
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLength" argument must be a non-negative integer (>= 0), "boolean" given.');
 
         $extendedTextInteraction->setExpectedLength(true);
     }

--- a/test/qtismtest/data/content/interactions/TextInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/TextInteractionTest.php
@@ -2,6 +2,7 @@
 
 namespace qtismtest\data\content\interactions;
 
+use InvalidArgumentException;
 use qtism\data\content\interactions\TextEntryInteraction;
 use qtismtest\QtiSmTestCase;
 
@@ -35,12 +36,54 @@ class TextInteractionTest extends QtiSmTestCase
     {
         $textEntryInteraction = new TextEntryInteraction('RESPONSE');
 
-        $this->setExpectedException(
-            '\\InvalidArgumentException',
-            "The 'expectedLength' argument must be a strictly positive (> 0) integer or -1, 'boolean' given."
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLength" argument must be a non-negative integer (>= 0), "boolean" given.');
 
         $textEntryInteraction->setExpectedLength(true);
+    }
+
+    /**
+     * @dataProvider nonNegativeIntegersForExpectedLength
+     * @param integer $expectedLength
+     */
+    public function testSetExpectedLengthToNonNegativeInteger($expectedLength)
+    {
+        $textEntryInteraction = new TextEntryInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLength($expectedLength);
+
+        $this->assertTrue($textEntryInteraction->hasExpectedLength());
+        $this->assertEquals($expectedLength, $textEntryInteraction->getExpectedLength());
+    }
+
+    public function nonNegativeIntegersForExpectedLength(): array
+    {
+        return [
+            [0],
+            [1],
+            [1012],
+            [2 ** 31 - 1],
+        ];
+    }
+
+    public function testSetExpectedLengthToNegativeIntegerThrowsException()
+    {
+        $textEntryInteraction = new TextEntryInteraction('RESPONSE');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLength" argument must be a non-negative integer (>= 0), "-1" given.');
+
+        $textEntryInteraction->setExpectedLength(-1);
+    }
+
+    public function testUnsetExpectedLengthWithNull()
+    {
+        $textEntryInteraction = new TextEntryInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLength(null);
+
+        $this->assertFalse($textEntryInteraction->hasExpectedLength());
+        $this->assertNull($textEntryInteraction->getExpectedLength());
     }
 
     public function testSetPatternMaskWrongType()


### PR DESCRIPTION
This PR aims at fixing the implementation of expectedLength for (Extended)TextEntryInteraction.
It allows 0 as a valid length and replace the usage of -1 as a magical value representing no value at all with a null value.

Related ticket:
https://oat-sa.atlassian.net/browse/NEX-1852