### PR TITLE
Support for % sign in width and height attributes of <img> and <object> tag - Main branch

### DIFF
--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -588,7 +588,7 @@ class Format
         $given = is_string($length) || is_int($length) || is_float($length)
             ? $length
             : gettype($length);
-        throw new InvalidArgumentException(
+        throw new \InvalidArgumentException(
             sprintf(
                 'The "%s" argument must be a positive integer with optional percent sign, "%s" given.',
                 $argumentName,

--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -588,7 +588,7 @@ class Format
         $given = is_string($length) || is_int($length) || is_float($length)
             ? $length
             : gettype($length);
-        throw new \InvalidArgumentException(
+        throw new InvalidArgumentException(
             sprintf(
                 'The "%s" argument must be a positive integer with optional percent sign, "%s" given.',
                 $argumentName,
@@ -599,7 +599,7 @@ class Format
 
     public static function isAriaLevel(string $level): bool
     {
-         return is_numeric($level) && (int)$level >= 1;
+        return is_numeric($level) && (int)$level >= 1;
     }
 
     public static function isAriaIdRefs(string $ariaIdRefs): bool

--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -554,10 +554,47 @@ class Format
         }
 
         if (is_string($length)) {
-            return preg_match('/[0-9]+%/', $length) === 1;
+            return preg_match('/^[0-9]+%?$/', $length) === 1;
         }
 
         return false;
+    }
+
+    /**
+     * Sanitize length to positive integer with optional percent sign or
+     * special value for non-set length.
+     *
+     * Authorized values are:
+     * * positive integers as strings or integers
+     * * strings containing positive integer and "%" sign
+     * * null and -1 (kept for backward compatibility) for a length non set.
+     *
+     * @param mixed $length length to sanitize
+     * @param string $argumentName argument name for exception message
+     * @return string|null length as string or null if not set
+     * @throws InvalidArgumentException when the length is not valid
+     */
+    public static function sanitizeXhtmlLength($length, string $argumentName): ?string
+    {
+        // Allows -1 as former null value still existing in compiled items.
+        if ($length === null || $length === -1) {
+            return null;
+        }
+
+        if (self::isXhtmlLength($length)) {
+            return (string)$length;
+        }
+
+        $given = is_string($length) || is_int($length) || is_float($length)
+            ? $length
+            : gettype($length);
+        throw new InvalidArgumentException(
+            sprintf(
+                'The "%s" argument must be a positive integer with optional percent sign, "%s" given.',
+                $argumentName,
+                $given
+            )
+        );
     }
 
     public static function isAriaLevel(string $level): bool

--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -25,7 +25,6 @@ namespace qtism\common\utils;
 
 use DateInterval;
 use Exception;
-use InvalidArgumentException;
 use qtism\common\utils\data\CharacterMap;
 use ValueError;
 
@@ -572,7 +571,7 @@ class Format
      * @param mixed $length length to sanitize
      * @param string $argumentName argument name for exception message
      * @return string|null length as string or null if not set
-     * @throws InvalidArgumentException when the length is not valid
+     * @throws \InvalidArgumentException when the length is not valid
      */
     public static function sanitizeXhtmlLength($length, string $argumentName): ?string
     {
@@ -588,7 +587,7 @@ class Format
         $given = is_string($length) || is_int($length) || is_float($length)
             ? $length
             : gettype($length);
-        throw new InvalidArgumentException(
+        throw new \InvalidArgumentException(
             sprintf(
                 'The "%s" argument must be a positive integer with optional percent sign, "%s" given.',
                 $argumentName,

--- a/src/qtism/data/content/xhtml/Img.php
+++ b/src/qtism/data/content/xhtml/Img.php
@@ -188,11 +188,9 @@ class Img extends AtomicInline
     }
 
     /**
-     * Set the height of the image.
+     * Set the height of the image. A null value unsets height.
      *
-     * A null value means that no height is provided.
-     *
-     * @param mixed $height A height.
+     * @param mixed $height
      * @throws InvalidArgumentException when $height is not valid.
      */
     public function setHeight($height): void
@@ -200,28 +198,20 @@ class Img extends AtomicInline
         $this->height = Format::sanitizeXhtmlLength($height, 'height');
     }
 
-    /**
-     * Get the height of the image.
-     * Null means that no height is set.
-     */
     public function getHeight(): ?string
     {
         return $this->height;
     }
 
-    /**
-     * Whether a height is set.
-     */
     public function hasHeight(): bool
     {
         return $this->height !== null;
     }
 
     /**
-     * Set the width of the image.
-     * A null value means that no width is set.
+     * Set the width of the image. A null value unsets width.
      *
-     * @param mixed $width A width.
+     * @param mixed $width
      * @throws InvalidArgumentException when $width is not valid.
      */
     public function setWidth($width): void
@@ -229,18 +219,11 @@ class Img extends AtomicInline
         $this->width = Format::sanitizeXhtmlLength($width, 'width');
     }
 
-    /**
-     * Get the width of the image.
-     * Null means that no width is set.
-     */
     public function getWidth(): ?string
     {
         return $this->width;
     }
 
-    /**
-     * Whether a width is set.
-     */
     public function hasWidth(): bool
     {
         return $this->width !== null;

--- a/src/qtism/data/content/xhtml/Img.php
+++ b/src/qtism/data/content/xhtml/Img.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/content/xhtml/Img.php
+++ b/src/qtism/data/content/xhtml/Img.php
@@ -57,32 +57,28 @@ class Img extends AtomicInline
     private $longdesc = '';
 
     /**
-     * The img's height attribute. A negative (< 0) value
-     * means that no height is indicated.
+     * The image's height attribute.
      *
      * The value of this attribute can be:
+     * * a string: a percentage e.g. "10%" or a length in pixels e.g. 10
+     * * null: no height is set
      *
-     * * a string, in order to describe a percentage e.g. "10%".
-     * * an integer, in order to describe a width in pixels e.g. 10.
-     *
-     * @var int|string
+     * @var string|null
      * @qtism-bean-property
      */
-    private $height = -1;
+    private $height;
 
     /**
-     * The img's width attribute. A negative (< 0) value
-     * means that no width is indicated.
+     * The image's width attribute.
      *
      * The value of this attribute can be:
+     * * a string: a percentage e.g. "10%" or a length in pixels e.g. 10
+     * * null: no width is set
      *
-     * * a string, in order to describe a percentag e.g. "10%".
-     * * an integer, in order to describe a width in pixels e.g. 10.
-     *
-     * @var int
+     * @var string|null
      * @qtism-bean-property
      */
-    private $width = -1;
+    private $width;
 
     /**
      * Create a new Img object.
@@ -101,8 +97,6 @@ class Img extends AtomicInline
         $this->setSrc($src);
         $this->setAlt($alt);
         $this->setLongdesc('');
-        $this->setHeight(-1);
-        $this->setWidth(-1);
     }
 
     /**
@@ -194,79 +188,62 @@ class Img extends AtomicInline
     }
 
     /**
-     * Set the height attribute. A negative (< 0) value for $height means there
-     * is no height indicated.
+     * Set the height of the image.
      *
-     * @param int|string $height An integer (pixels) or a string (percentage).
-     * @throws InvalidArgumentException If $height is not a valid integer or string value.
+     * A null value means that no height is provided.
+     *
+     * @param mixed $height A height.
+     * @throws InvalidArgumentException when $height is not valid.
      */
-    public function setHeight($height)
+    public function setHeight($height): void
     {
-        if ((is_int($height) && $height === -1) || Format::isXhtmlLength($height) === true) {
-            $this->height = $height;
-        } else {
-            $msg = "The 'height' argument must be a valid XHTML length value, '" . $height . "' given.";
-            throw new InvalidArgumentException($msg);
-        }
+        $this->height = Format::sanitizeXhtmlLength($height, 'height');
     }
 
     /**
-     * Get the height attribute. A negative (< 0) value for $height means there
-     * is no height indicated.
-     *
-     * @return int A height.
+     * Get the height of the image.
+     * Null means that no height is set.
      */
-    public function getHeight()
+    public function getHeight(): ?string
     {
         return $this->height;
     }
 
     /**
-     * Whether a height attribute is defined.
-     *
-     * @return bool
+     * Whether a height is set.
      */
-    public function hasHeight()
+    public function hasHeight(): bool
     {
-        return $this->getHeight() >= 0;
+        return $this->height !== null;
     }
 
     /**
-     * Set the width attribute. A negative (< 0) value for $width means there
-     * is no width indicated.
+     * Set the width of the image.
+     * A null value means that no width is set.
      *
-     * @param int $width An integer (pixels) or a string (percentage).
-     * @throws InvalidArgumentException If $width is not an integer value.
+     * @param mixed $width A width.
+     * @throws InvalidArgumentException when $width is not valid.
      */
-    public function setWidth($width)
+    public function setWidth($width): void
     {
-        if ((is_int($width) && $width === -1) || Format::isXhtmlLength($width) === true) {
-            $this->width = $width;
-        } else {
-            $msg = "The 'width' argument must be a valid XHTML length value, '" . $width . "' given.";
-            throw new InvalidArgumentException($msg);
-        }
+        $this->width = Format::sanitizeXhtmlLength($width, 'width');
     }
 
     /**
-     * Get the width attribute. A negative (< 0) value for $width means there
-     * is no width indicated.
-     *
-     * @return int a width.
+     * Get the width of the image.
+     * Null means that no width is set.
      */
-    public function getWidth()
+    public function getWidth(): ?string
     {
         return $this->width;
     }
 
     /**
-     * Whether a width attribute is defined.
-     *
-     * @return bool
+     * Whether a width is set.
      */
-    public function hasWidth()
+    public function hasWidth(): bool
     {
-        return $this->getWidth() >= 0;
+        return $this->width !== null;
     }
 
     /**

--- a/src/qtism/data/content/xhtml/ObjectElement.php
+++ b/src/qtism/data/content/xhtml/ObjectElement.php
@@ -68,20 +68,28 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
     private $type;
 
     /**
-     * The width. -1 means no height was provided.
+     * The object's width attribute.
      *
-     * @var int
+     * The value of this attribute can be:
+     * * a string: a percentage e.g. "10%" or a length in pixels e.g. 10
+     * * null: no width is set
+     *
+     * @var string|null
      * @qtism-bean-property
      */
-    private $width = -1;
+    private $width;
 
     /**
-     * The height. -1 means no height was provided.
+     * The object's height attribute.
      *
-     * @var int
+     * The value of this attribute can be:
+     * * a string: a percentage e.g. "10%" or a length in pixels e.g. 10
+     * * null: no height is set
+     *
+     * @var string|null
      * @qtism-bean-property
      */
-    private $height = -1;
+    private $height;
 
     /**
      * Create a new ObjectElement object.
@@ -99,8 +107,6 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
         parent::__construct($id, $class, $lang, $label);
         $this->setData($data);
         $this->setType($type);
-        $this->setWidth(-1);
-        $this->setHeight(-1);
         $this->setContent(new ObjectFlowCollection());
     }
 
@@ -158,79 +164,62 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
 
     /**
      * Set the width of the object.
+     * A null value means that no width is set.
      *
-     * A negative value describes that no width is provided.
-     *
-     * @param int $width A width.
-     * @throws InvalidArgumentException
+     * @param mixed $width A width.
+     * @throws InvalidArgumentException when $width is not valid.
      */
-    public function setWidth($width)
+    public function setWidth($width): void
     {
-        if (is_int($width)) {
-            $this->width = $width;
-        } else {
-            $msg = "The 'width' argument must be an integer, '" . gettype($width) . "' given.";
-            throw new InvalidArgumentException($msg);
-        }
+        $this->width = Format::sanitizeXhtmlLength($width, 'width');
     }
 
     /**
      * Get the width of the object.
-     *
-     * A negative value describes that no width is provided.
-     *
-     * @return int A width.
+     * Null means that no width is set.
      */
-    public function getWidth()
+    public function getWidth(): ?string
     {
         return $this->width;
     }
 
     /**
-     * Whether a width is defined for the object.
+     * Whether a width is set for the object.
      *
      * @return bool.
      */
-    public function hasWidth()
+    public function hasWidth(): bool
     {
-        return $this->width >= 0;
+        return $this->width !== null;
     }
 
     /**
      * Set the height of the object.
+     * A null value means that no height is set.
      *
-     * A negative value describes that no height is provided.
-     *
-     * @param int $height A height.
-     * @throws InvalidArgumentException If $height is not an integer value.
+     * @param mixed $height A height.
+     * @throws InvalidArgumentException when $height is not valid.
      */
-    public function setHeight($height)
+    public function setHeight($height): void
     {
-        if (is_int($height)) {
-            $this->height = $height;
-        } else {
-            $msg = "The 'height' argument must be an integer, '" . gettype($height) . "' given.";
-            throw new InvalidArgumentException($msg);
-        }
+        $this->height = Format::sanitizeXhtmlLength($height, 'height');
     }
 
     /**
-     * Get the width of the object. A negative value describes that no height is
-     * provided.
-     *
-     * @return int A height.
+     * Get the height of the object.
+     * A null value means that no height is set.
      */
-    public function getHeight()
+    public function getHeight(): ?string
     {
         return $this->height;
     }
 
     /**
-     * Whether the object has a height.
+     * Whether a height is set for the object.
      */
-    public function hasHeight()
+    public function hasHeight(): bool
     {
-        return $this->height >= 0;
+        return $this->height !== null;
     }
 
     /**

--- a/src/qtism/data/content/xhtml/ObjectElement.php
+++ b/src/qtism/data/content/xhtml/ObjectElement.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/content/xhtml/ObjectElement.php
+++ b/src/qtism/data/content/xhtml/ObjectElement.php
@@ -163,10 +163,9 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
     }
 
     /**
-     * Set the width of the object.
-     * A null value means that no width is set.
+     * Set the width of the object. A null value unsets width.
      *
-     * @param mixed $width A width.
+     * @param mixed $width
      * @throws InvalidArgumentException when $width is not valid.
      */
     public function setWidth($width): void
@@ -174,30 +173,20 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
         $this->width = Format::sanitizeXhtmlLength($width, 'width');
     }
 
-    /**
-     * Get the width of the object.
-     * Null means that no width is set.
-     */
     public function getWidth(): ?string
     {
         return $this->width;
     }
 
-    /**
-     * Whether a width is set for the object.
-     *
-     * @return bool.
-     */
     public function hasWidth(): bool
     {
         return $this->width !== null;
     }
 
     /**
-     * Set the height of the object.
-     * A null value means that no height is set.
+     * Set the height of the object. A null value unsets height.
      *
-     * @param mixed $height A height.
+     * @param mixed $height
      * @throws InvalidArgumentException when $height is not valid.
      */
     public function setHeight($height): void
@@ -205,18 +194,11 @@ class ObjectElement extends BodyElement implements FlowStatic, InlineStatic
         $this->height = Format::sanitizeXhtmlLength($height, 'height');
     }
 
-    /**
-     * Get the height of the object.
-     * A null value means that no height is set.
-     */
     public function getHeight(): ?string
     {
         return $this->height;
     }
 
-    /**
-     * Whether a height is set for the object.
-     */
     public function hasHeight(): bool
     {
         return $this->height !== null;

--- a/src/qtism/data/storage/xml/marshalling/ImgMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ImgMarshaller.php
@@ -40,24 +40,25 @@ class ImgMarshaller extends Marshaller
      */
     protected function marshall(QtiComponent $component)
     {
+        /** @var Img $component */
         $element = $this->createElement($component);
 
         $this->setDOMElementAttribute($element, 'src', $component->getSrc());
         $this->setDOMElementAttribute($element, 'alt', $component->getAlt());
 
-        if ($component->hasWidth() === true) {
+        if ($component->hasWidth()) {
             $this->setDOMElementAttribute($element, 'width', $component->getWidth());
         }
 
-        if ($component->hasHeight() === true) {
+        if ($component->hasHeight()) {
             $this->setDOMElementAttribute($element, 'height', $component->getHeight());
         }
 
-        if ($component->hasLongdesc() === true) {
+        if ($component->hasLongdesc()) {
             $this->setDOMElementAttribute($element, 'longdesc', $component->getLongdesc());
         }
 
-        if ($component->hasXmlBase() === true) {
+        if ($component->hasXmlBase()) {
             self::setXmlBase($element, $component->getXmlBase());
         }
 
@@ -75,46 +76,34 @@ class ImgMarshaller extends Marshaller
      */
     protected function unmarshall(DOMElement $element)
     {
-        if (($src = $this->getDOMElementAttributeAs($element, 'src')) !== null) {
-            if (($alt = $this->getDOMElementAttributeAs($element, 'alt')) === null) {
-                // The XSD does not force the 'alt' attribute to be non-empty,
-                // thus we consider the 'alt' attribute value as an empty string ('').
-                $alt = '';
-            }
-
-            $component = new Img($src, $alt);
-
-            if (($longdesc = $this->getDOMElementAttributeAs($element, 'longdesc')) !== null) {
-                $component->setLongdesc($longdesc);
-            }
-
-            if (($height = $this->getDOMElementAttributeAs($element, 'height', 'string')) !== null) {
-                if (stripos($height, '%') === false) {
-                    $component->setHeight((int)$height);
-                } else {
-                    $component->setHeight($height);
-                }
-            }
-
-            if (($width = $this->getDOMElementAttributeAs($element, 'width', 'string')) !== null) {
-                if (stripos($width, '%') === false) {
-                    $component->setWidth((int)$width);
-                } else {
-                    $component->setWidth($width);
-                }
-            }
-
-            if (($xmlBase = self::getXmlBase($element)) !== false) {
-                $component->setXmlBase($xmlBase);
-            }
-
-            $this->fillBodyElement($component, $element);
-
-            return $component;
-        } else {
+        $src = $this->getDOMElementAttributeAs($element, 'src');
+        if ($src === null) {
             $msg = "The 'mandatory' attribute 'src' is missing from element 'img'.";
             throw new UnmarshallingException($msg, $element);
         }
+
+        // The XSD does not force the 'alt' attribute to be non-empty,
+        // thus we consider the 'alt' attribute value as an empty string ('').
+        $alt = $this->getDOMElementAttributeAs($element, 'alt') ?? '';
+
+        $component = new Img($src, $alt);
+
+        $longDesc = $this->getDOMElementAttributeAs($element, 'longdesc');
+        if ($longDesc !== null) {
+            $component->setLongdesc($longDesc);
+        }
+
+        $component->setHeight($this->getDOMElementAttributeAs($element, 'height'));
+        $component->setWidth($this->getDOMElementAttributeAs($element, 'width'));
+
+        $xmlBase = self::getXmlBase($element);
+        if ($xmlBase !== false) {
+            $component->setXmlBase($xmlBase);
+        }
+
+        $this->fillBodyElement($component, $element);
+
+        return $component;
     }
 
     /**

--- a/test/qtismtest/common/utils/FormatTest.php
+++ b/test/qtismtest/common/utils/FormatTest.php
@@ -487,15 +487,37 @@ class FormatTest extends QtiSmTestCase
             [0, true],
             [1, true],
             [100, true],
+            ['', false],
+            ['0', true],
+            ['1', true],
+            ['100', true],
             ['100%', true],
             ['1%', true],
             ['0%', true],
+            ['0.5%', false],
             [new stdClass(), false],
+            [
+                new class() {
+                    public function __toString(): string
+                    {
+                        return '10';
+                    }
+                },
+                false,
+            ],
+            [-1, false],
+            [null, false],
             [-10, false],
             ['-10', false],
-            ['10', false],
+            ['10', true],
+            ['10.0', false],
+            ['10.01', false],
+            ['-10.0', false],
             [true, false],
             [10.0, false],
+            [10.01, false],
+            [-10.0, false],
+            [-10.01, false],
         ];
     }
 

--- a/test/qtismtest/data/content/xhtml/ImgTest.php
+++ b/test/qtismtest/data/content/xhtml/ImgTest.php
@@ -19,21 +19,85 @@ class ImgTest extends QtiSmTestCase
         new Img('999.png', 999);
     }
 
-    public function testSetHeightWrongFormat()
+    /**
+     * @dataProvider lengthsToTest
+     * @param mixed $width
+     * @param string|null $expected
+     */
+    public function testSetWidth($width, ?string $expected): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The 'height' argument must be a valid XHTML length value, '999xp' given.");
-
-        $img = new Img('999.png', '999');
-        $img->setHeight('999xp');
+        $object = new Img('999.png', '999');
+        $object->setWidth($width);
+        self::assertEquals($expected, $object->getWidth());
     }
 
-    public function testSetWidthWrongFormat()
+    /**
+     * @dataProvider lengthsToTest
+     * @param mixed $height
+     * @param string|null $expected
+     */
+    public function testSetHeight($height, ?string $expected): void
+    {
+        $object = new Img('999.png', '999');
+        $object->setHeight($height);
+        self::assertEquals($expected, $object->getHeight());
+    }
+
+    public function lengthsToTest(): array
+    {
+        return [
+            ['10%', '10%'],
+            [10, '10'],
+            ['10', '10'],
+            [null, null],
+            [-1, null],
+        ];
+    }
+
+    /**
+     * @dataProvider wrongLengthsToTest
+     * @param mixed $height
+     * @param string|null $message
+     */
+    public function testSetHeightWrongFormat($height, string $message = null): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The 'width' argument must be a valid XHTML length value, '999xp' given.");
+        $this->expectExceptionMessage('The "height" argument must be a positive integer with optional percent sign, "' . $message ?? $height . '" given.');
 
         $img = new Img('999.png', '999');
-        $img->setWidth('999xp');
+        $img->setHeight($height);
+    }
+
+    /**
+     * @dataProvider wrongLengthsToTest
+     * @param mixed $width
+     * @param string|null $message
+     */
+    public function testSetWidthWrongFormat($width, string $message = null): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "width" argument must be a positive integer with optional percent sign, "' . $message ?? $width . '" given.');
+
+        $img = new Img('999.png', '999');
+        $img->setWidth($width);
+    }
+
+    public function wrongLengthsToTest(): array
+    {
+        return [
+            [999.999],
+            [-10],
+            ['10px'],
+            [[], 'array'],
+            [
+                new class() {
+                    public function __toString(): string
+                    {
+                        return '10%';
+                    }
+                },
+                'object',
+            ],
+        ];
     }
 }

--- a/test/qtismtest/data/content/xhtml/ObjectTest.php
+++ b/test/qtismtest/data/content/xhtml/ObjectTest.php
@@ -19,21 +19,85 @@ class ObjectTest extends QtiSmTestCase
         new ObjectElement('./my-image.png', 999);
     }
 
-    public function testSetWidthWrongType()
+    /**
+     * @dataProvider lengthsToTest
+     * @param mixed $width
+     * @param string|null $expected
+     */
+    public function testSetWidth($width, ?string $expected): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The 'width' argument must be an integer, 'double' given.");
-
         $object = new ObjectElement('./my-image.png', 'image/png');
-        $object->setWidth(999.999);
+        $object->setWidth($width);
+        self::assertEquals($expected, $object->getWidth());
     }
 
-    public function testSetHeightWrongType()
+    /**
+     * @dataProvider lengthsToTest
+     * @param mixed $height
+     * @param string|null $expected
+     */
+    public function testSetHeight($height, ?string $expected): void
+    {
+        $object = new ObjectElement('./my-image.png', 'image/png');
+        $object->setHeight($height);
+        self::assertEquals($expected, $object->getHeight());
+    }
+
+    public function lengthsToTest(): array
+    {
+        return [
+            ['10%', '10%'],
+            [10, '10'],
+            ['10', '10'],
+            [null, null],
+            [-1, null],
+        ];
+    }
+
+    /**
+     * @dataProvider wrongLengthsToTest
+     * @param mixed $width
+     * @param string|null $message
+     */
+    public function testSetWidthWrongType($width, string $message = null): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The 'height' argument must be an integer, 'double' given.");
+        $this->expectExceptionMessage('The "width" argument must be a positive integer with optional percent sign, "' . $message ?? $width . '" given.');
 
         $object = new ObjectElement('./my-image.png', 'image/png');
-        $object->setHeight(999.999);
+        $object->setWidth($width);
+    }
+
+    /**
+     * @dataProvider wrongLengthsToTest
+     * @param mixed $height
+     * @param string|null $message
+     */
+    public function testSetHeightWrongType($height, string $message = null): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "height" argument must be a positive integer with optional percent sign, "' . $message ?? $height . '" given.');
+
+        $object = new ObjectElement('./my-image.png', 'image/png');
+        $object->setHeight($height);
+    }
+
+    public function wrongLengthsToTest(): array
+    {
+        return [
+            [999.999],
+            [-10],
+            ['10px'],
+            [[], 'array'],
+            [
+                new class() {
+                    public function __toString(): string
+                    {
+                        return '10%';
+                    }
+                },
+                'object',
+            ],
+        ];
     }
 }

--- a/test/qtismtest/data/storage/php/PhpDocumentTest.php
+++ b/test/qtismtest/data/storage/php/PhpDocumentTest.php
@@ -311,6 +311,7 @@ class PhpDocumentTest extends QtiSmTestCase
             [self::samplesDir() . 'rendering/choiceinteraction_1.xml', ItemBody::class],
             [self::samplesDir() . 'rendering/choiceinteraction_2.xml', ItemBody::class],
             [self::samplesDir() . 'rendering/drawinginteraction_1.xml', ItemBody::class],
+            [self::samplesDir() . 'rendering/drawinginteraction_2.xml', ItemBody::class],
             [self::samplesDir() . 'rendering/endattemptinteraction_1.xml', ItemBody::class],
             [self::samplesDir() . 'rendering/extendedtextinteraction_1.xml', ItemBody::class],
             [self::samplesDir() . 'rendering/gapmatchinteraction_1.xml', ItemBody::class],

--- a/test/qtismtest/data/storage/xml/marshalling/ImgMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ImgMarshallerTest.php
@@ -38,7 +38,7 @@ class ImgMarshallerTest extends QtiSmTestCase
         $img = new Img('my/image.png', 'An Image...', 'my-img');
         $img->setClass('beautiful');
         $img->setHeight('40%');
-        $img->setWidth(30);
+        $img->setWidth('30');
         $img->setLang('en-YO');
         $img->setLongdesc('A Long Description...');
         $img->setXmlBase('/home/jerome');
@@ -120,7 +120,7 @@ class ImgMarshallerTest extends QtiSmTestCase
         $this::assertInstanceOf(Img::class, $img);
         $this::assertEquals('my/image.png', $img->getSrc());
         $this::assertEquals('An Image...', $img->getAlt());
-        $this::assertSame(30, $img->getWidth());
+        $this::assertSame('30', $img->getWidth());
         $this::assertEquals('40%', $img->getHeight());
         $this::assertEquals('A Long Description...', $img->getLongDesc());
         $this::assertEquals('my-img', $img->getId());

--- a/test/qtismtest/data/storage/xml/marshalling/MediaInteractionMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/MediaInteractionMarshallerTest.php
@@ -19,8 +19,8 @@ class MediaInteractionMarshallerTest extends QtiSmTestCase
     public function testMarshall()
     {
         $object = new ObjectElement('my-video.mp4', 'video/mp4');
-        $object->setWidth(400);
-        $object->setHeight(300);
+        $object->setWidth('400');
+        $object->setHeight('300');
 
         $mediaInteraction = new MediaInteraction('RESPONSE', false, $object, 'my-media');
         $mediaInteraction->setMinPlays(1);

--- a/test/qtismtest/data/storage/xml/marshalling/ObjectMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ObjectMarshallerTest.php
@@ -16,6 +16,7 @@ class ObjectMarshallerTest extends QtiSmTestCase
 {
     public function testUnmarshallSimple()
     {
+        /** @var ObjectElement $object */
         $object = $this->createComponentFromXml('
 	        <object id="flash-movie" data="http://mywebsite.com/movie.swf" type="application/x-shockwave-flash">
 	            <param name="movie" value="movie.swf" valuetype="REF"/>
@@ -42,6 +43,9 @@ class ObjectMarshallerTest extends QtiSmTestCase
         $this::assertEquals('quality', $param2->getName());
         $this::assertEquals('high', $param2->getValue());
         $this::assertEquals(ParamType::DATA, $param2->getValueType());
+
+        $this::assertFalse($object->hasHeight());
+        $this::assertFalse($object->hasWidth());
     }
 
     public function testUnmarshallNoDataAttributeValue()
@@ -54,6 +58,32 @@ class ObjectMarshallerTest extends QtiSmTestCase
         $this::assertEquals('flash-movie', $object->getId());
         $this::assertEquals('', $object->getData());
         $this::assertEquals('application/x-shockwave-flash', $object->getType());
+    }
+
+    public function testUnmarshallWithDimensionPercentAttributesValue()
+    {
+        /** @var ObjectElement $object */
+        $object = $this->createComponentFromXml('
+	        <object id="flash-movie" width="100%" height="10%" data="" type="application/x-shockwave-flash"/>
+	    ');
+
+        $this::assertTrue($object->hasWidth());
+        $this::assertTrue($object->hasHeight());
+        $this::assertEquals('10%', $object->getHeight());
+        $this::assertEquals('100%', $object->getWidth());
+    }
+
+    public function testUnmarshallWithDimensionIntegerAttributesValue()
+    {
+        /** @var ObjectElement $object */
+        $object = $this->createComponentFromXml('
+	        <object id="flash-movie" width="1000" height="1" data="" type="application/x-shockwave-flash"/>
+	    ');
+
+        $this::assertTrue($object->hasWidth());
+        $this::assertTrue($object->hasHeight());
+        $this::assertEquals('1', $object->getHeight());
+        $this::assertEquals('1000', $object->getWidth());
     }
 
     public function testMarshallSimple()

--- a/test/qtismtest/data/storage/xml/marshalling/PositionObjectInteractionMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/PositionObjectInteractionMarshallerTest.php
@@ -20,8 +20,8 @@ class PositionObjectInteractionMarshallerTest extends QtiSmTestCase
     public function testMarshall21()
     {
         $object = new ObjectElement('myimg.jpg', 'image/jpeg');
-        $object->setWidth(400);
-        $object->setHeight(300);
+        $object->setWidth('400');
+        $object->setHeight('300');
 
         $prompt = new Prompt();
         $prompt->setContent(new FlowStaticCollection([new TextRun('Prompt...')]));

--- a/test/qtismtest/data/storage/xml/marshalling/PositionObjectStageMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/PositionObjectStageMarshallerTest.php
@@ -18,8 +18,8 @@ class PositionObjectStageMarshallerTest extends QtiSmTestCase
     public function testMarshall()
     {
         $interactionObject = new ObjectElement('airplane.jpg', 'image/jpeg');
-        $interactionObject->setHeight(16);
-        $interactionObject->setWidth(16);
+        $interactionObject->setHeight('16');
+        $interactionObject->setWidth('16');
 
         $interaction = new PositionObjectInteraction('RESPONSE', $interactionObject);
         $interaction->setCenterPoint(new QtiPoint(8, 8));

--- a/test/samples/rendering/drawinginteraction_2.xml
+++ b/test/samples/rendering/drawinginteraction_2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<itemBody xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd">
+	<p>
+		Read the following description of Giovanni's house and then colour the picture accordingly.
+	</p>
+	<drawingInteraction responseIdentifier="RESPONSE">
+		<prompt xml:lang="it">Il tetto è rosso e i muri sono gialli.</prompt>
+		<object type="image/png" data="images/house.png" width="100%" height="100%"/>
+	</drawingInteraction>
+</itemBody>


### PR DESCRIPTION
This PR fixes support for `%` sign in height and width attributes of `<object>` and `<img>` QTI/HTML elements.