### PR TITLE
Added LIBXML_BIGLINES flag to allow to deal with long XML lines.

### DIFF
--- a/qtism/data/storage/xml/XmlDocument.php
+++ b/qtism/data/storage/xml/XmlDocument.php
@@ -141,7 +141,10 @@ class XmlDocument extends QtiDocument
 
             $doc = $this->getDomDocument();
 
-            if (call_user_func_array([$doc, $loadMethod], [$data, LIBXML_COMPACT | LIBXML_NONET | LIBXML_XINCLUDE | LIBXML_PARSEHUGE])) {
+            if (call_user_func_array(
+                [$doc, $loadMethod],
+                [$data, LIBXML_COMPACT | LIBXML_NONET | LIBXML_XINCLUDE | LIBXML_BIGLINES | LIBXML_PARSEHUGE])
+            ) {
                 // Infer the QTI version.
                 try {
                     // Prefers the version contained in the XML payload if valid.


### PR DESCRIPTION
This PR allows XML parser to deal line numbers over 65535.
