### PR TITLE
fix: do not escape starting and ending symbols for patterns validation

### DIFF
--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -328,6 +328,8 @@ class Utils
      */
     public static function prepareXsdPatternForPcre($pattern)
     {
+        $pattern = trim($pattern, '^$');
+
         // XML schema always implicitly anchors the entire regular expression
         // because there is no carret (^) nor dollar ($) signs.
         // see http://www.regular-expressions.info/xml.html

--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -328,7 +328,7 @@ class Utils
      */
     public static function prepareXsdPatternForPcre($pattern)
     {
-        $pattern = trim($pattern, '^$');
+        $pattern = rtrim(ltrim($pattern, '^'), '$');
 
         // XML schema always implicitly anchors the entire regular expression
         // because there is no carret (^) nor dollar ($) signs.

--- a/test/qtismtest/runtime/expressions/operators/PatternMatchProcessorTest.php
+++ b/test/qtismtest/runtime/expressions/operators/PatternMatchProcessorTest.php
@@ -110,7 +110,9 @@ class PatternMatchProcessorTest extends QtiSmTestCase
             [new QtiString('string'), 'shell', false],
             [new QtiString('stringString'), '.*', true], // in xml schema 2, dot matches white-spaces
             [new QtiString('^String$'), 'String', false], // No carret nor dollar in xml schema 2
-            [new QtiString('^String$'), '^String$', true],
+            [new QtiString('String'), 'String', true],
+            [new QtiString('String'), '^String$', true],
+            [new QtiString('^String$'), '^String$', false],
             [new QtiString('Str/ing'), 'Str/ing', true],
             [new QtiString('Str^ing'), 'Str^ing', true],
             [new QtiString('99'), '\d{1,2}', true],


### PR DESCRIPTION
[TR-825](https://oat-sa.atlassian.net/browse/TR-825)

The goal of this PR is to fix the pattern control from validation constraint when starting and ending symbols are provided