### PR TITLE
Added compatibility pack for Match operator in PHP 7.*.

### DIFF
--- a/qtism/data/expressions/operators/Match.php
+++ b/qtism/data/expressions/operators/Match.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Julien Sébire <julien@taotesting.com>
+ * @license GPLv2
+ */
+
+namespace qtism\data\expressions\operators;
+
+/**
+ * This class provides backward compatibility Match operator in PHP 7.*.
+ * In PHP 8.*, match is a reserved word, the Match operator class has been
+ * renamed MacthOperator but compact tests contain generated PHP code which
+ * contains references to the Match class. This class makes sure these compact
+ * tests still run in PHP 7.*. When run on PHP 8.0, the compact tests have to
+ * be updated either by re-publishing the test or by running a script to update
+ * the generated PHP code.
+ */
+if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+    class Match extends MatchOperator
+    {
+    }
+}

--- a/test/qtismtest/data/expressions/operators/MatchTest.php
+++ b/test/qtismtest/data/expressions/operators/MatchTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace qtismtest\data\expressions\operators;
+
+use PHPUnit\Framework\TestCase;
+use qtism\data\expressions\ExpressionCollection;
+use qtism\data\expressions\operators\MatchOperator;
+
+/**
+ * This class provides test for the backward compatibility Match operator in
+ * PHP 7.*.
+ * In PHP 8.*, match is a reserved word, the Match operator class has been
+ * renamed MacthOperator but compact tests contain generated PHP code which
+ * contains references to the Match class. This class makes sure these compact
+ * tests still run in PHP 7.*. When run on PHP 8.0, the compact tests have to
+ * be updated either by re-publishing the test or by running a script to update
+ * the generated PHP code.
+ */
+class MatchTest extends TestCase
+{
+    public function testClassCreation()
+    {
+        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+            $expression = $this->createMock(ExpressionCollection::class);
+            $matchOperator = new \qtism\data\expressions\operators\Match($expression);
+            $this::assertInstanceOf(MatchOperator::class, $matchOperator);
+        } else {
+            $this::assertTrue(true);
+        }
+    }
+}


### PR DESCRIPTION
In PHP 8.*, `match` is a reserved word, the Match operator class has been renamed `MatchOperator` but former Tao compiled tests still contain generated PHP code with references to the `Match` class.

This PR makes sure these compiled tests still run in PHP 7.*.
However, when run on PHP 8.0, the older compiled tests containing usages of the `Match` class will have to be updated either by re-publishing or by running a script to update the generated PHP code.
