### PR TITLE
Changed regex for QTI class producing too many steps. - Main branch

### DIFF
--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -373,7 +373,7 @@ class Format
             return false;
         }
 
-        $pattern = "/^(?:[^\s]+?(?:\x20){0,})+$/";
+        $pattern = "/^\S+(?: +\S+)*$/";
 
         return preg_match($pattern, $string) === 1;
     }

--- a/test/qtismtest/data/content/BodyElementTest.php
+++ b/test/qtismtest/data/content/BodyElementTest.php
@@ -87,6 +87,14 @@ class BodyElementTest extends QtiSmTestCase
         $span->setClass(999);
     }
 
+    public function testVeryLongClass()
+    {
+        $wrongClass = 'x-tao-upload-type-application_zip x-tao-upload-type-text_plain x-tao-upload-type-application_pdf x-tao-upload-type-image_jpeg x-tao-upload-type-image_png x-tao-upload-type-image_gif x-tao-upload-type-image_svg+xml x-tao-upload-type-audio_mpeg x-tao-upload-type-audio_x-ms-wma x-tao-upload-type-audio_x-wav x-tao-upload-type-video_mpeg x-tao-upload-type-video_mp4 x-tao-upload-type-video_quicktime x-tao-upload-type-video_x-ms-wmv x-tao-upload-type-video_x-flv x-tao-upload-type-text_csv x-tao-upload-type-application_msword x-tao-upload-type-application_vnd.ms-excel x-tao-upload-type-application_vnd.ms-powerpoint x-tao-upload-type-application_vnd.oasis.opendocument.text x-tao-upload-type-application_vnd.oasis.opendocument.spreadsheet x-tao-upload-type-text_x-c x-tao-upload-type-text_x-csrc x-tao-upload-type-text_pascal x-tao-upload-type-video_avi x-tao-upload-type-image_bmp x-tao-upload-type-text_css x-tao-upload-type-image_x-emf x-tao-upload-type-application_vnd.geogebra.file x-tao-upload-type-text_x-h x-tao-upload-type-application_winhlp x-tao-upload-type-text_html x-tao-upload-type-text_javascript x-tao-upload-type-application_vnd.ms-access x-tao-upload-type-image_vnd.ms-modi x-tao-upload-type-multipart_related x-tao-upload-type-application_base64 x-tao-upload-type-audio_x-m4a x-tao-upload-type-video_x-sgi-movie x-tao-upload-type-application_vnd.ms-project x-tao-upload-type-application_vnd.oasis.opendocument.database x-tao-upload-type-application_vnd.oasis.opendocument.presentation x-tao-upload-type-application_vnd.oasis.opendocument.text-template x-tao-upload-type-application_octet-stream x-tao-upload-type-application_vnd.rn-realmedia x-tao-upload-type-application_rtf x-tao-upload-type-application_vnd.sun.xml.writer.template x-tao-upload-type-application_x-shockwave-flash x-tao-upload-type-application_x-sibelius-score x-tao-upload-type-application_x-tar x-tao-upload-type-application_vnd.sun.xml.calc x-tao-upload-type-application_vnd.sun.xml.writer x-tao-upload-type-application_x-tex x-tao-upload-type-image_tiff x-tao-upload-type-application_vnd.visio x-tao-upload-type-application_vnd.ms-works x-tao-upload-type-image_x-wmf x-tao-upload-type-application_x-mswrite x-tao-upload-type-text_xml x-tao-upload-type-application_vnd.ms-xpsdocument x-tao-upload-type-application_x-7z-compressed x-tao-upload-type-application_x-gzip x-tao-upload-type-application_x-rar-compressed x-tao-upload-type-application_x-tar x-tao-upload-type-application_x-compress';
+        $span = new Span('', $wrongClass);
+
+        $this::assertSame($wrongClass, $span->getClass());
+    }
+
     public function testSetLabelWrongType()
     {
         $span = new Span();


### PR DESCRIPTION
QTI class validation is producing thousands of steps due to under-optimized regex, making PHP give up at one moment. Just changed the regex to a simpler one.