### PR TITLE
Added binary session version to store variable count as integer (over 255 variables).

### DIFF
--- a/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
+++ b/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
@@ -294,7 +294,7 @@ abstract class AbstractQtiBinaryStorage extends AbstractStorage
 
                 // An already instantiated session for this route item?
                 if ($access->readBoolean() === true) {
-                    $itemSession = $access->readAssessmentItemSession($this->getManager(), $seeker);
+                    $itemSession = $access->readAssessmentItemSession($this->getManager(), $seeker, $this->version);
 
                     // last-update
                     if ($access->readBoolean() === true) {

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -678,12 +678,14 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
      *
      * @param AbstractSessionManager $manager
      * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object from where 'assessmentItemRef', 'outcomeDeclaration' and 'responseDeclaration' QTI components will be pulled out.
+     * @param QtiBinaryVersion $version Version of the binary session storage
      * @return AssessmentItemSession
      * @throws QtiBinaryStreamAccessException
      */
     public function readAssessmentItemSession(
         AbstractSessionManager $manager,
-        AssessmentTestSeeker $seeker
+        AssessmentTestSeeker $seeker,
+        QtiBinaryVersion $version
     ) {
         try {
             $itemRefPosition = $this->readShort();
@@ -711,7 +713,9 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             }
 
             // Read the number of item-specific variables involved in the session.
-            $varCount = $this->readTinyInt();
+            $varCount = $version->storesVariableCountAsInteger()
+                ? $this->readInteger()
+                : $this->readTinyInt();
 
             for ($i = 0; $i < $varCount; $i++) {
                 // For each of these variables...
@@ -826,7 +830,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             // Write the session variables.
             // (minus the 3 built-in variables)
             $varCount = count($session) - 3;
-            $this->writeTinyInt($varCount);
+            $this->writeInteger($varCount);
 
             $itemOutcomes = $session->getAssessmentItem()->getOutcomeDeclarations();
             $itemResponses = $session->getAssessmentItem()->getResponseDeclarations();

--- a/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
@@ -35,7 +35,7 @@ class QtiBinaryVersion
      *
      * @var int
      */
-    const CURRENT_VERSION = 10;
+    const CURRENT_VERSION = 11;
 
     /**
      * The QTI Sdk branch to select behaviour of the binary storage.
@@ -48,6 +48,8 @@ class QtiBinaryVersion
     /**
      * These constants make the different versions a bit more self explanatory.
      */
+    const VERSION_VARIABLE_COUNT_INTEGER = 11;
+
     const VERSION_FIRST_MASTER = 10;
 
     const VERSION_POSITION_INTEGER = 9;
@@ -125,6 +127,14 @@ class QtiBinaryVersion
     public function isCurrentVersion(): bool
     {
         return $this->version = self::CURRENT_VERSION;
+    }
+
+    /**
+     * @return bool
+     */
+    public function storesVariableCountAsInteger(): bool
+    {
+        return $this->version >= self::VERSION_VARIABLE_COUNT_INTEGER;
     }
 
     /**

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
@@ -92,6 +92,7 @@ class QtiBinaryVersionTest extends QtiSmTestCase
                 QtiBinaryVersion::VERSION_TRACK_PATH => 'storesTrackPath',
                 QtiBinaryVersion::VERSION_POSITION_INTEGER => 'storesPositionAndRouteCountAsInteger',
                 QtiBinaryVersion::VERSION_FIRST_MASTER => 'isInBothBranches',
+                QtiBinaryVersion::VERSION_VARIABLE_COUNT_INTEGER => 'storesVariableCountAsInteger',
             ]
         );
     }
@@ -127,6 +128,7 @@ class QtiBinaryVersionTest extends QtiSmTestCase
         return $this->createFeatureArray(
             [
                 QtiBinaryVersion::VERSION_FIRST_MASTER => 'isInBothBranches',
+                QtiBinaryVersion::VERSION_VARIABLE_COUNT_INTEGER => 'storesVariableCountAsInteger',
             ]
         );
     }


### PR DESCRIPTION
Count of variable declarations is stored in the test session using a short integer (0-255). This PR replaces this storage format with an integer (0-2147483647) and creates a new binary storage version, allowing the handling of test sessions with more than 255 variable declarations.

BEWARE:
All previously existing binary sessions are read correctly and subsequently written in this new format upon persistence.
BUT THERE'S NO TURNING BACK: A session stored in the new version won't be read correctly by a previous version, making the test unusable.