### PR TITLE
Allowed 0 as an expectedLines value for textEntry interactions.

### DIFF
--- a/src/qtism/data/content/interactions/ExtendedTextInteraction.php
+++ b/src/qtism/data/content/interactions/ExtendedTextInteraction.php
@@ -143,10 +143,10 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Engine should use the value of this attribute to set the size of the response box,
      * where applicable. This is not a validity constraint.
      *
-     * @var integer
+     * @var integer|null
      * @qtism-bean-property
      */
-    private $expectedLines = -1;
+    private $expectedLines;
 
     /**
      * From IMS QTI:
@@ -249,7 +249,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * response. A null value unsets expectedLength.
      *
      * @param integer|null $expectedLength A non-negative integer (>=0) or null to unset expectedLength.
-     * @throws InvalidArgumentException If $expectedLength is not a strictly positive integer nor -1.
+     * @throws InvalidArgumentException If $expectedLength is not a non-negative integer (>= 0) nor null.
      */
     public function setExpectedLength($expectedLength)
     {
@@ -257,8 +257,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
             $given = is_int($expectedLength)
                 ? $expectedLength
                 : gettype($expectedLength);
-
-
+            
             $msg = 'The "expectedLength" argument must be a non-negative integer (>= 0), "' . $given . '" given.';
             throw new InvalidArgumentException($msg);
         }
@@ -270,7 +269,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Get the hint to the candidate about the expected overall length of its response. If the returned
      * value is -1, it means that no value is defined for the expectedLength attribute.
      *
-     * @return integer A strictly positive (> 0) integer or -1 if undefined.
+     * @return integer A non-negative integer (>= 0) or null if undefined.
      */
     public function getExpectedLength()
     {
@@ -437,12 +436,16 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function setExpectedLines($expectedLines)
     {
-        if (is_int($expectedLines) && ($expectedLines > 0 || $expectedLines === -1)) {
-            $this->expectedLines = $expectedLines;
-        } else {
-            $msg = "The 'expectedLines' argument must be a strictly positive (> 0) intege or -1, '" . gettype($expectedLines) . "' given.";
+        if ($expectedLines !== null && (!is_int($expectedLines) || $expectedLines < 0)) {
+            $given = is_int($expectedLines)
+                ? $expectedLines
+                : gettype($expectedLines);
+
+            $msg = 'The "expectedLines" argument must be a non-negative integer (>= 0), "' . $given . '" given.';
             throw new InvalidArgumentException($msg);
         }
+
+        $this->expectedLines = $expectedLines;
     }
 
     /**
@@ -463,7 +466,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function hasExpectedLines()
     {
-        return $this->getExpectedLines() !== -1;
+        return $this->getExpectedLines() !== null;
     }
 
     /**

--- a/src/qtism/data/content/interactions/ExtendedTextInteraction.php
+++ b/src/qtism/data/content/interactions/ExtendedTextInteraction.php
@@ -266,10 +266,10 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     }
 
     /**
-     * Get the hint to the candidate about the expected overall length of its response. If the returned
-     * value is -1, it means that no value is defined for the expectedLength attribute.
+     * Get the hint to the candidate about the expected overall length of its response. 
+     * A null return means that no value is defined for the expectedLength attribute.
      *
-     * @return integer A non-negative integer (>= 0) or null if undefined.
+     * @return integer|null A non-negative integer (>= 0) or null if undefined.
      */
     public function getExpectedLength()
     {
@@ -428,11 +428,11 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     }
 
     /**
-     * Set the hint to the candidate as to the expected number of lines of input required. If
-     * $expectedLines is -1, it means that no value is defined for the expectedLines attribute.
+     * Set the hint to the candidate about the expected number of lines of its
+     * response. A null value unsets expectedLines.
      *
-     * @param integer $expectedLines A strictly positive (> 0) integer or -1.
-     * @throws InvalidArgumentException If $expectedLines is not a strictly positive integer nor -1.
+     * @param integer|null $expectedLines A non-negative integer (>= 0) or null.
+     * @throws InvalidArgumentException If $expectedLines is not a non-negative integer (>= 0) nor null.
      */
     public function setExpectedLines($expectedLines)
     {
@@ -449,10 +449,10 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     }
 
     /**
-     * Get the hint to the candidate as to the expected number of lines of input required. If
-     * the returned value is -1, it means that no value is defined for the expectedLines attribute.
+     * Get the hint to the candidate as to the expected number of lines of input required.
+     * A null return means that no value is defined for the expectedLines attribute.
      *
-     * @return integer A strictly positive (> 0) integer or -1.
+     * @return integer|null A non-negative integer (>= 0) or null if undefined.
      */
     public function getExpectedLines()
     {

--- a/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
@@ -43,7 +43,7 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
     }
 
     /**
-     * @dataProvider nonNegativeIntegersForExpectedLength
+     * @dataProvider nonNegativeIntegersForExpectedLengthAndLines
      * @param integer $expectedLength
      */
     public function testSetExpectedLengthToNonNegativeInteger($expectedLength)
@@ -54,16 +54,6 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
 
         $this->assertTrue($textEntryInteraction->hasExpectedLength());
         $this->assertEquals($expectedLength, $textEntryInteraction->getExpectedLength());
-    }
-
-    public function nonNegativeIntegersForExpectedLength(): array
-    {
-        return [
-            [0],
-            [1],
-            [1012],
-            [2 ** 31 - 1],
-        ];
     }
 
     public function testSetExpectedLengthToNegativeIntegerThrowsException()
@@ -138,12 +128,54 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
     {
         $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
 
-        $this->setExpectedException(
-            '\\InvalidArgumentException',
-            "The 'expectedLines' argument must be a strictly positive (> 0) intege or -1, 'boolean' given."
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLines" argument must be a non-negative integer (>= 0), "boolean" given.');
 
         $extendedTextInteraction->setExpectedLines(true);
+    }
+
+    /**
+     * @dataProvider nonNegativeIntegersForExpectedLengthAndLines
+     * @param integer $expectedLines
+     */
+    public function testSetExpectedLinesToNonNegativeInteger($expectedLines)
+    {
+        $textEntryInteraction = new ExtendedTextInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLines($expectedLines);
+
+        $this->assertTrue($textEntryInteraction->hasExpectedLines());
+        $this->assertEquals($expectedLines, $textEntryInteraction->getExpectedLines());
+    }
+
+    public function testSetExpectedLinesToNegativeIntegerThrowsException()
+    {
+        $textEntryInteraction = new ExtendedTextInteraction('RESPONSE');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLines" argument must be a non-negative integer (>= 0), "-1" given.');
+
+        $textEntryInteraction->setExpectedLines(-1);
+    }
+
+    public function testUnsetExpectedLinesWithNull()
+    {
+        $textEntryInteraction = new ExtendedTextInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLines(null);
+
+        $this->assertFalse($textEntryInteraction->hasExpectedLines());
+        $this->assertNull($textEntryInteraction->getExpectedLines());
+    }
+
+    public function nonNegativeIntegersForExpectedLengthAndLines(): array
+    {
+        return [
+            [0],
+            [1],
+            [1012],
+            [2 ** 31 - 1],
+        ];
     }
 
     public function testSetFormatWrongType()


### PR DESCRIPTION
As previous, the expectedLines also can accept 0 as a valid value.