### PR TITLE
Moved custom operators from lib-tao-qti.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - 7.2
   - 7.3
   - 7.4
+
+before_install: phpenv config-add travis-cfg.ini
   
 before_script:
   - composer self-update && composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 	"require" : {
 		"php" : "~7.0",
 		"oat-sa/lib-tao-dtms" :  "1.0.0",
+		"oat-sa/lib-beeme" :  "0.2.0",
 		"ext-dom": "*",
 		"ext-json": "*",
 		"ext-libxml": "*"
@@ -37,6 +38,9 @@
 	"autoload": {
 		"psr-0": {
 			"qtism\\": "."
+		},
+		"psr-4": {
+			"qti\\customOperators\\": "qtism/runtime/expressions/operators/custom/"
 		}
 	},
 	"autoload-dev": {

--- a/qtism/runtime/expressions/operators/custom/CsvToContainer.php
+++ b/qtism/runtime/expressions/operators/custom/CsvToContainer.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace qti\customOperators;
+
+use qtism\common\enums\BaseType;
+use qtism\common\datatypes\QtiString;
+use qtism\runtime\expressions\operators\CustomOperatorProcessor;
+
+abstract class CsvToContainer extends CustomOperatorProcessor
+{
+    public function process() 
+    {
+        $returnValue = null;
+        
+        $operands = $this->getOperands();
+        if (count($operands) > 0) {
+            $operand = $operands[0];
+            
+            if ($operand !== null && $operand instanceof QtiString) {
+                $returnValue = $this->createContainer();
+                $values = explode(',', $operand->getValue());
+                
+                foreach ($values as $value) {
+                    $returnValue[] = new QtiString($value);
+                }
+            }
+        }
+        
+        return $returnValue;
+    }
+    
+    abstract protected function createContainer();
+}

--- a/qtism/runtime/expressions/operators/custom/CsvToMultiple.php
+++ b/qtism/runtime/expressions/operators/custom/CsvToMultiple.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace qti\customOperators;
+
+use qtism\common\enums\BaseType;
+use qtism\runtime\common\MultipleContainer;
+use qtism\runtime\expressions\operators\CustomOperatorProcessor;
+
+class CsvToMultiple extends CsvToContainer
+{
+    protected function createContainer()
+    {
+        return new MultipleContainer(BaseType::STRING);
+    }
+}

--- a/qtism/runtime/expressions/operators/custom/CsvToOrdered.php
+++ b/qtism/runtime/expressions/operators/custom/CsvToOrdered.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace qti\customOperators;
+
+use qtism\common\enums\BaseType;
+use qtism\runtime\common\OrderedContainer;
+use qtism\runtime\expressions\operators\CustomOperatorProcessor;
+
+class CsvToOrdered extends CsvToContainer
+{
+    protected function createContainer()
+    {
+        return new OrderedContainer(BaseType::STRING);
+    }
+}

--- a/qtism/runtime/expressions/operators/custom/math/fraction/Denominator.php
+++ b/qtism/runtime/expressions/operators/custom/math/fraction/Denominator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace qti\customOperators\math\fraction;
+
+class Denominator extends NumeratorDenominator
+{
+    protected function extract(array $values)
+    {
+        return $values[1];
+    }
+}

--- a/qtism/runtime/expressions/operators/custom/math/fraction/Numerator.php
+++ b/qtism/runtime/expressions/operators/custom/math/fraction/Numerator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace qti\customOperators\math\fraction;
+
+class Numerator extends NumeratorDenominator
+{
+    protected function extract(array $values)
+    {
+        return $values[0];
+    }
+}

--- a/qtism/runtime/expressions/operators/custom/math/fraction/NumeratorDenominator.php
+++ b/qtism/runtime/expressions/operators/custom/math/fraction/NumeratorDenominator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace qti\customOperators\math\fraction;
+
+use qtism\common\datatypes\QtiString;
+use qtism\common\datatypes\QtiInteger;
+use qtism\runtime\expressions\operators\CustomOperatorProcessor;
+
+abstract class NumeratorDenominator extends CustomOperatorProcessor
+{
+    public function process() 
+    {
+        $returnValue = null;
+        
+        $operands = $this->getOperands();
+        if (count($operands) > 0) {
+            $operand = $operands[0];
+            
+            if ($operand !== null && $operand instanceof QtiString && preg_match('@[0-9]+/[0-9]+@', $operand->getValue()) === 1) {
+                $values = explode('/', $operand->getValue());
+                return new QtiInteger(intval($this->extract($values)));
+            }
+        }
+        
+        return $returnValue;
+    }
+    
+    abstract protected function extract(array $values);
+}

--- a/qtism/runtime/expressions/operators/custom/math/graph/CountPointsThatSatisfyEquation.php
+++ b/qtism/runtime/expressions/operators/custom/math/graph/CountPointsThatSatisfyEquation.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace qti\customOperators\math\graph;
+
+use qtism\common\enums\BaseType;
+use qtism\common\datatypes\QtiInteger as QtismInteger;
+use qtism\common\datatypes\QtiString as QtismString;
+use qtism\common\datatypes\QtiPoint;
+use qtism\runtime\common\MultipleContainer;
+use qtism\runtime\common\OrderedContainer;
+use qtism\runtime\expressions\operators\CustomOperatorProcessor;
+
+class CountPointsThatSatisfyEquation extends CustomOperatorProcessor
+{
+    public function process() 
+    {
+        $returnValue = new QtismInteger(0);
+        $operands = $this->getOperands();
+        
+        if (count($operands) >= 2) {
+            $points = $operands[0];
+            $equation = $operands[1];
+            
+            if (($points instanceof MultipleContainer || $points instanceof OrderedContainer) && ($points->getBaseType() === BaseType::POINT || $points->getBaseType() === BaseType::STRING) && $equation instanceof QtismString) {
+                // Check every Point X,Y against the equation...
+                $math = new \oat\beeme\Parser();
+                $math->setConstant('#pi', M_PI);
+                
+                try {
+                    foreach ($points as $point) {
+                        
+                        if ($point instanceof QtiPoint) {
+                            $x = floatval($point->getX());
+                            $y = floatval($point->getY());
+                        } else {
+                            $strs = explode("\x20", $point->getValue());
+                            if (count($strs) !== 2) {
+                                // Parsing error, the NULL value is returned.
+                                return null;
+                            } else {
+                                $x = floatval($strs[0]);
+                                $y = floatval($strs[1]);
+                            }
+                        }
+                        
+                        $result = $math->evaluate(
+                            $equation->getValue(),
+                            array(
+                                'x' => $x,
+                                'y' => $y
+                            )
+                        );
+                        
+                        if ($result === true) {
+                            // The Point X,Y satisfies the equation...
+                            $returnValue->setValue($returnValue->getValue() + 1);
+                        }
+                    }
+                } catch (\Exception $e) {
+                    // If an error occurs e.g. invalid expression, the NULL value is returned.
+                    return null;
+                }
+            } else {
+                // Not supported operands, return the NULL value.
+                return null;
+            }
+        }
+        
+        return $returnValue;
+    }
+}

--- a/qtism/runtime/expressions/operators/custom/text/StringToNumber.php
+++ b/qtism/runtime/expressions/operators/custom/text/StringToNumber.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace qti\customOperators\text;
+
+use qtism\common\datatypes\QtiString as QtismString;
+use qtism\common\datatypes\QtiFloat as QtismFloat;
+use qtism\runtime\expressions\operators\CustomOperatorProcessor;
+
+class StringToNumber extends CustomOperatorProcessor
+{
+    public function process() 
+    {
+        $returnValue = null;
+        
+        $operands = $this->getOperands();
+        if (count($operands) > 0) {
+            $operand = $operands[0];
+            
+            if ($operand !== null && $operand instanceof QtismString) {
+                $str = str_replace(',', '', $operand->getValue());
+                $float = @floatval($str);
+                
+                $returnValue = new QtismFloat($float);
+            }
+        }
+        
+        return $returnValue;
+    }
+}

--- a/test/qtismtest/runtime/expressions/operators/custom/CsvToMultipleTest.php
+++ b/test/qtismtest/runtime/expressions/operators/custom/CsvToMultipleTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\runtime\expressions\operators\custom;
+
+use qtism\common\enums\BaseType;
+use qtism\common\datatypes\QtiBoolean;
+use qtism\common\datatypes\QtiString;
+use qtism\data\expressions\operators\CustomOperator;
+use qtism\data\expressions\ExpressionCollection;
+use qtism\data\expressions\BaseValue;
+use qtism\runtime\expressions\operators\OperandsCollection;
+use qtism\runtime\common\MultipleContainer;
+use qti\customOperators\CsvToMultiple;
+use qtismtest\QtiSmTestCase;
+
+/**
+ * Tests for CsvToMultiple custom operator.
+ */
+class CsvToMultipleTest extends QtiSmTestCase {
+	
+    public function testSimple() {
+        $baseValue = new BaseValue(BaseType::STRING, 'Boba,Fett');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.csvToMultiple"><baseValue baseType="string">Boba,Fett</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiString('Boba,Fett')));
+        $operator = new CsvToMultiple($customOperator, $operands);
+        $result = $operator->process();
+        
+        $expected = new MultipleContainer(
+            BaseType::STRING, array(
+                new QtiString('Boba'),
+                new QtiString('Fett')
+            )
+        );
+
+        $this->assertInstanceOf(MultipleContainer::class, $result);
+        $this->assertTrue($expected->equals($result));
+    }
+    
+    /**
+     * @depends testSimple
+     */
+    public function testSingleStringValue() {
+        $baseValue = new BaseValue(BaseType::STRING, 'Boba');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.csvToMultiple"><baseValue baseType="string">Boba</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiString('Boba')));
+        $operator = new CsvToMultiple($customOperator, $operands);
+        $result = $operator->process();
+        
+        $expected = new MultipleContainer(
+            BaseType::STRING, array(
+                new QtiString('Boba')
+            )
+        );
+
+        $this->assertInstanceOf(MultipleContainer::class, $result);
+        $this->assertTrue($expected->equals($result));
+    }
+    
+    /**
+     * @depends testSimple
+     */
+    public function testReturnsNull() {
+        $baseValue = new BaseValue(BaseType::BOOLEAN, false);
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.csvToMultiple"><baseValue baseType="boolean">false</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiBoolean(false)));
+        $operator = new CsvToMultiple($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertNull($result);
+    }
+    
+    /**
+     * @depends testSimple
+     */
+    public function testEmptyStringValue() {
+        $baseValue = new BaseValue(BaseType::STRING, '');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.csvToMultiple"><baseValue baseType="string"></baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiString('')));
+        $operator = new CsvToMultiple($customOperator, $operands);
+        $result = $operator->process();
+        
+        $expected = new MultipleContainer(
+            BaseType::STRING, array(
+                new QtiString('')
+            )
+        );
+
+        $this->assertInstanceOf(MultipleContainer::class, $result);
+        $this->assertTrue($expected->equals($result));
+    }
+}

--- a/test/qtismtest/runtime/expressions/operators/custom/CsvToOrderedTest.php
+++ b/test/qtismtest/runtime/expressions/operators/custom/CsvToOrderedTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\runtime\expressions\operators\custom;
+
+use qtism\common\enums\BaseType;
+use qtism\common\datatypes\QtiBoolean;
+use qtism\common\datatypes\QtiString;
+use qtism\data\expressions\operators\CustomOperator;
+use qtism\data\expressions\ExpressionCollection;
+use qtism\data\expressions\BaseValue;
+use qtism\runtime\expressions\operators\OperandsCollection;
+use qtism\runtime\common\OrderedContainer;
+use qti\customOperators\CsvToOrdered;
+use qtismtest\QtiSmTestCase;
+
+/**
+ * Tests for CsvToOrdered custom operator.
+ */
+class CsvToOrderedTest extends QtiSmTestCase {
+	
+    public function testSimple() {
+        $baseValue = new BaseValue(BaseType::STRING, 'Boba,Fett');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.csvToOrdered"><baseValue baseType="string">Boba,Fett</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiString('Boba,Fett')));
+        $operator = new CsvToOrdered($customOperator, $operands);
+        $result = $operator->process();
+        
+        $expected = new OrderedContainer(
+            BaseType::STRING, array(
+                new QtiString('Boba'),
+                new QtiString('Fett')
+            )
+        );
+
+        $this->assertInstanceOf(OrderedContainer::class, $result);
+        $this->assertTrue($expected->equals($result));
+    }
+    
+    /**
+     * @depends testSimple
+     */
+    public function testSingleStringValue() {
+        $baseValue = new BaseValue(BaseType::STRING, 'Boba');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.csvToOrdered"><baseValue baseType="string">Boba</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiString('Boba')));
+        $operator = new CsvToOrdered($customOperator, $operands);
+        $result = $operator->process();
+        
+        $expected = new OrderedContainer(
+            BaseType::STRING, array(
+                new QtiString('Boba')
+            )
+        );
+        
+        $this->assertInstanceOf(OrderedContainer::class, $result);
+        $this->assertTrue($expected->equals($result));
+    }
+    
+    /**
+     * @depends testSimple
+     */
+    public function testReturnsNull() {
+        $baseValue = new BaseValue(BaseType::BOOLEAN, false);
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.csvToOrdered"><baseValue baseType="boolean">false</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiBoolean(false)));
+        $operator = new CsvToOrdered($customOperator, $operands);
+        $result = $operator->process();
+        
+        $this->assertNull($result);
+    }
+    
+    /**
+     * @depends testSimple
+     */
+    public function testEmptyStringValue() {
+        $baseValue = new BaseValue(BaseType::STRING, '');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.csvToOrdered"><baseValue baseType="string"></baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiString('')));
+        $operator = new CsvToOrdered($customOperator, $operands);
+        $result = $operator->process();
+        
+        $expected = new OrderedContainer(
+            BaseType::STRING, array(
+                new QtiString('')
+            )
+        );
+        
+        $this->assertInstanceOf(OrderedContainer::class, $result);
+        $this->assertTrue($expected->equals($result));
+    }
+}

--- a/test/qtismtest/runtime/expressions/operators/custom/math/fraction/DenominatorTest.php
+++ b/test/qtismtest/runtime/expressions/operators/custom/math/fraction/DenominatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\runtime\expressions\operators\custom\math\fraction;
+
+use qti\customOperators\math\fraction\Denominator;
+use qtism\common\datatypes\QtiBoolean;
+use qtism\common\datatypes\QtiString;
+use qtism\common\enums\BaseType;
+use qtism\data\expressions\BaseValue;
+use qtism\data\expressions\ExpressionCollection;
+use qtism\data\expressions\operators\CustomOperator;
+use qtism\runtime\expressions\operators\OperandsCollection;
+use qtismtest\QtiSmTestCase;
+
+/**
+ * Tests for Denominator custom operator.
+ */
+class DenominatorTest extends QtiSmTestCase
+{
+    public function testSimple()
+    {
+        $baseValue = new BaseValue(BaseType::STRING, '1/2');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection([$baseValue]),
+            '<customOperator class="qti.customOperators.math.Denominator"><baseValue baseType="string">1/2</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection([new QtiString('1/2')]);
+        $operator = new Denominator($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertEquals(2, $result->getValue());
+    }
+
+    public function testReturnsNullOne()
+    {
+        $baseValue = new BaseValue(BaseType::BOOLEAN, false);
+        $customOperator = new CustomOperator(
+            new ExpressionCollection([$baseValue]),
+            '<customOperator class="qti.customOperators.math.Denominator"><baseValue baseType="boolean">false</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection([new QtiBoolean(false)]);
+        $operator = new Denominator($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertNull($result);
+    }
+
+    public function testReturnsNullTwo()
+    {
+        $baseValue = new BaseValue(BaseType::BOOLEAN, false);
+        $customOperator = new CustomOperator(
+            new ExpressionCollection([$baseValue]),
+            '<customOperator class="qti.customOperators.math.Denominator"><baseValue baseType="string">bla</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection([new QtiBoolean(false)]);
+        $operator = new Denominator($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertNull($result);
+    }
+}

--- a/test/qtismtest/runtime/expressions/operators/custom/math/fraction/NumeratorTest.php
+++ b/test/qtismtest/runtime/expressions/operators/custom/math/fraction/NumeratorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\runtime\expressions\operators\custom\math\fraction;
+
+use qti\customOperators\math\fraction\Numerator;
+use qtism\common\datatypes\QtiBoolean;
+use qtism\common\datatypes\QtiString;
+use qtism\common\enums\BaseType;
+use qtism\data\expressions\BaseValue;
+use qtism\data\expressions\ExpressionCollection;
+use qtism\data\expressions\operators\CustomOperator;
+use qtism\runtime\expressions\operators\OperandsCollection;
+use qtismtest\QtiSmTestCase;
+
+/**
+ * Tests for Numerator custom operator.
+ */
+class NumeratorTest extends QtiSmTestCase
+{
+    public function testSimple()
+    {
+        $baseValue = new BaseValue(BaseType::STRING, '1/2');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection([$baseValue]),
+            '<customOperator class="qti.customOperators.math.Numerator"><baseValue baseType="string">1/2</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection([new QtiString('1/2')]);
+        $operator = new Numerator($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertEquals($result->getValue(), 1);
+    }
+
+    public function testReturnsNullOne()
+    {
+        $baseValue = new BaseValue(BaseType::BOOLEAN, false);
+        $customOperator = new CustomOperator(
+            new ExpressionCollection([$baseValue]),
+            '<customOperator class="qti.customOperators.math.Numerator"><baseValue baseType="boolean">false</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection([new QtiBoolean(false)]);
+        $operator = new Numerator($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertSame(null, $result);
+    }
+
+    public function testReturnsNullTwo()
+    {
+        $baseValue = new BaseValue(BaseType::BOOLEAN, false);
+        $customOperator = new CustomOperator(
+            new ExpressionCollection([$baseValue]),
+            '<customOperator class="qti.customOperators.math.Numerator"><baseValue baseType="string">bla</baseValue></customOperator>'
+        );
+        $operands = new OperandsCollection([new QtiBoolean(false)]);
+        $operator = new Numerator($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertNull($result);
+    }
+}

--- a/test/qtismtest/runtime/expressions/operators/custom/math/graph/CountPointsThatSatisfyEquationTest.php
+++ b/test/qtismtest/runtime/expressions/operators/custom/math/graph/CountPointsThatSatisfyEquationTest.php
@@ -1,0 +1,444 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\runtime\expressions\operators\custom\math\graph;
+
+use qti\customOperators\math\graph\CountPointsThatSatisfyEquation;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\datatypes\QtiInteger;
+use qtism\common\datatypes\QtiPoint;
+use qtism\common\datatypes\QtiString;
+use qtism\common\enums\BaseType;
+use qtism\data\expressions\BaseValue;
+use qtism\data\expressions\ExpressionCollection;
+use qtism\data\expressions\NullValue;
+use qtism\data\expressions\operators\CustomOperator;
+use qtism\data\expressions\operators\Multiple;
+use qtism\runtime\common\MultipleContainer;
+use qtism\runtime\expressions\operators\OperandsCollection;
+use qtismtest\QtiSmTestCase;
+
+/**
+ * Tests for CountPointsThatSatisfyEquation custom operator.
+ */
+class CountPointsThatSatisfyEquationTest extends QtiSmTestCase
+{
+    public function testSimpleOne()
+    {
+        // --- Build Custom Operator PHP Expression Model.
+        $points = new Multiple(
+            new ExpressionCollection(
+                [
+                    new BaseValue(BaseType::POINT, new QtiPoint(0, 0)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(1, 1)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(2, 4)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(3, 9)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(4, 16)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(5, 25)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(6, 36)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(7, 49)),
+                ]
+            )
+        );
+        $equation = new BaseValue(BaseType::STRING, 'x ^ 2');
+
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(
+                [
+                    $points,
+                    $equation,
+                ]
+            ),
+            '<customOperator class="qti.customOperators.math.graph.CountPointsThatSatisfyEquation">
+                <multiple>
+                    <baseValue baseType="point">0 0</baseValue>
+                    <baseValue baseType="point">1 1</baseValue>
+                    <baseValue baseType="point">2 4</baseValue>
+                    <baseValue baseType="point">3 9</baseValue>
+                    <baseValue baseType="point">4 16</baseValue>
+                    <baseValue baseType="point">5 25</baseValue>
+                    <baseValue baseType="point">6 36</baseValue>
+                    <baseValue baseType="point">7 49</baseValue>
+                </multiple>
+                <baseValue baseType="string">y = x ^ 2</baseValue>
+            </customOperator>'
+        );
+
+        // --- Build Runtime Operands for PHP Runtime Model.
+        $operands = new OperandsCollection(
+            [
+                new MultipleContainer(
+                    BaseType::POINT,
+                    [
+                        new QtiPoint(0, 0),
+                        new QtiPoint(1, 1),
+                        new QtiPoint(2, 4),
+                        new QtiPoint(3, 9),
+                        new QtiPoint(4, 16),
+                        new QtiPoint(5, 25),
+                        new QtiPoint(6, 36),
+                        new QtiPoint(7, 49),
+                    ]
+                ),
+                new QtiString('y = x ^ 2'),
+            ]
+        );
+        $operator = new CountPointsThatSatisfyEquation($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertEquals(8, $result->getValue());
+    }
+
+    public function testSimpleOneWithStrings()
+    {
+        // --- Build Custom Operator PHP Expression Model.
+        $points = new Multiple(
+            new ExpressionCollection(
+                [
+                    new BaseValue(BaseType::STRING, '0 0'),
+                    new BaseValue(BaseType::STRING, '1 1'),
+                    new BaseValue(BaseType::STRING, '2 4'),
+                    new BaseValue(BaseType::STRING, '3 9'),
+                    new BaseValue(BaseType::STRING, '4 16'),
+                    new BaseValue(BaseType::STRING, '5 25'),
+                    new BaseValue(BaseType::STRING, '6 36'),
+                    new BaseValue(BaseType::STRING, '7 49'),
+                ]
+            )
+        );
+        $equation = new BaseValue(BaseType::STRING, 'x ^ 2');
+
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(
+                [
+                    $points,
+                    $equation,
+                ]
+            ),
+            '<customOperator class="qti.customOperators.math.graph.CountPointsThatSatisfyEquation">
+                <multiple>
+                    <baseValue baseType="string">0 0</baseValue>
+                    <baseValue baseType="string">1 1</baseValue>
+                    <baseValue baseType="string">2 4</baseValue>
+                    <baseValue baseType="string">3 9</baseValue>
+                    <baseValue baseType="string">4 16</baseValue>
+                    <baseValue baseType="string">5 25</baseValue>
+                    <baseValue baseType="string">6 36</baseValue>
+                    <baseValue baseType="string">7 49</baseValue>
+                </multiple>
+                <baseValue baseType="string">y = x ^ 2</baseValue>
+            </customOperator>'
+        );
+
+        // --- Build Runtime Operands for PHP Runtime Model.
+        $operands = new OperandsCollection(
+            [
+                new MultipleContainer(
+                    BaseType::STRING,
+                    [
+                        new QtiString('0 0'),
+                        new QtiString('1 1'),
+                        new QtiString('2 4'),
+                        new QtiString('3 9'),
+                        new QtiString('4 16'),
+                        new QtiString('5 25'),
+                        new QtiString('6 36'),
+                        new QtiString('7 49'),
+                    ]
+                ),
+                new QtiString('y = x ^ 2'),
+            ]
+        );
+        $operator = new CountPointsThatSatisfyEquation($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertEquals(8, $result->getValue());
+    }
+
+    public function testSimpleTwo()
+    {
+        // --- Build Custom Operator PHP Expression Model.
+        $points = new Multiple(
+            new ExpressionCollection(
+                [
+                    new BaseValue(BaseType::POINT, new QtiPoint(0, 0)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(-1, 1)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(2, 4)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(3, 9)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(4, 16)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(5, 25)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(14, 35)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(-5, 49)),
+                ]
+            )
+        );
+        $equation = new BaseValue(BaseType::STRING, 'x ^ 2');
+
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(
+                [
+                    $points,
+                    $equation,
+                ]
+            ),
+            '<customOperator class="qti.customOperators.math.graph.CountPointsThatSatisfyEquation">
+                <multiple>
+                    <baseValue baseType="point">0 0</baseValue>
+                    <baseValue baseType="point">-1 1</baseValue>
+                    <baseValue baseType="point">2 4</baseValue>
+                    <baseValue baseType="point">3 9</baseValue>
+                    <baseValue baseType="point">4 16</baseValue>
+                    <baseValue baseType="point">5 25</baseValue>
+                    <baseValue baseType="point">14 35</baseValue>
+                    <baseValue baseType="point">-5 49</baseValue>
+                </multiple>
+                <baseValue baseType="string">y = x ^ 2</baseValue>
+            </customOperator>'
+        );
+
+        // --- Build Runtime Operands for PHP Runtime Model.
+        $operands = new OperandsCollection(
+            [
+                new MultipleContainer(
+                    BaseType::POINT,
+                    [
+                        new QtiPoint(0, 0),
+                        new QtiPoint(-1, 1),
+                        new QtiPoint(2, 4),
+                        new QtiPoint(3, 9),
+                        new QtiPoint(4, 16),
+                        new QtiPoint(5, 25),
+                        new QtiPoint(14, 35),
+                        new QtiPoint(-5, 49),
+                    ]
+                ),
+                new QtiString('y = x ^ 2'),
+            ]
+        );
+        $operator = new CountPointsThatSatisfyEquation($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertEquals(6, $result->getValue());
+    }
+
+    public function testInvalidEquation()
+    {
+        // --- Build Custom Operator PHP Expression Model.
+        $points = new Multiple(
+            new ExpressionCollection(
+                [
+                    new BaseValue(BaseType::POINT, new QtiPoint(0, 0)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(-1, 1)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(2, 4)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(3, 9)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(4, 16)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(5, 25)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(14, 35)),
+                    new BaseValue(BaseType::POINT, new QtiPoint(-5, 49)),
+                ]
+            )
+        );
+        $equation = new BaseValue(BaseType::STRING, 'x ^ 2');
+
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(
+                [
+                    $points,
+                    $equation,
+                ]
+            ),
+            '<customOperator class="qti.customOperators.math.graph.CountPointsThatSatisfyEquation">
+                <multiple>
+                    <baseValue baseType="point">0 0</baseValue>
+                    <baseValue baseType="point">-1 1</baseValue>
+                    <baseValue baseType="point">2 4</baseValue>
+                    <baseValue baseType="point">3 9</baseValue>
+                    <baseValue baseType="point">4 16</baseValue>
+                    <baseValue baseType="point">5 25</baseValue>
+                    <baseValue baseType="point">14 35</baseValue>
+                    <baseValue baseType="point">-5 49</baseValue>
+                </multiple>
+                <baseValue baseType="string">y = x ^^^^^^ 4 \ vli 2</baseValue>
+            </customOperator>'
+        );
+
+        // --- Build Runtime Operands for PHP Runtime Model.
+        $operands = new OperandsCollection(
+            [
+                new MultipleContainer(
+                    BaseType::POINT,
+                    [
+                        new QtiPoint(0, 0),
+                        new QtiPoint(-1, 1),
+                        new QtiPoint(2, 4),
+                        new QtiPoint(3, 9),
+                        new QtiPoint(4, 16),
+                        new QtiPoint(5, 25),
+                        new QtiPoint(14, 35),
+                        new QtiPoint(-5, 49),
+                    ]
+                ),
+                new QtiString('y = x ^^^^^^ 4 \ vli 2'),
+            ]
+        );
+        $operator = new CountPointsThatSatisfyEquation($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertNull($result);
+    }
+
+    public function testWrongEquationType()
+    {
+        // --- Build Custom Operator PHP Expression Model.
+        $points = new Multiple(
+            new ExpressionCollection(
+                [
+                    new BaseValue(BaseType::POINT, new QtiPoint(0, 0)),
+                ]
+            )
+        );
+        $equation = new BaseValue(BaseType::INTEGER, 3);
+
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(
+                [
+                    $points,
+                    $equation,
+                ]
+            ),
+            '<customOperator class="qti.customOperators.math.graph.CountPointsThatSatisfyEquation">
+                <multiple>
+                    <baseValue baseType="point">0 0</baseValue>
+                </multiple>
+                <baseValue baseType="integer">3</baseValue>
+            </customOperator>'
+        );
+
+        // --- Build Runtime Operands for PHP Runtime Model.
+        $operands = new OperandsCollection(
+            [
+                new MultipleContainer(
+                    BaseType::POINT,
+                    [
+                        new QtiPoint(0, 0),
+                    ]
+                ),
+                new QtiInteger(3),
+            ]
+        );
+        $operator = new CountPointsThatSatisfyEquation($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertNull($result);
+    }
+
+    public function testNullEquation()
+    {
+        // --- Build Custom Operator PHP Expression Model.
+        $points = new Multiple(
+            new ExpressionCollection(
+                [
+                    new BaseValue(BaseType::POINT, new QtiPoint(0, 0)),
+                ]
+            )
+        );
+        $equation = new NullValue();
+
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(
+                [
+                    $points,
+                    $equation,
+                ]
+            ),
+            '<customOperator class="qti.customOperators.math.graph.CountPointsThatSatisfyEquation">
+                <multiple>
+                    <baseValue baseType="point">0 0</baseValue>
+                </multiple>
+                </null>
+            </customOperator>'
+        );
+
+        // --- Build Runtime Operands for PHP Runtime Model.
+        $operands = new OperandsCollection(
+            [
+                new MultipleContainer(
+                    BaseType::POINT,
+                    [
+                        new QtiPoint(0, 0),
+                    ]
+                ),
+                null,
+            ]
+        );
+        $operator = new CountPointsThatSatisfyEquation($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertNull($result);
+    }
+
+    public function testWrongPointsType()
+    {
+        // --- Build Custom Operator PHP Expression Model.
+        $points = new Multiple(
+            new ExpressionCollection(
+                [
+                    new BaseValue(BaseType::IDENTIFIER, '0 0'),
+                ]
+            )
+        );
+        $equation = new BaseValue(BaseType::STRING, 'x = y');
+
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(
+                [
+                    $points,
+                    $equation,
+                ]
+            ),
+            '<customOperator class="qti.customOperators.math.graph.CountPointsThatSatisfyEquation">
+                <multiple>
+                    <baseValue baseType="point">0 0</baseValue>
+                </multiple>
+                <baseValue baseType="string">x = y</baseValue>
+            </customOperator>'
+        );
+
+        // --- Build Runtime Operands for PHP Runtime Model.
+        $operands = new OperandsCollection(
+            [
+                new MultipleContainer(
+                    BaseType::IDENTIFIER,
+                    [
+                        new QtiIdentifier('0 0'),
+                    ]
+                ),
+                new QtiString('x = y'),
+            ]
+        );
+        $operator = new CountPointsThatSatisfyEquation($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertNull($result);
+    }
+}

--- a/test/qtismtest/runtime/expressions/operators/custom/text/StringToNumberTest.php
+++ b/test/qtismtest/runtime/expressions/operators/custom/text/StringToNumberTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtismtest\runtime\expressions\operators\custom\text;
+
+use qtism\common\enums\BaseType;
+use qtism\common\datatypes\QtiBoolean;
+use qtism\common\datatypes\QtiString;
+use qtism\data\expressions\operators\CustomOperator;
+use qtism\data\expressions\ExpressionCollection;
+use qtism\data\expressions\BaseValue;
+use qtism\runtime\expressions\operators\OperandsCollection;
+use qti\customOperators\text\StringToNumber;
+use qtismtest\QtiSmTestCase;
+ 
+/**
+ * Tests for StringToNumber custom operator.
+ */
+class StringToNumberTest extends QtiSmTestCase {
+	
+    public function testSimpleOne() {
+        $baseValue = new BaseValue(BaseType::STRING, '13,37');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.text.StringToNumber">
+                <baseValue baseType="string">13,37</baseValue>
+            </customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiString('13,37')));
+        $operator = new StringToNumber($customOperator, $operands);
+        $result = $operator->process();
+        
+        $this->assertEquals($result->getValue(), (float)1337);
+    }
+    
+    public function testSimpleTwo() {
+        $baseValue = new BaseValue(BaseType::STRING, '13.37');
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.text.StringToNumber">
+                <baseValue baseType="string">13.37</baseValue>
+            </customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiString('13.37')));
+        $operator = new StringToNumber($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertEquals(round($result->getValue(), 2), round(13.37, 2));
+    }
+    
+    public function testReturnsNull() {
+        $baseValue = new BaseValue(BaseType::BOOLEAN, false);
+        $customOperator = new CustomOperator(
+            new ExpressionCollection(array($baseValue)),
+            '<customOperator class="qti.customOperators.text.StringToNumber">
+                <baseValue baseType="boolean">false</baseValue>
+            </customOperator>'
+        );
+        $operands = new OperandsCollection(array(new QtiBoolean(false)));
+        $operator = new StringToNumber($customOperator, $operands);
+        $result = $operator->process();
+
+        $this->assertNull($result);
+    }
+}

--- a/travis-cfg.ini
+++ b/travis-cfg.ini
@@ -1,0 +1,2 @@
+xdebug.mode="coverage"
+


### PR DESCRIPTION
This PR is the counterpart of https://github.com/oat-sa/qti-sdk/pull/238.

Code for support of QTI extension for custom operators is located in lib-tao-qti. That repository is used to include the legacy branch of oat-sa/qti-sdk in Tao software. The QTI extension is therefore not available for users of the main branch of qti-sdk.

This PR moves QTI extension for custom operators from lib-tao-qti to qti-sdk in the legacy branch.