### PR TITLE
Avoided escaping caret when used as excluding character range marker.

### DIFF
--- a/qtism/runtime/expressions/operators/Utils.php
+++ b/qtism/runtime/expressions/operators/Utils.php
@@ -233,10 +233,14 @@ class Utils
 
         for ($i = 0; $i < $len; $i++) {
             $char = mb_substr($string, $i, 1); // get a multi-byte char.
-            // Check escaping.
-            // If the amount of preceding backslashes is odd, it is escaped.
-            // If the amount of preceding backslashes is even, it is not escaped.
-            if ((in_array($char, $symbols)) && static::getPrecedingBackslashesCount($string, $i) % 2 === 0) {
+            // Check escaping the amount of preceding backslashes:
+            // - it is odd, the character is already escaped.
+            // - it is even, the character is not yet escaped.
+            // If a caret is preceded by a left bracket, don't escape it.
+            if (in_array($char, $symbols, true)
+                && static::getPrecedingBackslashesCount($string, $i) % 2 === 0
+                && ($i === 0 || $char !== '^' || $string[$i-1] !== '[')
+            ) {
                 // It is not escaped, so ecape it.
                 $returnValue .= '\\';
             }
@@ -328,8 +332,9 @@ class Utils
      */
     public static function prepareXsdPatternForPcre($pattern)
     {
-        // XML schema always implicitly anchors the entire regular expression
-        // because there is no carret (^) nor dollar ($) signs.
+        // XML schema always implicitly anchors the entire regular expression.
+        // Neither caret (^) nor dollar ($) sign have special meaning so they
+        // are considered normal characters.
         // see http://www.regular-expressions.info/xml.html
         $pattern = self::escapeSymbols($pattern, ['$', '^']);
         $pattern = self::pregAddDelimiter('^' . $pattern . '$');

--- a/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
+++ b/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
@@ -182,15 +182,14 @@ class OperatorsUtilsTest extends QtiSmTestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function escapeSymbolsProvider()
+    public function escapeSymbolsProvider(): array
     {
         return [
             ['10$ are 10$', ['$', '^'], '10\\$ are 10\\$'],
             ['$$$Jackpot$$$', '$', '\\$\\$\\$Jackpot\\$\\$\\$'],
             ['^exp$', ['$', '^'], '\\^exp\\$'],
+            ['(?:[^\s]+)$', ['$', '^'], '(?:[^\s]+)\\$'],
+            ['(?:[\s^]+)$', ['$', '^'], '(?:[\s\\^]+)\\$'],
         ];
     }
 

--- a/test/qtismtest/runtime/expressions/operators/PatternMatchProcessorTest.php
+++ b/test/qtismtest/runtime/expressions/operators/PatternMatchProcessorTest.php
@@ -99,10 +99,7 @@ class PatternMatchProcessorTest extends QtiSmTestCase
         }
     }
 
-    /**
-     * @return array
-     */
-    public function patternMatchProvider()
+    public function patternMatchProvider(): array
     {
         return [
             [new QtiString('string'), 'string', true],
@@ -111,6 +108,8 @@ class PatternMatchProcessorTest extends QtiSmTestCase
             [new QtiString('stringString'), '.*', true], // in xml schema 2, dot matches white-spaces
             [new QtiString('^String$'), 'String', false], // No carret nor dollar in xml schema 2
             [new QtiString('^String$'), '^String$', true],
+            [new QtiString('^String'), '[^String]*', false],
+            [new QtiString('aaa'), '[^String]*', true],
             [new QtiString('Str/ing'), 'Str/ing', true],
             [new QtiString('Str^ing'), 'Str^ing', true],
             [new QtiString('99'), '\d{1,2}', true],


### PR DESCRIPTION
Avoided escaping caret when used as excluding character range marker.