### PR TITLE
added LIBXML_BIGLINES | LIBXML_PARSEHUGE to work with big files

### DIFF
--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -213,7 +213,10 @@ class XmlDocument extends QtiDocument
                 }
             }
 
-            if (@call_user_func_array([$doc, $loadMethod], [$data, LIBXML_COMPACT | LIBXML_NONET | LIBXML_XINCLUDE | LIBXML_PARSEHUGE])) {
+            if (@call_user_func_array(
+                [$doc, $loadMethod],
+                [$data, LIBXML_COMPACT | LIBXML_NONET | LIBXML_XINCLUDE | LIBXML_BIGLINES | LIBXML_PARSEHUGE])
+            ) {
                 // Infer the QTI version.
                 try {
                     // Prefers the version contained in the XML payload if valid.


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/UNO-628
 
added LIBXML_BIGLINES | LIBXML_PARSEHUGE to work with big files, or data stored as a base64