### PR TITLE
Added storage of file hash instead of file content in the test session.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,9 @@
 		"php" : "~7.0",
 		"oat-sa/lib-tao-dtms" :  "1.0.0",
 		"ext-dom": "*",
+		"ext-json": "*",
 		"ext-libxml": "*"
-	},
+    },
 	"require-dev": {
 		"phpunit/phpunit": "<6.0.0",
 		"squizlabs/php_codesniffer": "3.*"

--- a/qtism/common/datatypes/files/FileHash.php
+++ b/qtism/common/datatypes/files/FileHash.php
@@ -1,0 +1,281 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Julien Sébire <julien@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\common\datatypes\files;
+
+use JsonSerializable;
+use qtism\common\datatypes\QtiFile;
+use qtism\common\enums\BaseType;
+use qtism\common\enums\Cardinality;
+
+/**
+ * An implementation of File storing only a hash of the file.
+ * File contents has to be previously persisted externally.
+ * Hash string will serve the purpose of comparing files only.
+ */
+class FileHash implements QtiFile, JsonSerializable
+{
+    /**
+     * Key to use in json payload to trigger the storage of a file hash instead
+     * of a hash.
+     */
+    const FILE_HASH_KEY = 'fileHash';
+
+    /**
+     * The id of the file on the persistent storage.
+     *
+     * @var string
+     */
+    private $id;
+
+    /**
+     * The MIME type of the file content.
+     *
+     * @var string
+     */
+    private $mimeType;
+
+    /**
+     * The original file name.
+     *
+     * @var string
+     */
+    private $filename;
+
+    /**
+     * The hash of the file contents.
+     *
+     * @var string
+     */
+    private $hash;
+
+    /**
+     * Create a new FileHash object.
+     *
+     * @param string $id The id of the file in the external file store.
+     * @param string $mimeType The mime-type of the file.
+     * @param string $filename The name of the original file.
+     * @param string $hash The hash of the file.
+     */
+    public function __construct($id, $mimeType, $filename, $hash)
+    {
+        $this->setId($id);
+        $this->setMimeType($mimeType);
+        $this->setFilename($filename);
+        $this->setHash($hash);
+    }
+
+    /**
+     * Create a new FileHash object from an array of properties.
+     *
+     * @param array $properties
+     * @return FileHash
+     */
+    public static function createFromArray(array $properties): self
+    {
+        return new self(
+            $properties['id'],
+            $properties['mime'],
+            $properties['name'],
+            $properties['data']
+        );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id,
+            'mime' => $this->mimeType,
+            'name' => $this->filename,
+            'data' => $this->hash,
+        ];
+    }
+
+    /**
+     * Set the id of the file.
+     *
+     * @param string $id
+     */
+    protected function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * Get the id of the file.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set the mime-type of the file.
+     *
+     * @param string $mimeType
+     */
+    protected function setMimeType($mimeType)
+    {
+        $this->mimeType = $mimeType;
+    }
+
+    /**
+     * Get the mime-type of the file.
+     *
+     * @return string
+     */
+    public function getMimeType()
+    {
+        return $this->mimeType;
+    }
+
+    /**
+     * Get the name of the file.
+     *
+     * @return string
+     */
+    public function getFilename()
+    {
+        return $this->filename;
+    }
+
+    /**
+     * Set the name of the file.
+     *
+     * @param string $filename
+     */
+    protected function setFilename($filename)
+    {
+        $this->filename = $filename;
+    }
+
+    /**
+     * Get the sequence of bytes composing the hash of the file.
+     */
+    public function getData()
+    {
+        return $this->getHash();
+    }
+
+    /**
+     * Returns nothing because the content of the file is stored externally
+     * and thus not accessible in here.
+     */
+    public function getStream()
+    {
+    }
+
+    /**
+     * Get the hash of the file.
+     *
+     * @return string
+     */
+    public function getHash()
+    {
+        return $this->hash;
+    }
+
+    /**
+     * Set the hash of the file.
+     *
+     * @param string $hash
+     */
+    protected function setHash($hash)
+    {
+        $this->hash = $hash;
+    }
+
+    /**
+     * Get the cardinality of the File value.
+     *
+     * @return int A value from the Cardinality enumeration.
+     */
+    public function getCardinality()
+    {
+        return Cardinality::SINGLE;
+    }
+
+    /**
+     * Get the baseType of the File value.
+     *
+     * @return int A value from the BaseType enumeration.
+     */
+    public function getBaseType()
+    {
+        return BaseType::FILE;
+    }
+
+    /**
+     * Whether or not the File has a file name.
+     *
+     * @return bool
+     */
+    public function hasFilename()
+    {
+        return true;
+    }
+
+    /**
+     * Whether or not two File objects are equals. Two File values
+     * are considered to be identical if they have the same file name,
+     * mime-type and hash.
+     *
+     * @param mixed $obj
+     * @return bool
+     */
+    public function equals($obj)
+    {
+        if (!$obj instanceof self) {
+            return false;
+        }
+
+        return $this->getId() === $obj->getId()
+            && $this->getMimeType() === $obj->getMimeType()
+            && $this->getFilename() === $obj->getFilename()
+            && $this->getHash() === $obj->getHash();
+    }
+
+    /**
+     * Get the unique identifier of the File.
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->getId();
+    }
+
+    /**
+     * File as a string
+     *
+     * Returns the file name.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getFilename();
+    }
+}

--- a/qtism/runtime/pci/json/Marshaller.php
+++ b/qtism/runtime/pci/json/Marshaller.php
@@ -24,6 +24,7 @@
 namespace qtism\runtime\pci\json;
 
 use InvalidArgumentException;
+use qtism\common\datatypes\files\FileHash;
 use qtism\common\datatypes\QtiBoolean;
 use qtism\common\datatypes\QtiDatatype;
 use qtism\common\datatypes\QtiDirectedPair;
@@ -227,6 +228,8 @@ class Marshaller
             return $this->marshallPair($complex);
         } elseif ($complex instanceof QtiDuration) {
             return $this->marshallDuration($complex);
+        } elseif ($complex instanceof FileHash) {
+            return $this->marshallFileHash($complex);
         } elseif ($complex instanceof QtiFile) {
             return $this->marshallFile($complex);
         } else {
@@ -377,5 +380,20 @@ class Marshaller
         }
 
         return $data;
+    }
+
+    /**
+     * Marshall a QTI fileHash datatype into its PCI JSON Representation.
+     *
+     * @param FileHash $file
+     * @return array
+     */
+    protected function marshallFileHash(FileHash $file)
+    {
+        return [
+            'base' => [
+                FileHash::FILE_HASH_KEY => $file->jsonSerialize()
+            ],
+        ];
     }
 }

