### PR TITLE
fix: allow class names with spaces for body element marshalling

### DIFF
--- a/src/qtism/data/content/BodyElement.php
+++ b/src/qtism/data/content/BodyElement.php
@@ -229,9 +229,8 @@ abstract class BodyElement extends QtiComponent
 
             if (empty($class) || Format::isClass($class) === true) {
                 $this->class = $class;
+                return;
             }
-            
-            return;
         }
 
         $msg = "The 'class' argument must be a valid class name, '" . $class . "' given";

--- a/src/qtism/data/content/BodyElement.php
+++ b/src/qtism/data/content/BodyElement.php
@@ -224,18 +224,19 @@ abstract class BodyElement extends QtiComponent
      */
     public function setClass($class = '')
     {
-        if (is_string($class)) {
-            $class = trim($class);
-
-            if (empty($class) || Format::isClass($class) === true) {
-                $this->class = $class;
-                return;
-            }
+        if (!is_string($class)) {
+            $msg = 'The "class" argument must be a valid class name, "' . gettype($class) . '" given';
+            throw new InvalidArgumentException($msg);
         }
 
-        $msg = "The 'class' argument must be a valid class name, '" . $class . "' given";
-        throw new InvalidArgumentException($msg);
+        $class = trim($class);
 
+        if ($class !== '' && !Format::isClass($class)) {
+            $msg = 'The "class" argument must be a valid class name, "' . $class . '" given';
+            throw new InvalidArgumentException($msg);
+        }
+
+        $this->class = $class;
     }
 
     /**

--- a/src/qtism/data/content/BodyElement.php
+++ b/src/qtism/data/content/BodyElement.php
@@ -224,13 +224,19 @@ abstract class BodyElement extends QtiComponent
      */
     public function setClass($class = '')
     {
-        if (is_string($class) && (empty($class) || Format::isClass($class) === true)) {
+        if (is_string($class)) {
             $class = trim($class);
-            $this->class = $class;
-        } else {
-            $msg = "The 'class' argument must be a valid class name, '" . $class . "' given";
-            throw new InvalidArgumentException($msg);
+
+            if (empty($class) || Format::isClass($class) === true) {
+                $this->class = $class;
+            }
+            
+            return;
         }
+
+        $msg = "The 'class' argument must be a valid class name, '" . $class . "' given";
+        throw new InvalidArgumentException($msg);
+
     }
 
     /**

--- a/test/qtismtest/data/content/BodyElementTest.php
+++ b/test/qtismtest/data/content/BodyElementTest.php
@@ -87,6 +87,14 @@ class BodyElementTest extends QtiSmTestCase
         $span->setClass(999);
     }
 
+    public function testClassRightTypeWithSpace()
+    {
+        $span = new Span();
+        $span->setClass('custom-text-box ');
+
+        $this::assertSame('custom-text-box', $span->getClass());
+    }
+
     public function testVeryLongClass()
     {
         $wrongClass = 'x-tao-upload-type-application_zip x-tao-upload-type-text_plain x-tao-upload-type-application_pdf x-tao-upload-type-image_jpeg x-tao-upload-type-image_png x-tao-upload-type-image_gif x-tao-upload-type-image_svg+xml x-tao-upload-type-audio_mpeg x-tao-upload-type-audio_x-ms-wma x-tao-upload-type-audio_x-wav x-tao-upload-type-video_mpeg x-tao-upload-type-video_mp4 x-tao-upload-type-video_quicktime x-tao-upload-type-video_x-ms-wmv x-tao-upload-type-video_x-flv x-tao-upload-type-text_csv x-tao-upload-type-application_msword x-tao-upload-type-application_vnd.ms-excel x-tao-upload-type-application_vnd.ms-powerpoint x-tao-upload-type-application_vnd.oasis.opendocument.text x-tao-upload-type-application_vnd.oasis.opendocument.spreadsheet x-tao-upload-type-text_x-c x-tao-upload-type-text_x-csrc x-tao-upload-type-text_pascal x-tao-upload-type-video_avi x-tao-upload-type-image_bmp x-tao-upload-type-text_css x-tao-upload-type-image_x-emf x-tao-upload-type-application_vnd.geogebra.file x-tao-upload-type-text_x-h x-tao-upload-type-application_winhlp x-tao-upload-type-text_html x-tao-upload-type-text_javascript x-tao-upload-type-application_vnd.ms-access x-tao-upload-type-image_vnd.ms-modi x-tao-upload-type-multipart_related x-tao-upload-type-application_base64 x-tao-upload-type-audio_x-m4a x-tao-upload-type-video_x-sgi-movie x-tao-upload-type-application_vnd.ms-project x-tao-upload-type-application_vnd.oasis.opendocument.database x-tao-upload-type-application_vnd.oasis.opendocument.presentation x-tao-upload-type-application_vnd.oasis.opendocument.text-template x-tao-upload-type-application_octet-stream x-tao-upload-type-application_vnd.rn-realmedia x-tao-upload-type-application_rtf x-tao-upload-type-application_vnd.sun.xml.writer.template x-tao-upload-type-application_x-shockwave-flash x-tao-upload-type-application_x-sibelius-score x-tao-upload-type-application_x-tar x-tao-upload-type-application_vnd.sun.xml.calc x-tao-upload-type-application_vnd.sun.xml.writer x-tao-upload-type-application_x-tex x-tao-upload-type-image_tiff x-tao-upload-type-application_vnd.visio x-tao-upload-type-application_vnd.ms-works x-tao-upload-type-image_x-wmf x-tao-upload-type-application_x-mswrite x-tao-upload-type-text_xml x-tao-upload-type-application_vnd.ms-xpsdocument x-tao-upload-type-application_x-7z-compressed x-tao-upload-type-application_x-gzip x-tao-upload-type-application_x-rar-compressed x-tao-upload-type-application_x-tar x-tao-upload-type-application_x-compress';

--- a/test/qtismtest/data/content/BodyElementTest.php
+++ b/test/qtismtest/data/content/BodyElementTest.php
@@ -77,30 +77,53 @@ class BodyElementTest extends QtiSmTestCase
         $span->setId(999);
     }
 
-    public function testClassWrongType()
+    /**
+     * @dataProvider wrongClassesToTest
+     * @param mixed $class the class to set
+     * @param string|null $message the expected message or null if identical to $class to set
+     */
+    public function testSetClassWithWrongClass($class, string $message = null)
     {
         $span = new Span();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The 'class' argument must be a valid class name, '999' given");
+        $this->expectExceptionMessage('The "class" argument must be a valid class name, "' . $message ?? $class . '" given');
 
-        $span->setClass(999);
+        $span->setClass($class);
     }
 
-    public function testClassRightTypeWithSpace()
+    public function wrongClassesToTest(): array
     {
-        $span = new Span();
-        $span->setClass('custom-text-box ');
-
-        $this::assertSame('custom-text-box', $span->getClass());
+        return [
+            [999, 'integer'],
+            [[999], 'array'],
+            ["a\tb"],
+            ["  a\tb  "],
+        ];
     }
 
-    public function testVeryLongClass()
+    /**
+     * @dataProvider rightClassesToTest
+     * @param mixed $class
+     */
+    public function testSetClassWithRightClass($class): void
     {
-        $wrongClass = 'x-tao-upload-type-application_zip x-tao-upload-type-text_plain x-tao-upload-type-application_pdf x-tao-upload-type-image_jpeg x-tao-upload-type-image_png x-tao-upload-type-image_gif x-tao-upload-type-image_svg+xml x-tao-upload-type-audio_mpeg x-tao-upload-type-audio_x-ms-wma x-tao-upload-type-audio_x-wav x-tao-upload-type-video_mpeg x-tao-upload-type-video_mp4 x-tao-upload-type-video_quicktime x-tao-upload-type-video_x-ms-wmv x-tao-upload-type-video_x-flv x-tao-upload-type-text_csv x-tao-upload-type-application_msword x-tao-upload-type-application_vnd.ms-excel x-tao-upload-type-application_vnd.ms-powerpoint x-tao-upload-type-application_vnd.oasis.opendocument.text x-tao-upload-type-application_vnd.oasis.opendocument.spreadsheet x-tao-upload-type-text_x-c x-tao-upload-type-text_x-csrc x-tao-upload-type-text_pascal x-tao-upload-type-video_avi x-tao-upload-type-image_bmp x-tao-upload-type-text_css x-tao-upload-type-image_x-emf x-tao-upload-type-application_vnd.geogebra.file x-tao-upload-type-text_x-h x-tao-upload-type-application_winhlp x-tao-upload-type-text_html x-tao-upload-type-text_javascript x-tao-upload-type-application_vnd.ms-access x-tao-upload-type-image_vnd.ms-modi x-tao-upload-type-multipart_related x-tao-upload-type-application_base64 x-tao-upload-type-audio_x-m4a x-tao-upload-type-video_x-sgi-movie x-tao-upload-type-application_vnd.ms-project x-tao-upload-type-application_vnd.oasis.opendocument.database x-tao-upload-type-application_vnd.oasis.opendocument.presentation x-tao-upload-type-application_vnd.oasis.opendocument.text-template x-tao-upload-type-application_octet-stream x-tao-upload-type-application_vnd.rn-realmedia x-tao-upload-type-application_rtf x-tao-upload-type-application_vnd.sun.xml.writer.template x-tao-upload-type-application_x-shockwave-flash x-tao-upload-type-application_x-sibelius-score x-tao-upload-type-application_x-tar x-tao-upload-type-application_vnd.sun.xml.calc x-tao-upload-type-application_vnd.sun.xml.writer x-tao-upload-type-application_x-tex x-tao-upload-type-image_tiff x-tao-upload-type-application_vnd.visio x-tao-upload-type-application_vnd.ms-works x-tao-upload-type-image_x-wmf x-tao-upload-type-application_x-mswrite x-tao-upload-type-text_xml x-tao-upload-type-application_vnd.ms-xpsdocument x-tao-upload-type-application_x-7z-compressed x-tao-upload-type-application_x-gzip x-tao-upload-type-application_x-rar-compressed x-tao-upload-type-application_x-tar x-tao-upload-type-application_x-compress';
-        $span = new Span('', $wrongClass);
+        $span = new Span('', $class);
+        $span->setClass($class);
 
-        $this::assertSame($wrongClass, $span->getClass());
+        $this::assertSame(trim($class), $span->getClass());
+    }
+
+    public function rightClassesToTest(): array
+    {
+        return [
+            ['x-tao-upload-type-application_zip x-tao-upload-type-text_plain x-tao-upload-type-application_pdf x-tao-upload-type-image_jpeg x-tao-upload-type-image_png x-tao-upload-type-image_gif x-tao-upload-type-image_svg+xml x-tao-upload-type-audio_mpeg x-tao-upload-type-audio_x-ms-wma x-tao-upload-type-audio_x-wav x-tao-upload-type-video_mpeg x-tao-upload-type-video_mp4 x-tao-upload-type-video_quicktime x-tao-upload-type-video_x-ms-wmv x-tao-upload-type-video_x-flv x-tao-upload-type-text_csv x-tao-upload-type-application_msword x-tao-upload-type-application_vnd.ms-excel x-tao-upload-type-application_vnd.ms-powerpoint x-tao-upload-type-application_vnd.oasis.opendocument.text x-tao-upload-type-application_vnd.oasis.opendocument.spreadsheet x-tao-upload-type-text_x-c x-tao-upload-type-text_x-csrc x-tao-upload-type-text_pascal x-tao-upload-type-video_avi x-tao-upload-type-image_bmp x-tao-upload-type-text_css x-tao-upload-type-image_x-emf x-tao-upload-type-application_vnd.geogebra.file x-tao-upload-type-text_x-h x-tao-upload-type-application_winhlp x-tao-upload-type-text_html x-tao-upload-type-text_javascript x-tao-upload-type-application_vnd.ms-access x-tao-upload-type-image_vnd.ms-modi x-tao-upload-type-multipart_related x-tao-upload-type-application_base64 x-tao-upload-type-audio_x-m4a x-tao-upload-type-video_x-sgi-movie x-tao-upload-type-application_vnd.ms-project x-tao-upload-type-application_vnd.oasis.opendocument.database x-tao-upload-type-application_vnd.oasis.opendocument.presentation x-tao-upload-type-application_vnd.oasis.opendocument.text-template x-tao-upload-type-application_octet-stream x-tao-upload-type-application_vnd.rn-realmedia x-tao-upload-type-application_rtf x-tao-upload-type-application_vnd.sun.xml.writer.template x-tao-upload-type-application_x-shockwave-flash x-tao-upload-type-application_x-sibelius-score x-tao-upload-type-application_x-tar x-tao-upload-type-application_vnd.sun.xml.calc x-tao-upload-type-application_vnd.sun.xml.writer x-tao-upload-type-application_x-tex x-tao-upload-type-image_tiff x-tao-upload-type-application_vnd.visio x-tao-upload-type-application_vnd.ms-works x-tao-upload-type-image_x-wmf x-tao-upload-type-application_x-mswrite x-tao-upload-type-text_xml x-tao-upload-type-application_vnd.ms-xpsdocument x-tao-upload-type-application_x-7z-compressed x-tao-upload-type-application_x-gzip x-tao-upload-type-application_x-rar-compressed x-tao-upload-type-application_x-tar x-tao-upload-type-application_x-compress'],
+            ['custom-text-box '],
+            [''],
+            [' '],
+            // todo: check that it's intended to be that permissive. 
+            ['   e v e n   that kind of things */4231\'"("        -(&é(   '],
+        ];
     }
 
     public function testSetLabelWrongType()


### PR DESCRIPTION
[TR-1225](https://oat-sa.atlassian.net/browse/TR-1225)

The goal of this PR is to allow to set a class name of body element ending with space (trimed later)