### PR TITLE
Fix object unmarshaller support for height and width in percent

### DIFF
--- a/qtism/common/utils/Format.php
+++ b/qtism/common/utils/Format.php
@@ -607,7 +607,7 @@ class Format
         if (is_int($length)) {
             return $length >= 0;
         } elseif (is_string($length)) {
-            return preg_match('/[0-9]+%/', $length) === 1;
+            return preg_match('/^[0-9]+%?$/', $length) === 1;
         } else {
             return false;
         }

--- a/qtism/data/content/xhtml/ObjectElement.php
+++ b/qtism/data/content/xhtml/ObjectElement.php
@@ -166,10 +166,10 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      */
     public function setWidth($width)
     {
-        if ((is_int($width) && $width === -1) || Format::isXhtmlLength($width) === true) {
+        if ((is_int($width) && $width === -1) || Format::isXhtmlLength($width)) {
             $this->width = $width;
         } else {
-            $msg = "The 'width' argument must be an integer, '" . gettype($width) . "' given.";
+            $msg = "The 'width' argument must be a valid XHTML Length, '" . $width . "' given.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -206,10 +206,10 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      */
     public function setHeight($height)
     {
-        if ((is_int($height) && $height === -1) || Format::isXhtmlLength($height) === true) {
+        if ((is_int($height) && $height === -1) || Format::isXhtmlLength($height)) {
             $this->height = $height;
         } else {
-            $msg = "The 'height' argument must be an integer, '" . gettype($height) . "' given.";
+            $msg = "The 'height' argument must be a valid XHTML Length, '" . $height . "' given.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/qtism/data/content/xhtml/ObjectElement.php
+++ b/qtism/data/content/xhtml/ObjectElement.php
@@ -70,7 +70,7 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
     /**
      * The width. -1 means no height was provided.
      *
-     * @var int
+     * @var string|int
      * @qtism-bean-property
      */
     private $width = -1;
@@ -78,7 +78,7 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
     /**
      * The height. -1 means no height was provided.
      *
-     * @var int
+     * @var string|int
      * @qtism-bean-property
      */
     private $height = -1;
@@ -161,12 +161,12 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      *
      * A negative value describes that no width is provided.
      *
-     * @param int $width A width.
+     * @param string|int $width A width.
      * @throws InvalidArgumentException
      */
     public function setWidth($width)
     {
-        if (is_int($width)) {
+        if ((is_int($width) && $width === -1) || Format::isXhtmlLength($width) === true) {
             $this->width = $width;
         } else {
             $msg = "The 'width' argument must be an integer, '" . gettype($width) . "' given.";
@@ -201,12 +201,12 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      *
      * A negative value describes that no height is provided.
      *
-     * @param int $height A height.
+     * @param string|int $height A height.
      * @throws InvalidArgumentException If $height is not an integer value.
      */
     public function setHeight($height)
     {
-        if (is_int($height)) {
+        if ((is_int($height) && $height === -1) || Format::isXhtmlLength($height) === true) {
             $this->height = $height;
         } else {
             $msg = "The 'height' argument must be an integer, '" . gettype($height) . "' given.";

--- a/qtism/data/content/xhtml/ObjectElement.php
+++ b/qtism/data/content/xhtml/ObjectElement.php
@@ -161,7 +161,7 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      *
      * A negative value describes that no width is provided.
      *
-     * @param string|int $width A width.
+     * @param mixed $width A width.
      * @throws InvalidArgumentException
      */
     public function setWidth($width)
@@ -201,7 +201,7 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      *
      * A negative value describes that no height is provided.
      *
-     * @param string|int $height A height.
+     * @param mixed $height A height.
      * @throws InvalidArgumentException If $height is not an integer value.
      */
     public function setHeight($height)

--- a/qtism/data/content/xhtml/ObjectElement.php
+++ b/qtism/data/content/xhtml/ObjectElement.php
@@ -179,7 +179,7 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      *
      * A negative value describes that no width is provided.
      *
-     * @return int A width.
+     * @return string|int A width.
      */
     public function getWidth()
     {
@@ -218,7 +218,7 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      * Get the width of the object. A negative value describes that no height is
      * provided.
      *
-     * @return int A height.
+     * @return string|int A height.
      */
     public function getHeight()
     {

--- a/qtism/data/content/xhtml/ObjectElement.php
+++ b/qtism/data/content/xhtml/ObjectElement.php
@@ -166,7 +166,7 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      */
     public function setWidth($width)
     {
-        if ((is_int($width) && $width === -1) || Format::isXhtmlLength($width)) {
+        if ($width === -1 || Format::isXhtmlLength($width)) {
             $this->width = $width;
         } else {
             $msg = "The 'width' argument must be a valid XHTML Length, '" . $width . "' given.";
@@ -206,7 +206,7 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
      */
     public function setHeight($height)
     {
-        if ((is_int($height) && $height === -1) || Format::isXhtmlLength($height)) {
+        if ($height === -1 || Format::isXhtmlLength($height)) {
             $this->height = $height;
         } else {
             $msg = "The 'height' argument must be a valid XHTML Length, '" . $height . "' given.";

--- a/qtism/data/storage/xml/marshalling/ObjectMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ObjectMarshaller.php
@@ -52,12 +52,22 @@ class ObjectMarshaller extends ContentMarshaller
             $component = new $fqClass($data, $type);
             $component->setContent(new ObjectFlowCollection($children->getArrayCopy()));
 
-            if (($width = $this->getDOMElementAttributeAs($element, 'width', 'integer')) !== null) {
-                $component->setWidth($width);
+            if (($height = self::getDOMElementAttributeAs($element, 'height', 'string')) !== null) {
+                if (stripos($height, '%') === false) {
+                    $component->setHeight(intval($height));
+                }
+                else {
+                    $component->setHeight($height);
+                }
             }
 
-            if (($height = $this->getDOMElementAttributeAs($element, 'height', 'integer')) !== null) {
-                $component->setHeight($height);
+            if (($width = self::getDOMElementAttributeAs($element, 'width', 'string')) !== null) {
+                if (stripos($width, '%') === false) {
+                    $component->setWidth(intval($width));
+                }
+                else {
+                    $component->setWidth($width);
+                }
             }
 
             if (($xmlBase = self::getXmlBase($element)) !== false) {

--- a/qtism/data/storage/xml/marshalling/ObjectMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ObjectMarshaller.php
@@ -54,22 +54,12 @@ class ObjectMarshaller extends ContentMarshaller
 
             $height = self::getDOMElementAttributeAs($element, 'height', 'string');
             if ($height !== null) {
-                if (stripos($height, '%') === false) {
-                    $component->setHeight(intval($height));
-                }
-                else {
-                    $component->setHeight($height);
-                }
+                $component->setHeight($height);
             }
 
             $width = self::getDOMElementAttributeAs($element, 'width', 'string');
             if ($width !== null) {
-                if (stripos($width, '%') === false) {
-                    $component->setWidth(intval($width));
-                }
-                else {
-                    $component->setWidth($width);
-                }
+                $component->setWidth($width);
             }
 
             if (($xmlBase = self::getXmlBase($element)) !== false) {

--- a/qtism/data/storage/xml/marshalling/ObjectMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/ObjectMarshaller.php
@@ -52,7 +52,8 @@ class ObjectMarshaller extends ContentMarshaller
             $component = new $fqClass($data, $type);
             $component->setContent(new ObjectFlowCollection($children->getArrayCopy()));
 
-            if (($height = self::getDOMElementAttributeAs($element, 'height', 'string')) !== null) {
+            $height = self::getDOMElementAttributeAs($element, 'height', 'string');
+            if ($height !== null) {
                 if (stripos($height, '%') === false) {
                     $component->setHeight(intval($height));
                 }
@@ -61,7 +62,8 @@ class ObjectMarshaller extends ContentMarshaller
                 }
             }
 
-            if (($width = self::getDOMElementAttributeAs($element, 'width', 'string')) !== null) {
+            $width = self::getDOMElementAttributeAs($element, 'width', 'string');
+            if ($width !== null) {
                 if (stripos($width, '%') === false) {
                     $component->setWidth(intval($width));
                 }

--- a/test/qtismtest/common/utils/FormatTest.php
+++ b/test/qtismtest/common/utils/FormatTest.php
@@ -472,7 +472,7 @@ class FormatTest extends QtiSmTestCase
             [new stdClass(), false],
             [-10, false],
             ['-10', false],
-            ['10', false],
+            ['10', true],
             [true, false],
             [10.0, false],
         ];

--- a/test/qtismtest/data/content/xhtml/ObjectTest.php
+++ b/test/qtismtest/data/content/xhtml/ObjectTest.php
@@ -30,7 +30,7 @@ class ObjectTest extends QtiSmTestCase
     public function testSetWidthWrongType()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The 'width' argument must be an integer, 'double' given.");
+        $this->expectExceptionMessage("The 'width' argument must be a valid XHTML Length, '999.999' given.");
 
         $object = new ObjectElement('./my-image.png', 'image/png');
         $object->setWidth(999.999);
@@ -39,7 +39,7 @@ class ObjectTest extends QtiSmTestCase
     public function testSetHeightWrongType()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The 'height' argument must be an integer, 'double' given.");
+        $this->expectExceptionMessage("The 'height' argument must be a valid XHTML Length, '999.999' given.");
 
         $object = new ObjectElement('./my-image.png', 'image/png');
         $object->setHeight(999.999);

--- a/test/qtismtest/data/storage/xml/marshalling/ObjectMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ObjectMarshallerTest.php
@@ -16,8 +16,9 @@ class ObjectMarshallerTest extends QtiSmTestCase
 {
     public function testUnmarshallSimple()
     {
+        /** @var ObjectElement $object */
         $object = $this->createComponentFromXml('
-	        <object id="flash-movie" data="http://mywebsite.com/movie.swf" type="application/x-shockwave-flash">
+	        <object id="flash-movie" data="https://mywebsite.com/movie.swf" type="application/x-shockwave-flash">
 	            <param name="movie" value="movie.swf" valuetype="REF"/>
 	            <param name="quality" value="high" valuetype="DATA"/>
 	        </object>                
@@ -25,7 +26,7 @@ class ObjectMarshallerTest extends QtiSmTestCase
 
         $this::assertInstanceOf(ObjectElement::class, $object);
         $this::assertEquals('flash-movie', $object->getId());
-        $this::assertEquals('http://mywebsite.com/movie.swf', $object->getData());
+        $this::assertEquals('https://mywebsite.com/movie.swf', $object->getData());
         $this::assertEquals('application/x-shockwave-flash', $object->getType());
 
         $objectContent = $object->getContent();
@@ -42,6 +43,9 @@ class ObjectMarshallerTest extends QtiSmTestCase
         $this::assertEquals('quality', $param2->getName());
         $this::assertEquals('high', $param2->getValue());
         $this::assertEquals(ParamType::DATA, $param2->getValueType());
+
+        $this::assertFalse($object->hasHeight());
+        $this::assertFalse($object->hasWidth());
     }
 
     public function testUnmarshallNoDataAttributeValue()
@@ -54,6 +58,32 @@ class ObjectMarshallerTest extends QtiSmTestCase
         $this::assertEquals('flash-movie', $object->getId());
         $this::assertEquals('', $object->getData());
         $this::assertEquals('application/x-shockwave-flash', $object->getType());
+    }
+
+    public function testUnmarshallWithDimensionPercentAttributesValue()
+    {
+        /** @var ObjectElement $object */
+        $object = $this->createComponentFromXml('
+	        <object id="flash-movie" width="100%" height="10%" data="" type="application/x-shockwave-flash"/>
+	    ');
+
+        $this::assertTrue($object->hasWidth());
+        $this::assertTrue($object->hasHeight());
+        $this::assertEquals('10%', $object->getHeight());
+        $this::assertEquals('100%', $object->getWidth());
+    }
+
+    public function testUnmarshallWithDimensionIntegerAttributesValue()
+    {
+        /** @var ObjectElement $object */
+        $object = $this->createComponentFromXml('
+	        <object id="flash-movie" width="1000" height="1" data="" type="application/x-shockwave-flash"/>
+	    ');
+
+        $this::assertTrue($object->hasWidth());
+        $this::assertTrue($object->hasHeight());
+        $this::assertEquals('1', $object->getHeight());
+        $this::assertEquals('1000', $object->getWidth());
     }
 
     public function testMarshallSimple()

--- a/test/qtismtest/data/storage/xml/marshalling/ObjectMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ObjectMarshallerTest.php
@@ -18,7 +18,7 @@ class ObjectMarshallerTest extends QtiSmTestCase
     {
         /** @var ObjectElement $object */
         $object = $this->createComponentFromXml('
-	        <object id="flash-movie" data="https://mywebsite.com/movie.swf" type="application/x-shockwave-flash">
+	        <object id="flash-movie" data="http://mywebsite.com/movie.swf" type="application/x-shockwave-flash">
 	            <param name="movie" value="movie.swf" valuetype="REF"/>
 	            <param name="quality" value="high" valuetype="DATA"/>
 	        </object>                
@@ -26,7 +26,7 @@ class ObjectMarshallerTest extends QtiSmTestCase
 
         $this::assertInstanceOf(ObjectElement::class, $object);
         $this::assertEquals('flash-movie', $object->getId());
-        $this::assertEquals('https://mywebsite.com/movie.swf', $object->getData());
+        $this::assertEquals('http://mywebsite.com/movie.swf', $object->getData());
         $this::assertEquals('application/x-shockwave-flash', $object->getType());
 
         $objectContent = $object->getContent();


### PR DESCRIPTION
In order to fix this: https://oat-sa.atlassian.net/browse/AUT-245

**Issue:**
When fetching an QTI xml with object with dimensions set in percent like `<object width="100%" ...`
object fulfilled with integer width equals 100 because of type conversion

**Note:** this fix implementation reasonable in terms of legacy version. To satisfy a best practices rather to avoid mixed type for width and height attributes and using -1 as default. Use nullable string instead.