--- a/qtism/runtime/pci/json/Unmarshaller.php
+++ b/qtism/runtime/pci/json/Unmarshaller.php
@@ -24,6 +24,7 @@
 namespace qtism\runtime\pci\json;
 
 use InvalidArgumentException;
+use qtism\common\datatypes\files\FileHash;
 use qtism\common\datatypes\files\FileManager;
 use qtism\common\datatypes\files\FileManagerException;
 use qtism\common\datatypes\QtiBoolean;
@@ -275,6 +276,10 @@ class Unmarshaller
                     return $this->unmarshallFile($unit);
                     break;
 
+                case FileHash::FILE_HASH_KEY:
+                    return $this->unmarshallFileHash($unit);
+                    break;
+                    
                 case 'uri':
                     return $this->unmarshallUri($unit);
                     break;
@@ -392,7 +397,7 @@ class Unmarshaller
     }
 
     /**
-     * Unmarshall a duration JSON PCI representation.
+     * Unmarshall an uploaded file payload JSON PCI representation.
      *
      * @param array $unit
      * @return QtiFile
@@ -406,7 +411,36 @@ class Unmarshaller
     }
 
     /**
-     * Unmarshall a duration JSON PCI representation.
+     * Unmarshall an uploaded file hash JSON PCI representation.
+     *
+     * This is not a standard QTI feature but a convenience to store only
+     * a hash of the file, to avoid storing huge files in the test session.
+     * This suppose the following:
+     * * Payload of the file has been persisted before.
+     * * "id" key contains the persisted file id in the external file store.
+     * * "data" key contains the hash, base64_encoded.
+     *
+     * @param array $unit
+     * @return QtiFile
+     * @throws FileManagerException
+     */
+    protected function unmarshallFileHash(array $unit)
+    {
+        $fileHashArray = $unit['base'][FileHash::FILE_HASH_KEY];
+        if (empty($fileHashArray['id'])) {
+            throw new FileManagerException('To store an uploaded file hash, the file has to be persisted before and the file id provided in the "id" key.');
+        }
+
+        return new FileHash(
+            $fileHashArray['id'],
+            $fileHashArray['mime'],
+            $fileHashArray['name'],
+            $fileHashArray['data']
+        );
+    }
+    
+    /**
+     * Unmarshall a URI JSON PCI representation.
      *
      * @param array $unit
      * @return QtiUri

--- a/test/qtismtest/runtime/pci/json/JsonMarshallerTest.php
+++ b/test/qtismtest/runtime/pci/json/JsonMarshallerTest.php
@@ -2,6 +2,7 @@
 
 namespace qtismtest\runtime\pci\json;
 
+use qtism\common\datatypes\files\FileHash;
 use qtism\common\datatypes\files\FileSystemFile;
 use qtism\common\datatypes\QtiBoolean;
 use qtism\common\datatypes\QtiDatatype;
@@ -172,6 +173,16 @@ class JsonMarshallerTest extends QtiSmTestCase
         $file = new FileSystemFile($samples . 'datatypes/file/image-png_noname_data.png');
         $returnValue[] = [$file, json_encode(['base' => ['file' => ['mime' => $file->getMimeType(), 'data' => base64_encode($file->getData())]]])];
 
+        $id = 'http://some.cloud.storage/path/to/stored-file.txt';
+        $mimeType = 'text/plain';
+        $filename = 'file.txt';
+        $sha256 = '165940940A02A187E4463FF467090930038C5AF8FC26107BF301E714F599A1DA';
+
+        $fileHash = new FileHash($id, $mimeType, $filename, $sha256);
+        $returnValue[] = [$fileHash, json_encode(
+            ['base' => [FileHash::FILE_HASH_KEY => ['id' => $id, 'mime' => $mimeType, 'name' => $filename, 'data' => $sha256]]]
+        )];
+        
         return $returnValue;
     }
 

--- a/test/qtismtest/runtime/pci/json/JsonUnmarshallerTest.php
+++ b/test/qtismtest/runtime/pci/json/JsonUnmarshallerTest.php
@@ -2,6 +2,7 @@
 
 namespace qtismtest\runtime\pci\json;
 
+use qtism\common\datatypes\files\FileHash;
 use qtism\common\datatypes\files\FileManagerException;
 use qtism\common\datatypes\files\FileSystemFile;
 use qtism\common\datatypes\files\FileSystemFileManager;
@@ -89,6 +90,33 @@ class JsonUnmarshallerTest extends QtiSmTestCase
         // cleanup.
         $fileManager = new FileSystemFileManager();
         $fileManager->delete($value);
+    }
+
+    public function testUnmarshallFileHash()
+    {
+        $id = 'http://some.cloud.storage/path/to/file.txt';
+        $mimeType = 'text/plain';
+        $filename = 'file.txt';
+        $sha256 = '165940940A02A187E4463FF467090930038C5AF8FC26107BF301E714F599A1DA';
+
+        $expectedFile = new FileHash($id, $mimeType, $filename, $sha256);
+
+        $json = sprintf(
+            '{ "base" : { "%s" : {
+            "mime" : "%s", 
+            "data" : "%s", 
+            "name" : "%s",
+            "id" : "%s" } } }',
+            FileHash::FILE_HASH_KEY,
+            $mimeType,
+            $sha256,
+            $filename,
+            $id
+        );
+
+        $unmarshaller = self::createUnmarshaller();
+        $value = $unmarshaller->unmarshall($json);
+        $this->assertTrue($expectedFile->equals($value));
     }
 
     /**

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
@@ -4,6 +4,7 @@ namespace qtismtest\runtime\storage\binary;
 
 use qtism\common\Comparable;
 use qtism\common\datatypes\files\DefaultFileManager;
+use qtism\common\datatypes\files\FileHash;
 use qtism\common\datatypes\files\FileSystemFile;
 use qtism\common\datatypes\files\FileSystemFileManager;
 use qtism\common\datatypes\QtiBoolean;
@@ -220,6 +221,7 @@ class QtiBinaryStreamAccessTest extends QtiSmTestCase
         $returnValue[] = [new OutcomeVariable('VAR', Cardinality::MULTIPLE, BaseType::INT_OR_IDENTIFIER), "\x00" . "\x00" . pack('S', 0), new MultipleContainer(BaseType::INT_OR_IDENTIFIER)];
         $returnValue[] = [new OutcomeVariable('VAR', Cardinality::ORDERED, BaseType::INT_OR_IDENTIFIER, new OrderedContainer(BaseType::INT_OR_IDENTIFIER, [new QtiIntOrIdentifier(1)])), "\x01", null];
 
+        // Files
         $returnValue[] = [new ResponseVariable('VAR', Cardinality::SINGLE, BaseType::FILE), "\x01", null];
         $path = self::samplesDir() . 'datatypes/file/text-plain_text_data.txt';
         $returnValue[] = [new ResponseVariable('VAR', Cardinality::SINGLE, BaseType::FILE), "\x00" . "\x01" . pack('S', strlen($path)) . $path, FileSystemFile::retrieveFile($path)];
@@ -470,7 +472,8 @@ class QtiBinaryStreamAccessTest extends QtiSmTestCase
             [new OutcomeVariable('VAR', Cardinality::MULTIPLE, BaseType::INT_OR_IDENTIFIER, new MultipleContainer(BaseType::INT_OR_IDENTIFIER, [new QtiIntOrIdentifier(0), null, new QtiIntOrIdentifier(1), null, new QtiIntOrIdentifier(200000)]))],
             [new OutcomeVariable('VAR', Cardinality::ORDERED, BaseType::INT_OR_IDENTIFIER, new OrderedContainer(BaseType::INT_OR_IDENTIFIER, [new QtiIntOrIdentifier(0), null, new QtiIntOrIdentifier('Q01'), null, new QtiIntOrIdentifier(200000)]))],
 
-            [new ResponseVariable('VAR', Cardinality::SINGLE, BaseType::FILE, FileSystemFile::retrieveFile(self::samplesDir() . 'datatypes/file/text-plain_text_data.txt'))],
+            // Files
+            [new OutcomeVariable('VAR', Cardinality::SINGLE, BaseType::FILE, FileSystemFile::retrieveFile(self::samplesDir() . 'datatypes/file/text-plain_text_data.txt'))],
             [
                 new OutcomeVariable(
                     'VAR',
@@ -480,6 +483,10 @@ class QtiBinaryStreamAccessTest extends QtiSmTestCase
                 ),
             ],
 
+            // FileHash
+            [new OutcomeVariable('VAR', Cardinality::SINGLE, BaseType::FILE, new FileHash('id', 'text/plain', 'my_file.txt', 'AA025C4DB95A39A2CB8525F83F1387C1A2B13595C8E4C337CDF9AD7B043518A3'))],
+
+            // Records
             [new OutcomeVariable('VAR', Cardinality::RECORD)],
             [new OutcomeVariable('VAR', Cardinality::RECORD, -1, new RecordContainer(['key1' => null]))],
             [new OutcomeVariable('Var', Cardinality::RECORD, -1, new RecordContainer(['key1' => new QtiDuration('PT1S'), 'key2' => new QtiFloat(25.5), 'key3' => new QtiInteger(2), 'key4' => new QtiString('String!'), 'key5' => null, 'key6' => new QtiBoolean(true)]))],


### PR DESCRIPTION
This is the legacy counterpart of https://github.com/oat-sa/qti-sdk/pull/227.

This PR aims at allowing the storage of a hash of an uploaded file instead of the content of the file itself, to avoid huge payloads to be stored in the test session. This requires that the file has been persisted to an external storage prior to call to qtism\runtime\pci\json\Unmarshaller::unmarshall.
A convenience to trigger this process is to use the FileHash::FILE_HASH_KEY constant as a key when encoding the JSON payload. An extra 4th parameter id is then required, containing the id of the persisted file allowing the retrieval of the file by the application that persisted the file on the external storage:

Replace key file in

{ "base" : { "file" : {
            "mime" : "text-plain", 
            "data" : "The contents of the file...", 
            "name" : "my-file.txt" } } }

with key FileHash::FILE_HASH_KEY:

{ "base" : { "fileHash" : {
            "mime" : "text-plain", 
            "data" : "AA025C4DB95A39A2CB8525F83F1387C1A2B13595C8E4C337CDF9AD7B043518A3", 
            "name" : "my-file.txt",
            "id" : "some-identifier/provided/by-the/external/file-store" } } }
