### PR TITLE
Merge for backport release 0.22.6

### DIFF
--- a/qtism/data/content/interactions/HottextInteraction.php
+++ b/qtism/data/content/interactions/HottextInteraction.php
@@ -135,7 +135,7 @@ class HottextInteraction extends BlockInteraction
     public function setMinChoices($minChoices)
     {
         if (is_int($minChoices) && $minChoices > 0) {
-            if ($minChoices > $this->getMaxChoices()) {
+            if ($this->maxChoices > 0 && $minChoices > $this->maxChoices) {
                 $msg = "The 'minChoices' argument must respect the limits imposed by 'maxChoices'.";
                 throw new InvalidArgumentException($msg);
             }

--- a/qtism/data/content/interactions/PositionObjectInteraction.php
+++ b/qtism/data/content/interactions/PositionObjectInteraction.php
@@ -180,7 +180,7 @@ class PositionObjectInteraction extends Interaction
     public function setMinChoices($minChoices)
     {
         if (is_int($minChoices) && ($minChoices > 0 || $minChoices === -1)) {
-            if ($minChoices > $this->getMaxChoices()) {
+            if ($this->maxChoices > 0 && $minChoices > $this->maxChoices) {
                 $msg = "The 'minChoices' argument must be less than or equal to the limits imposed by 'maxChoices'.";
                 throw new InvalidArgumentException($msg);
             }

--- a/test/qtismtest/data/content/interactions/HottextInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/HottextInteractionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace qtismtest\data\content\interactions;
+
+use qtism\data\content\BlockStaticCollection;
+use qtism\data\content\FlowCollection;
+use qtism\data\content\interactions\HottextInteraction;
+use qtism\data\content\TextRun;
+use qtism\data\content\xhtml\text\Div;
+use qtismtest\QtiSmTestCase;
+
+/**
+ * Class HottextInteractionTest
+ */
+class HottextInteractionTest extends QtiSmTestCase
+{
+    public function testSetMinChoicesValidValueWhenMaxChoicesIsZero()
+    {
+        $div = new Div();
+        $div->setContent(new FlowCollection([new TextRun('content...')]));
+        $hottextInteraction = new HottextInteraction('RESPONSE', new BlockStaticCollection([$div]));
+
+        $hottextInteraction->setMaxChoices(0);
+        $hottextInteraction->setMinChoices(2);
+
+        self::assertSame(2, $hottextInteraction->getMinChoices());
+    }
+}

--- a/test/qtismtest/data/content/interactions/PositionObjectInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/PositionObjectInteractionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace qtismtest\data\content\interactions;
+
+use qtism\data\content\FlowCollection;
+use qtism\data\content\interactions\PositionObjectInteraction;
+use qtism\data\content\TextRun;
+use qtism\data\content\xhtml\ObjectElement;
+use qtism\data\content\xhtml\text\Div;
+use qtismtest\QtiSmTestCase;
+
+/**
+ * Class PositionObjectInteractionTest
+ */
+class PositionObjectInteractionTest extends QtiSmTestCase
+{
+    public function testSetMinChoicesValidValueWhenMaxChoicesIsZero()
+    {
+        $div = new Div();
+        $div->setContent(new FlowCollection([new TextRun('content...')]));
+        $object = new ObjectElement('myimg.jpg', 'image/jpeg');
+        $object->setWidth(400);
+        $object->setHeight(300);
+
+        $positionObjectInteraction = new PositionObjectInteraction('RESPONSE', $object, 'my-pos');
+
+        $positionObjectInteraction->setMaxChoices(0);
+        $positionObjectInteraction->setMinChoices(2);
+
+        self::assertSame(2, $positionObjectInteraction->getMinChoices());
+    }
+}


### PR DESCRIPTION
Made minChoices > maxChoices valid when maxChoices is 0 in HotTextInteraction and PositionObjectInteraction.