### PR TITLE
Made minChoices > maxChoices valid when maxChoices is 0 in HotTextInteraction and PositionObjectInteraction.

### DIFF
--- a/src/qtism/data/content/interactions/HottextInteraction.php
+++ b/src/qtism/data/content/interactions/HottextInteraction.php
@@ -136,7 +136,7 @@ class HottextInteraction extends BlockInteraction
     public function setMinChoices($minChoices)
     {
         if (is_int($minChoices) && $minChoices > 0) {
-            if ($minChoices > $this->getMaxChoices() && $this->getMaxChoices() > 0) {
+            if ($this->maxChoices > 0 && $minChoices > $this->maxChoices) {
                 $msg = "The 'minChoices' argument must respect the limits imposed by 'maxChoices'.";
                 throw new InvalidArgumentException($msg);
             }

--- a/src/qtism/data/content/interactions/PositionObjectInteraction.php
+++ b/src/qtism/data/content/interactions/PositionObjectInteraction.php
@@ -181,7 +181,7 @@ class PositionObjectInteraction extends Interaction
     public function setMinChoices($minChoices)
     {
         if (is_int($minChoices) && $minChoices >= 0) {
-            if (($maxChoices = $this->getMaxChoices()) > 0 && $minChoices > $maxChoices) {
+            if ($this->maxChoices > 0 && $minChoices > $this->maxChoices) {
                 $msg = "The 'minChoices' argument must be less than or equal to the limits imposed by 'maxChoices'.";
                 throw new InvalidArgumentException($msg);
             }

--- a/test/qtismtest/data/content/interactions/HottextInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/HottextInteractionTest.php
@@ -59,4 +59,16 @@ class HottextInteractionTest extends QtiSmTestCase
         $hottextInteraction->setMaxChoices(1);
         $hottextInteraction->setMinChoices(2);
     }
+
+    public function testSetMinChoicesValidValueWhenMaxChoicesIsZero()
+    {
+        $div = new Div();
+        $div->setContent(new FlowCollection([new TextRun('content...')]));
+        $hottextInteraction = new HottextInteraction('RESPONSE', new BlockStaticCollection([$div]));
+
+        $hottextInteraction->setMaxChoices(0);
+        $hottextInteraction->setMinChoices(2);
+
+        $this->assertSame(2, $hottextInteraction->getMinChoices());
+    }
 }

--- a/test/qtismtest/data/content/interactions/PositionObjectInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/PositionObjectInteractionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace qtismtest\data\content\interactions;
+
+use qtism\data\content\FlowCollection;
+use qtism\data\content\interactions\PositionObjectInteraction;
+use qtism\data\content\TextRun;
+use qtism\data\content\xhtml\ObjectElement;
+use qtism\data\content\xhtml\text\Div;
+use qtismtest\QtiSmTestCase;
+
+/**
+ * Class PositionObjectInteractionTest
+ */
+class PositionObjectInteractionTest extends QtiSmTestCase
+{
+    public function testSetMinChoicesValidValueWhenMaxChoicesIsZero()
+    {
+        $div = new Div();
+        $div->setContent(new FlowCollection([new TextRun('content...')]));
+        $object = new ObjectElement('myimg.jpg', 'image/jpeg');
+        $object->setWidth(400);
+        $object->setHeight(300);
+
+        $positionObjectInteraction = new PositionObjectInteraction('RESPONSE', $object, 'my-pos');
+
+        $positionObjectInteraction->setMaxChoices(0);
+        $positionObjectInteraction->setMinChoices(2);
+
+        self::assertSame(2, $positionObjectInteraction->getMinChoices());
+    }
+}


### PR DESCRIPTION
In HottextInteraction and PositionObjectInteraction, minChoices is valid when greater than maxChoices when the latter is 0.