### PR TITLE
Allowed 0 as an accepted value for expectedLength and expectedLines in text interactions.

### DIFF
--- a/qtism/data/content/interactions/ExtendedTextInteraction.php
+++ b/qtism/data/content/interactions/ExtendedTextInteraction.php
@@ -70,10 +70,10 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * use the value of this attribute to set the size of the response box, where applicable.
      * This is not a validity constraint.
      *
-     * @var integer
+     * @var integer|null
      * @qtism-bean-property
      */
-    private $expectedLength = -1;
+    private $expectedLength;
 
     /**
      * From IMS QTI:
@@ -142,10 +142,10 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Engine should use the value of this attribute to set the size of the response box,
      * where applicable. This is not a validity constraint.
      *
-     * @var integer
+     * @var integer|null
      * @qtism-bean-property
      */
-    private $expectedLines = -1;
+    private $expectedLines;
 
     /**
      * From IMS QTI:
@@ -244,27 +244,31 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     }
 
     /**
-     * Set the hint to the candidate about the expected overall length of its response. If $expectedLength
-     * is -1, it means that no value is defined for the expectedLength attribute.
+     * Set the hint to the candidate about the expected overall length of its
+     * response. A null value unsets expectedLength.
      *
-     * @param  $expectedLength integer A non negative (>= 0) integer or -1.
-     * @throws InvalidArgumentException If $expectedLength is not non negative integer nor -1.
+     * @param integer|null $expectedLength A non-negative integer (>=0) or null to unset expectedLength.
+     * @throws InvalidArgumentException If $expectedLength is not a non-negative integer (>= 0) nor null.
      */
     public function setExpectedLength($expectedLength)
     {
-        if (is_int($expectedLength) && ($expectedLength >= 0 || $expectedLength === -1)) {
-            $this->expectedLength = $expectedLength;
-        } else {
-            $msg = "The 'expectedLength' argument must be a strictly positive (> 0) integer or -1, '" . gettype($expectedLength) . "' given.";
+        if ($expectedLength !== null && (!is_int($expectedLength) || $expectedLength < 0)) {
+            $given = is_int($expectedLength)
+                ? $expectedLength
+                : gettype($expectedLength);
+
+            $msg = 'The "expectedLength" argument must be a non-negative integer (>= 0), "' . $given . '" given.';
             throw new InvalidArgumentException($msg);
         }
+
+        $this->expectedLength = $expectedLength;
     }
 
     /**
-     * Get the hint to the candidate about the expected overall length of its response. If the returned
-     * value is -1, it means that no value is defined for the expectedLength attribute.
+     * Get the hint to the candidate about the expected overall length of its response. 
+     * A null return means that no value is defined for the expectedLength attribute.
      *
-     * @return integer A non negative integer (>= 0) or -1 if undefined.
+     * @return integer|null A non-negative integer (>= 0) or null if undefined.
      */
     public function getExpectedLength()
     {
@@ -278,7 +282,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function hasExpectedLength()
     {
-        return $this->getExpectedLength() !== -1;
+        return $this->getExpectedLength() !== null;
     }
 
     /**
@@ -423,27 +427,31 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     }
 
     /**
-     * Set the hint to the candidate as to the expected number of lines of input required. If
-     * $expectedLines is -1, it means that no value is defined for the expectedLines attribute.
+     * Set the hint to the candidate about the expected number of lines of its
+     * response. A null value unsets expectedLines.
      *
-     * @param integer $expectedLines A non negative integer integer or -1.
-     * @throws InvalidArgumentException If $expectedLines is not a non negative integer nor -1.
+     * @param integer|null $expectedLines A non-negative integer (>= 0) or null.
+     * @throws InvalidArgumentException If $expectedLines is not a non-negative integer (>= 0) nor null.
      */
     public function setExpectedLines($expectedLines)
     {
-        if (is_int($expectedLines) && ($expectedLines >= 0 || $expectedLines === -1)) {
-            $this->expectedLines = $expectedLines;
-        } else {
-            $msg = "The 'expectedLines' argument must be a strictly positive (> 0) intege or -1, '" . gettype($expectedLines) . "' given.";
+        if ($expectedLines !== null && (!is_int($expectedLines) || $expectedLines < 0)) {
+            $given = is_int($expectedLines)
+                ? $expectedLines
+                : gettype($expectedLines);
+
+            $msg = 'The "expectedLines" argument must be a non-negative integer (>= 0), "' . $given . '" given.';
             throw new InvalidArgumentException($msg);
         }
+
+        $this->expectedLines = $expectedLines;
     }
 
     /**
-     * Get the hint to the candidate as to the expected number of lines of input required. If
-     * the returned value is -1, it means that no value is defined for the expectedLines attribute.
+     * Get the hint to the candidate as to the expected number of lines of input required.
+     * A null return means that no value is defined for the expectedLines attribute.
      *
-     * @return integer A non negative integer (>= 0) integer or -1.
+     * @return integer|null A non-negative integer (>= 0) or null if undefined.
      */
     public function getExpectedLines()
     {
@@ -457,7 +465,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function hasExpectedLines()
     {
-        return $this->getExpectedLines() !== -1;
+        return $this->getExpectedLines() !== null;
     }
 
     /**

--- a/qtism/data/content/interactions/TextEntryInteraction.php
+++ b/qtism/data/content/interactions/TextEntryInteraction.php
@@ -70,10 +70,10 @@ class TextEntryInteraction extends InlineInteraction implements StringInteractio
      * use the value of this attribute to set the size of the response box, where applicable.
      * This is not a validity constraint.
      *
-     * @var integer
+     * @var integer|null
      * @qtism-bean-property
      */
-    private $expectedLength = -1;
+    private $expectedLength;
 
     /**
      * From IMS QTI:
@@ -120,7 +120,6 @@ class TextEntryInteraction extends InlineInteraction implements StringInteractio
         parent::__construct($responseIdentifier, $id, $class, $lang, $label);
         $this->setBase(10);
         $this->setStringIdentifier('');
-        $this->setExpectedLength(-1);
         $this->setPatternMask('');
         $this->setPlaceholderText('');
     }
@@ -194,27 +193,31 @@ class TextEntryInteraction extends InlineInteraction implements StringInteractio
     }
 
     /**
-     * Set the hint to the candidate about the expected overall length of its response. If $expectedLength
-     * is -1, it means that no value is defined for the expectedLength attribute.
+     * Set the hint to the candidate about the expected overall length of its
+     * response. A null value unsets expectedLength.
      *
-     * @param integer $expectedLength A non negative (>= 0) integer or -1.
-     * @throws InvalidArgumentException If $expectedLength is not a non negative integer nor -1.
+     * @param integer|null $expectedLength A non-negative integer (>=0) or null to unset expectedLength.
+     * @throws InvalidArgumentException If $expectedLength is not a non-negative integer nor null.
      */
     public function setExpectedLength($expectedLength)
     {
-        if (is_int($expectedLength) && ($expectedLength >= 0 || $expectedLength === -1)) {
-            $this->expectedLength = $expectedLength;
-        } else {
-            $msg = "The 'expectedLength' argument must be a strictly positive (> 0) integer or -1, '" . gettype($expectedLength) . "' given.";
+        if ($expectedLength !== null && (!is_int($expectedLength) || $expectedLength < 0)) {
+            $given = is_int($expectedLength)
+                ? $expectedLength
+                : gettype($expectedLength);
+
+            $msg = 'The "expectedLength" argument must be a non-negative integer (>= 0), "' . $given . '" given.';
             throw new InvalidArgumentException($msg);
         }
+
+        $this->expectedLength = $expectedLength;
     }
 
     /**
      * Get the hint to the candidate about the expected overall length of its response. If the returned
      * value is -1, it means that no value is defined for the expectedLength attribute.
      *
-     * @return A strictly positive (> 0) integer or -1 if undefined.
+     * @return integer|null A non-negative integer (>= 0) or null if undefined.
      */
     public function getExpectedLength()
     {
@@ -228,7 +231,7 @@ class TextEntryInteraction extends InlineInteraction implements StringInteractio
      */
     public function hasExpectedLength()
     {
-        return $this->getExpectedLength() !== -1;
+        return $this->getExpectedLength() !== null;
     }
 
     /**

--- a/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
@@ -2,6 +2,7 @@
 
 namespace qtismtest\data\content\interactions;
 
+use InvalidArgumentException;
 use qtism\data\content\interactions\ExtendedTextInteraction;
 use qtismtest\QtiSmTestCase;
 
@@ -35,12 +36,44 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
     {
         $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
 
-        $this->setExpectedException(
-            '\\InvalidArgumentException',
-            "The 'expectedLength' argument must be a strictly positive (> 0) integer or -1, 'boolean' given."
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLength" argument must be a non-negative integer (>= 0), "boolean" given.');
 
         $extendedTextInteraction->setExpectedLength(true);
+    }
+
+    /**
+     * @dataProvider nonNegativeIntegersForExpectedLengthAndLines
+     * @param integer $expectedLength
+     */
+    public function testSetExpectedLengthToNonNegativeInteger($expectedLength)
+    {
+        $textEntryInteraction = new ExtendedTextInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLength($expectedLength);
+
+        $this->assertTrue($textEntryInteraction->hasExpectedLength());
+        $this->assertEquals($expectedLength, $textEntryInteraction->getExpectedLength());
+    }
+
+    public function testSetExpectedLengthToNegativeIntegerThrowsException()
+    {
+        $textEntryInteraction = new ExtendedTextInteraction('RESPONSE');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLength" argument must be a non-negative integer (>= 0), "-1" given.');
+
+        $textEntryInteraction->setExpectedLength(-1);
+    }
+
+    public function testUnsetExpectedLengthWithNull()
+    {
+        $textEntryInteraction = new ExtendedTextInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLength(null);
+
+        $this->assertFalse($textEntryInteraction->hasExpectedLength());
+        $this->assertNull($textEntryInteraction->getExpectedLength());
     }
 
     public function testSetPatternMaskWrongType()
@@ -95,12 +128,54 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
     {
         $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
 
-        $this->setExpectedException(
-            '\\InvalidArgumentException',
-            "The 'expectedLines' argument must be a strictly positive (> 0) intege or -1, 'boolean' given."
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLines" argument must be a non-negative integer (>= 0), "boolean" given.');
 
         $extendedTextInteraction->setExpectedLines(true);
+    }
+
+    /**
+     * @dataProvider nonNegativeIntegersForExpectedLengthAndLines
+     * @param integer $expectedLines
+     */
+    public function testSetExpectedLinesToNonNegativeInteger($expectedLines)
+    {
+        $textEntryInteraction = new ExtendedTextInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLines($expectedLines);
+
+        $this->assertTrue($textEntryInteraction->hasExpectedLines());
+        $this->assertEquals($expectedLines, $textEntryInteraction->getExpectedLines());
+    }
+
+    public function testSetExpectedLinesToNegativeIntegerThrowsException()
+    {
+        $textEntryInteraction = new ExtendedTextInteraction('RESPONSE');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLines" argument must be a non-negative integer (>= 0), "-1" given.');
+
+        $textEntryInteraction->setExpectedLines(-1);
+    }
+
+    public function testUnsetExpectedLinesWithNull()
+    {
+        $textEntryInteraction = new ExtendedTextInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLines(null);
+
+        $this->assertFalse($textEntryInteraction->hasExpectedLines());
+        $this->assertNull($textEntryInteraction->getExpectedLines());
+    }
+
+    public function nonNegativeIntegersForExpectedLengthAndLines(): array
+    {
+        return [
+            [0],
+            [1],
+            [1012],
+            [2 ** 31 - 1],
+        ];
     }
 
     public function testSetFormatWrongType()

--- a/test/qtismtest/data/content/interactions/TextInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/TextInteractionTest.php
@@ -2,6 +2,7 @@
 
 namespace qtismtest\data\content\interactions;
 
+use InvalidArgumentException;
 use qtism\data\content\interactions\TextEntryInteraction;
 use qtismtest\QtiSmTestCase;
 
@@ -35,12 +36,54 @@ class TextInteractionTest extends QtiSmTestCase
     {
         $textEntryInteraction = new TextEntryInteraction('RESPONSE');
 
-        $this->setExpectedException(
-            '\\InvalidArgumentException',
-            "The 'expectedLength' argument must be a strictly positive (> 0) integer or -1, 'boolean' given."
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLength" argument must be a non-negative integer (>= 0), "boolean" given.');
 
         $textEntryInteraction->setExpectedLength(true);
+    }
+
+    /**
+     * @dataProvider nonNegativeIntegersForExpectedLength
+     * @param integer $expectedLength
+     */
+    public function testSetExpectedLengthToNonNegativeInteger($expectedLength)
+    {
+        $textEntryInteraction = new TextEntryInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLength($expectedLength);
+
+        $this->assertTrue($textEntryInteraction->hasExpectedLength());
+        $this->assertEquals($expectedLength, $textEntryInteraction->getExpectedLength());
+    }
+
+    public function nonNegativeIntegersForExpectedLength(): array
+    {
+        return [
+            [0],
+            [1],
+            [1012],
+            [2 ** 31 - 1],
+        ];
+    }
+
+    public function testSetExpectedLengthToNegativeIntegerThrowsException()
+    {
+        $textEntryInteraction = new TextEntryInteraction('RESPONSE');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "expectedLength" argument must be a non-negative integer (>= 0), "-1" given.');
+
+        $textEntryInteraction->setExpectedLength(-1);
+    }
+
+    public function testUnsetExpectedLengthWithNull()
+    {
+        $textEntryInteraction = new TextEntryInteraction('RESPONSE');
+
+        $textEntryInteraction->setExpectedLength(null);
+
+        $this->assertFalse($textEntryInteraction->hasExpectedLength());
+        $this->assertNull($textEntryInteraction->getExpectedLength());
     }
 
     public function testSetPatternMaskWrongType()


### PR DESCRIPTION
This is the legacy backport of 
https://github.com/oat-sa/qti-sdk/pull/221
https://github.com/oat-sa/qti-sdk/pull/223
https://github.com/oat-sa/qti-sdk/pull/224
https://github.com/oat-sa/qti-sdk/pull/226