### PR TITLE
Added support for cardinality Record on ResponseVariable value conversion

### DIFF
--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -545,9 +545,16 @@ abstract class Variable
 
             case Cardinality::MULTIPLE:
             case Cardinality::ORDERED:
-            case Cardinality::RECORD:
                 foreach ($this->getValue() as $v) {
                     $values[] = $this->createValue($v);
+                }
+                break;
+
+            case Cardinality::RECORD:
+                foreach ($this->getValue() as $v) {
+                    if ($v !== null) {
+                        $values[] = $this->createRecordValue($v);
+                    }
                 }
                 break;
         }
@@ -557,20 +564,30 @@ abstract class Variable
 
     /**
      * @param QtiDatatype $value
+     * @param int|null $baseType
      * @return Value
      */
-    private function createValue(QtiDatatype $value): Value
+    private function createValue(QtiDatatype $value, int $baseType = null): Value
     {
         if (!$value instanceof QtiFile || !$this->isFile()) {
             $value = StorageUtils::stringToDatatype(
                 (string)$value,
-                $this->getCardinality() === Cardinality::RECORD
-                    ? $value->getBaseType()
-                    : $this->getBaseType()
+                $baseType ?? $this->getBaseType()
             );
         }
 
         return new Value($value);
+    }
+
+    /**
+     * @param QtiDatatype $value
+     * @return Value
+     */
+    private function createRecordValue(QtiDatatype $value): Value
+    {
+        $value = $this->createValue($value, $value->getBaseType());
+        $value->setPartOfRecord(true);
+        return $value;
     }
 
     /**

--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -545,6 +545,7 @@ abstract class Variable
 
             case Cardinality::MULTIPLE:
             case Cardinality::ORDERED:
+            case Cardinality::RECORD:
                 foreach ($this->getValue() as $v) {
                     $values[] = $this->createValue($v);
                 }
@@ -563,7 +564,9 @@ abstract class Variable
         if (!$value instanceof QtiFile || !$this->isFile()) {
             $value = StorageUtils::stringToDatatype(
                 (string)$value,
-                $this->getBaseType()
+                $this->getCardinality() === Cardinality::RECORD
+                    ? $value->getBaseType()
+                    : $this->getBaseType()
             );
         }
 

--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -164,7 +164,7 @@ abstract class Variable
     /**
      * Get the baseType of the Variable.
      *
-     * @return int A value from the Cardinality enumeration.
+     * @return int A value from the BaseType enumeration.
      */
     public function getBaseType()
     {
@@ -552,9 +552,9 @@ abstract class Variable
 
             case Cardinality::RECORD:
                 foreach ($this->getValue() as $v) {
-                    if ($v !== null) {
-                        $values[] = $this->createRecordValue($v);
-                    }
+                    $values[] = $v === null
+                        ? $this->createRecordNullValue()
+                        : $this->createRecordValue($v);
                 }
                 break;
         }
@@ -586,6 +586,18 @@ abstract class Variable
     private function createRecordValue(QtiDatatype $value): Value
     {
         $value = $this->createValue($value, $value->getBaseType());
+        $value->setPartOfRecord(true);
+        return $value;
+    }
+
+    /**
+     * Creates a null value to fill a gap in a record set.
+     *
+     * @return Value
+     */
+    private function createRecordNullValue(): Value
+    {
+        $value = new Value(null);
         $value->setPartOfRecord(true);
         return $value;
     }

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -224,6 +224,8 @@ class ResponseVariableTest extends QtiSmTestCase
 
     public function testGetDataModelValuesRecordCardinality(): void
     {
+        $qtiPair = new QtiPair('A', 'B');
+
         $responseVariable = new ResponseVariable(
             'MYVAR',
             Cardinality::RECORD,
@@ -233,16 +235,17 @@ class ResponseVariableTest extends QtiSmTestCase
                     'twelve' => new QtiInteger(12),
                     'foo' => new QtiString('bar'),
                     'null' => null,
-                    'pair' => new QtiPair('A', 'B'),
+                    'pair' => $qtiPair,
                 ]
             )
         );
         $values = $responseVariable->getDataModelValues();
 
-        $this::assertCount(3, $values);
-        $this::assertEquals(12, $values[0]->getValue());
-        $this::assertEquals('bar', $values[1]->getValue());
-        $this::assertEquals('A B', $values[2]->getValue());
+        $this::assertCount(4, $values);
+        $this::assertSame(12, $values[0]->getValue());
+        $this::assertSame('bar', $values[1]->getValue());
+        $this::assertNull($values[2]->getValue());
+        $this::assertTrue($qtiPair->equals($values[3]->getValue()));
     }
 
     public function testClone()

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -232,7 +232,8 @@ class ResponseVariableTest extends QtiSmTestCase
                 [
                     'twelve' => new QtiInteger(12),
                     'foo' => new QtiString('bar'),
-                    'pair' => new QtiPair('A', 'B')
+                    'null' => null,
+                    'pair' => new QtiPair('A', 'B'),
                 ]
             )
         );

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -9,14 +9,16 @@ use qtism\common\datatypes\QtiFloat;
 use qtism\common\datatypes\QtiInteger;
 use qtism\common\datatypes\QtiPair;
 use qtism\common\datatypes\QtiPoint;
+use qtism\common\datatypes\QtiString;
 use qtism\common\enums\BaseType;
 use qtism\common\enums\Cardinality;
-use qtism\runtime\common\MultipleContainer;
-use qtism\runtime\common\OrderedContainer;
-use qtism\runtime\common\ResponseVariable;
-use qtismtest\QtiSmTestCase;
 use qtism\data\state\AreaMapping;
 use qtism\data\state\Mapping;
+use qtism\runtime\common\MultipleContainer;
+use qtism\runtime\common\OrderedContainer;
+use qtism\runtime\common\RecordContainer;
+use qtism\runtime\common\ResponseVariable;
+use qtismtest\QtiSmTestCase;
 
 /**
  * Class ResponseVariableTest
@@ -218,6 +220,28 @@ class ResponseVariableTest extends QtiSmTestCase
         $this::assertCount(2, $values);
         $this::assertTrue($qtiPoint1->equals($values[0]->getValue()));
         $this::assertTrue($qtiPoint2->equals($values[1]->getValue()));
+    }
+
+    public function testGetDataModelValuesRecordCardinality(): void
+    {
+        $responseVariable = new ResponseVariable(
+            'MYVAR',
+            Cardinality::RECORD,
+            -1,
+            new RecordContainer(
+                [
+                    'twelve' => new QtiInteger(12),
+                    'foo' => new QtiString('bar'),
+                    'pair' => new QtiPair('A', 'B')
+                ]
+            )
+        );
+        $values = $responseVariable->getDataModelValues();
+
+        $this::assertCount(3, $values);
+        $this::assertEquals(12, $values[0]->getValue());
+        $this::assertEquals('bar', $values[1]->getValue());
+        $this::assertEquals('A B', $values[2]->getValue());
     }
 
     public function testClone()


### PR DESCRIPTION
Response variable now supports value retrieval for result building with cardinality `Record`.