### PR TITLE
Added binary session version to store variable count as integer (over 255 variables).

### DIFF
--- a/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -607,7 +607,9 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             }
 
             // Read the number of item-specific variables involved in the session.
-            $varCount = $this->readTinyInt();
+            $varCount = $version->storesVariableCountAsInteger()
+                ? $this->readInteger()
+                : $this->readTinyInt();
 
             for ($i = 0; $i < $varCount; $i++) {
                 $isOutcome = $this->readBoolean();
@@ -675,7 +677,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
 
             // minus the 3 built-in variables
             $varCount = count($session) - 3;
-            $this->writeTinyInt($varCount);
+            $this->writeInteger($varCount);
 
             $itemOutcomes = $session->getAssessmentItem()->getOutcomeDeclarations();
             $itemResponses = $session->getAssessmentItem()->getResponseDeclarations();

--- a/qtism/runtime/storage/binary/QtiBinaryVersion.php
+++ b/qtism/runtime/storage/binary/QtiBinaryVersion.php
@@ -35,7 +35,7 @@ class QtiBinaryVersion
      *
      * @var int
      */
-    const CURRENT_VERSION = 10;
+    const CURRENT_VERSION = 11;
 
     /**
      * The QTI Sdk branch to select behaviour of the binary storage.
@@ -48,6 +48,8 @@ class QtiBinaryVersion
     /**
      * These constants make the different versions a bit more self explanatory.
      */
+    const VERSION_VARIABLE_COUNT_INTEGER = 11;
+
     const VERSION_FIRST_MASTER = 10;
 
     const VERSION_POSITION_INTEGER = 9;
@@ -125,6 +127,14 @@ class QtiBinaryVersion
     public function isCurrentVersion(): bool
     {
         return $this->version = self::CURRENT_VERSION;
+    }
+
+    /**
+     * @return bool
+     */
+    public function storesVariableCountAsInteger(): bool
+    {
+        return $this->version >= self::VERSION_VARIABLE_COUNT_INTEGER;
     }
 
     /**

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
@@ -946,7 +946,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $access->writeAssessmentItemSession($seeker, $session);
 
         $stream->rewind();
-        $version = $this->createVersionMock(2);
+        $version = $this->createVersionMock(QtiBinaryVersion::CURRENT_VERSION);
         $session = $access->readAssessmentItemSession(new SessionManager(), $seeker, $version);
         $this::assertEquals(AssessmentItemSessionState::INITIAL, $session->getState());
         $this::assertEquals(NavigationMode::LINEAR, $session->getNavigationMode());
@@ -975,7 +975,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $access->writeAssessmentItemSession($seeker, $session);
 
         $stream->rewind();
-        $version = $this->createVersionMock(2);
+        $version = $this->createVersionMock(QtiBinaryVersion::CURRENT_VERSION);
         $session = $access->readAssessmentItemSession(new SessionManager(), $seeker, $version);
         $this::assertEquals(AssessmentItemSessionState::INITIAL, $session->getState());
         $this::assertEquals(NavigationMode::LINEAR, $session->getNavigationMode());
@@ -1004,7 +1004,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $access->writeAssessmentItemSession($seeker, $session);
 
         $stream->rewind();
-        $version = $this->createVersionMock(2);
+        $version = $this->createVersionMock(QtiBinaryVersion::CURRENT_VERSION);
         $session = $access->readAssessmentItemSession(new SessionManager(), $seeker, $version);
         $this::assertEquals(AssessmentItemSessionState::INITIAL, $session->getState());
         $this::assertEquals(NavigationMode::LINEAR, $session->getNavigationMode());
@@ -1078,7 +1078,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $access->writeAssessmentItemSession($seeker, $session);
 
         $stream->rewind();
-        $version = $this->createVersionMock(2);
+        $version = $this->createVersionMock(QtiBinaryVersion::CURRENT_VERSION);
         $session = $access->readAssessmentItemSession(new SessionManager(), $seeker, $version);
 
         $this::assertTrue($session->getVariable('RESPONSE')->getCorrectResponse()->equals(new MultipleContainer(BaseType::PAIR, [new QtiPair('A', 'P')])));

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
@@ -92,6 +92,7 @@ class QtiBinaryVersionTest extends QtiSmTestCase
                 QtiBinaryVersion::VERSION_TRACK_PATH => 'storesTrackPath',
                 QtiBinaryVersion::VERSION_POSITION_INTEGER => 'storesPositionAndRouteCountAsInteger',
                 QtiBinaryVersion::VERSION_FIRST_MASTER => 'isInBothBranches',
+                QtiBinaryVersion::VERSION_VARIABLE_COUNT_INTEGER => 'storesVariableCountAsInteger',
             ]
         );
     }
@@ -127,6 +128,7 @@ class QtiBinaryVersionTest extends QtiSmTestCase
         return $this->createFeatureArray(
             [
                 QtiBinaryVersion::VERSION_FIRST_MASTER => 'isInBothBranches',
+                QtiBinaryVersion::VERSION_VARIABLE_COUNT_INTEGER => 'storesVariableCountAsInteger',
             ]
         );
     }


### PR DESCRIPTION
Count of variable declarations is stored in the test session using a short integer (0-255). This PR replaces this storage format with an integer (0-2147483647) and creates a new binary storage version, allowing the handling of test sessions with more than 255 variable declarations.

BEWARE:
All previously existing binary sessions are read correctly and subsequently written in this new format upon persistence.
BUT THERE'S NO TURNING BACK: A session stored in the new version won't be read correctly by a previous version, making the test unusable.
