### PR TITLE
Fix TR-1084: skip unnecessary variable instantiation

### DIFF
--- a/src/qtism/runtime/common/VariableFactory.php
+++ b/src/qtism/runtime/common/VariableFactory.php
@@ -44,7 +44,9 @@ final class VariableFactory implements VariableFactoryInterface
      */
     public function createFromDataModel(VariableDeclaration $variableDeclaration): Variable
     {
-        return [$this->createVariableClass($variableDeclaration), 'createFromDataModel']($variableDeclaration);
+        $variableClassName = $this->createVariableClassName($variableDeclaration);
+
+        return $variableClassName::createFromDataModel($variableDeclaration);
     }
 
     /**
@@ -52,7 +54,7 @@ final class VariableFactory implements VariableFactoryInterface
      * @return string|Variable A matching Variable class
      * @throws UnexpectedValueException If $variableDeclaration is not consistent.
      */
-    private function createVariableClass(VariableDeclaration $variableDeclaration): string
+    private function createVariableClassName(VariableDeclaration $variableDeclaration): string
     {
         $variableDeclarationClass = get_class($variableDeclaration);
 

--- a/src/qtism/runtime/common/VariableFactory.php
+++ b/src/qtism/runtime/common/VariableFactory.php
@@ -54,16 +54,18 @@ final class VariableFactory implements VariableFactoryInterface
      */
     private function createVariableClass(VariableDeclaration $variableDeclaration): string
     {
-        if (!isset(self::VARIABLE_DECLARATION_MAP[$variableDeclaration::class])) {
+        $variableDeclarationClass = get_class($variableDeclaration);
+
+        if (!isset(self::VARIABLE_DECLARATION_MAP[$variableDeclarationClass])) {
             throw new UnexpectedValueException(
                 sprintf(
                     '`%s` is an unexpected `%s` implementation.',
-                    $variableDeclaration::class,
+                    $variableDeclarationClass,
                     VariableDeclaration::class
                 )
             );
         }
 
-        return self::VARIABLE_DECLARATION_MAP[$variableDeclaration::class];
+        return self::VARIABLE_DECLARATION_MAP[$variableDeclarationClass];
     }
 }

--- a/src/qtism/runtime/common/VariableFactory.php
+++ b/src/qtism/runtime/common/VariableFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ * @license GPLv2
+ */
+
+declare(strict_types=1);
+
+namespace qtism\runtime\common;
+
+use qtism\data\state\OutcomeDeclaration;
+use qtism\data\state\ResponseDeclaration;
+use qtism\data\state\TemplateDeclaration;
+use qtism\data\state\VariableDeclaration;
+use UnexpectedValueException;
+
+final class VariableFactory implements VariableFactoryInterface
+{
+    private const VARIABLE_DECLARATION_MAP = [
+        TemplateDeclaration::class => TemplateVariable::class,
+        OutcomeDeclaration::class  => OutcomeVariable::class,
+        ResponseDeclaration::class => ResponseVariable::class,
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function createFromDataModel(VariableDeclaration $variableDeclaration): Variable
+    {
+        return [$this->createVariableClass($variableDeclaration), 'createFromDataModel']($variableDeclaration);
+    }
+
+    /**
+     * @param VariableDeclaration $variableDeclaration A VariableDeclaration object from the QTI Data Model.
+     * @return string|Variable A matching Variable class
+     * @throws UnexpectedValueException If $variableDeclaration is not consistent.
+     */
+    private function createVariableClass(VariableDeclaration $variableDeclaration): string
+    {
+        if (!isset(self::VARIABLE_DECLARATION_MAP[$variableDeclaration::class])) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    '`%s` is an unexpected `%s` implementation.',
+                    $variableDeclaration::class,
+                    VariableDeclaration::class
+                )
+            );
+        }
+
+        return self::VARIABLE_DECLARATION_MAP[$variableDeclaration::class];
+    }
+}

--- a/src/qtism/runtime/common/VariableFactoryInterface.php
+++ b/src/qtism/runtime/common/VariableFactoryInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ * @license GPLv2
+ */
+
+declare(strict_types=1);
+
+namespace qtism\runtime\common;
+
+use UnexpectedValueException;
+use qtism\data\state\VariableDeclaration;
+
+interface VariableFactoryInterface
+{
+    /**
+     * Create a runtime Variable object from its Data Model representation.
+     *
+     * @param VariableDeclaration $variableDeclaration A VariableDeclaration object from the QTI Data Model.
+     * @return Variable A Variable object.
+     * @throws UnexpectedValueException If $variableDeclaration is not consistent.
+     */
+    public function createFromDataModel(VariableDeclaration $variableDeclaration): Variable;
+}

--- a/src/qtism/runtime/storage/binary/LocalQtiBinaryStorage.php
+++ b/src/qtism/runtime/storage/binary/LocalQtiBinaryStorage.php
@@ -30,6 +30,7 @@ use qtism\common\storage\IStream;
 use qtism\common\storage\MemoryStream;
 use qtism\common\storage\StreamAccessException;
 use qtism\data\AssessmentTest;
+use qtism\runtime\common\VariableFactory;
 use qtism\runtime\storage\common\StorageException;
 use qtism\runtime\tests\AbstractSessionManager;
 use qtism\runtime\tests\AssessmentTestSession;
@@ -134,7 +135,7 @@ class LocalQtiBinaryStorage extends AbstractQtiBinaryStorage
      */
     protected function createBinaryStreamAccess(IStream $stream)
     {
-        return new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        return new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
     }
 
     /**

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -81,9 +81,9 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     const RW_CORRECTRESPONSE = 2;
 
     private const VARIABLE_TYPES = [
-        'outcomeDeclaration',
-        'responseDeclaration',
-        'templateDeclaration',
+        0 => 'outcomeDeclaration',
+        1 => 'responseDeclaration',
+        2 => 'templateDeclaration',
     ];
 
     /** @var FileManager */

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -81,11 +81,9 @@ use qtism\runtime\tests\RouteItem;
  */
 class QtiBinaryStreamAccess extends BinaryStreamAccess
 {
-    const RW_VALUE = 0;
-
-    const RW_DEFAULTVALUE = 1;
-
-    const RW_CORRECTRESPONSE = 2;
+    public const RW_VALUE = 0;
+    public const RW_DEFAULTVALUE = 1;
+    public const RW_CORRECTRESPONSE = 2;
 
     private const VARIABLE_TYPES = [
         0 => 'outcomeDeclaration',

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -44,14 +44,20 @@ use qtism\common\storage\BinaryStreamAccess;
 use qtism\common\storage\BinaryStreamAccessException;
 use qtism\common\storage\IStream;
 use qtism\common\storage\StreamAccessException;
+use qtism\data\AssessmentItemRef;
 use qtism\data\AssessmentSectionCollection;
+use qtism\data\IAssessmentItem;
+use qtism\data\ItemSessionControl;
 use qtism\data\rules\BranchRuleCollection;
 use qtism\data\rules\PreConditionCollection;
+use qtism\data\state\ResponseDeclaration;
 use qtism\data\state\Shuffling;
 use qtism\data\state\ShufflingCollection;
 use qtism\data\state\ShufflingGroup;
 use qtism\data\state\ShufflingGroupCollection;
+use qtism\data\state\TemplateDeclaration;
 use qtism\data\state\VariableDeclaration;
+use qtism\data\TestPart;
 use qtism\runtime\common\MultipleContainer;
 use qtism\runtime\common\OrderedContainer;
 use qtism\runtime\common\OutcomeVariable;
@@ -699,6 +705,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     ) {
         try {
             $itemRefPosition = $this->readShort();
+            /** @var IAssessmentItem $assessmentItemRef */
             $assessmentItemRef = $seeker->seekComponent('assessmentItemRef', $itemRefPosition);
 
             $session = $manager->createAssessmentItemSession($assessmentItemRef);
@@ -709,6 +716,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             $session->setAttempting($this->readBoolean());
 
             if ($this->readBoolean() === true) {
+                /** @var ItemSessionControl $itemSessionControl */
                 $itemSessionControl = $seeker->seekComponent('itemSessionControl', $this->readShort());
                 $session->setItemSessionControl($itemSessionControl);
             }
@@ -848,14 +856,17 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                 if (in_array($varId, ['numAttempts', 'duration', 'completionStatus']) === false) {
                     $var = $session->getVariable($varId);
                     if ($var instanceof OutcomeVariable) {
+                        /** @var VariableDeclaration $variableDeclaration */
                         $variableDeclaration = $itemOutcomes[$varId];
                         $variable = OutcomeVariable::createFromDataModel($variableDeclaration);
                         $varNature = 0;
                     } elseif ($var instanceof ResponseVariable) {
+                        /** @var ResponseDeclaration $variableDeclaration */
                         $variableDeclaration = $itemResponses[$varId];
                         $variable = ResponseVariable::createFromDataModel($variableDeclaration);
                         $varNature = 1;
                     } elseif ($var instanceof TemplateVariable) {
+                        /** @var TemplateDeclaration $variableDeclaration */
                         $variableDeclaration = $itemTemplates[$varId];
                         $variable = TemplateVariable::createFromDataModel($variableDeclaration);
                         $varNature = 2;
@@ -914,7 +925,9 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     {
         try {
             $occurence = $this->readTinyInt();
+            /** @var AssessmentItemRef $itemRef */
             $itemRef = $seeker->seekComponent('assessmentItemRef', $this->readShort());
+            /** @var TestPart $testPart */
             $testPart = $seeker->seekComponent('testPart', $this->readShort());
 
             $sectionsCount = $this->readTinyInt();
@@ -1011,6 +1024,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             $varCount = $this->readTinyInt();
 
             for ($i = 0; $i < $varCount; $i++) {
+                /** @var ResponseDeclaration $responseDeclaration */
                 $responseDeclaration = $seeker->seekComponent('responseDeclaration', $this->readShort());
                 $responseVariable = ResponseVariable::createFromDataModel($responseDeclaration);
                 $this->readVariableValue($responseVariable);
@@ -1018,6 +1032,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             }
 
             // Read the assessmentItemRef.
+            /** @var AssessmentItemRef $itemRef */
             $itemRef = $seeker->seekComponent('assessmentItemRef', $this->readShort());
 
             // Read the occurence number.

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -924,7 +924,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     public function readRouteItem(AssessmentTestSeeker $seeker)
     {
         try {
-            $occurence = $this->readTinyInt();
+            $occurrence = $this->readTinyInt();
             /** @var AssessmentItemRef $itemRef */
             $itemRef = $seeker->seekComponent('assessmentItemRef', $this->readShort());
             /** @var TestPart $testPart */
@@ -952,7 +952,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             }
 
             $routeItem = new RouteItem($itemRef, $sections, $testPart, $seeker->getAssessmentTest());
-            $routeItem->setOccurence($occurence);
+            $routeItem->setOccurence($occurrence);
             $routeItem->setBranchRules($branchRules);
             $routeItem->setPreConditions($preConditions);
 
@@ -1035,10 +1035,10 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             /** @var AssessmentItemRef $itemRef */
             $itemRef = $seeker->seekComponent('assessmentItemRef', $this->readShort());
 
-            // Read the occurence number.
-            $occurence = $this->readTinyInt();
+            // Read the occurrence number.
+            $occurrence = $this->readTinyInt();
 
-            return new PendingResponses($state, $itemRef, $occurence);
+            return new PendingResponses($state, $itemRef, $occurrence);
         } catch (BinaryStreamAccessException $e) {
             $msg = 'An error occurred while reading some pending responses.';
             throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::PENDING_RESPONSES, $e);
@@ -1060,7 +1060,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
         try {
             $state = $pendingResponses->getState();
             $itemRef = $pendingResponses->getAssessmentItemRef();
-            $occurence = $pendingResponses->getOccurence();
+            $occurrence = $pendingResponses->getOccurence();
 
             // Write the state.
             $responseDeclarations = $itemRef->getResponseDeclarations();
@@ -1081,8 +1081,8 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             // Write the assessmentItemRef.
             $this->writeShort($seeker->seekPosition($itemRef));
 
-            // Write the occurence number.
-            $this->writeTinyInt($occurence);
+            // Write the occurrence number.
+            $this->writeTinyInt($occurrence);
         } catch (BinaryStreamAccessException $e) {
             $msg = 'An error occurred while reading some pending responses.';
             throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::PENDING_RESPONSES, $e);

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -67,6 +67,7 @@ use qtism\runtime\common\State;
 use qtism\runtime\common\TemplateVariable;
 use qtism\runtime\common\Utils;
 use qtism\runtime\common\Variable;
+use qtism\runtime\common\VariableFactory;
 use qtism\runtime\common\VariableFactoryInterface;
 use qtism\runtime\storage\common\AssessmentTestSeeker;
 use qtism\runtime\tests\AbstractSessionManager;
@@ -105,11 +106,14 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
      * @param FileManager $fileManager The FileManager object to handle file variable.
      * @throws StreamAccessException
      */
-    public function __construct(IStream $stream, FileManager $fileManager, VariableFactoryInterface $variableFactory)
-    {
+    public function __construct(
+        IStream $stream,
+        FileManager $fileManager,
+        VariableFactoryInterface $variableFactory = null
+    ) {
         parent::__construct($stream);
         $this->setFileManager($fileManager);
-        $this->variableFactory = $variableFactory;
+        $this->variableFactory = $variableFactory ?? new VariableFactory();
     }
 
     /**

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -745,9 +745,13 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             for ($i = 0; $i < $varCount; $i++) {
                 // For each of these variables...
 
-                // Detect the nature of the variable
-                // 0 = outcomeVariable, 1 = responseVariable, 2 = templateVariable
-                $varNature = $this->readShort();
+                /**
+                 * Detect the type of the variable
+                 * @see QtiBinaryStreamAccess::VARIABLE_DECLARATION_TYPES
+                 */
+                $variableType = $this->decodeVariableDeclarationType(
+                    $this->readShort()
+                );
 
                 // Read the position of the associated variableDeclaration
                 // in the assessment tree.
@@ -755,10 +759,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
 
                 try {
                     /** @var VariableDeclaration $variableDeclaration */
-                    $variableDeclaration = $seeker->seekComponent(
-                        $this->decodeVariableDeclarationType($varNature),
-                        $varPosition
-                    );
+                    $variableDeclaration = $seeker->seekComponent($variableType, $varPosition);
                 } catch (OutOfBoundsException $e) {
                     $msg = "No variable found at position ${varPosition} in the assessmentTest tree structure.";
                     throw new QtiBinaryStreamAccessException(

--- a/test/qtismtest/runtime/common/VariableFactoryTest.php
+++ b/test/qtismtest/runtime/common/VariableFactoryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ * @license GPLv2
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\runtime\common;
+
+use UnexpectedValueException;
+use qtism\common\enums\BaseType;
+use qtism\data\state\OutcomeDeclaration;
+use qtism\data\state\ResponseDeclaration;
+use qtism\data\state\TemplateDeclaration;
+use qtism\data\state\VariableDeclaration;
+use qtism\runtime\common\OutcomeVariable;
+use qtism\runtime\common\ResponseVariable;
+use qtism\runtime\common\TemplateVariable;
+use qtism\runtime\common\Variable;
+use qtism\runtime\common\VariableFactory;
+use qtismtest\QtiSmTestCase;
+
+class VariableFactoryTest extends QtiSmTestCase
+{
+    /** @var VariableFactory */
+    private $sut;
+
+    /**
+     * @before
+     */
+    public function setUpSut(): void
+    {
+        $this->sut = new VariableFactory();
+    }
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param string|Variable $expectedVariableClass
+     * @param VariableDeclaration $variableDeclaration
+     */
+    public function testCreateFromDataModel(
+        string $expectedVariableClass,
+        VariableDeclaration $variableDeclaration
+    ): void {
+        $this->assertEquals(
+            $expectedVariableClass::createFromDataModel($variableDeclaration),
+            $this->sut->createFromDataModel($variableDeclaration)
+        );
+    }
+
+    public function testCreateFromUnknownDataModel(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $this->sut->createFromDataModel(
+            new class ('test', BaseType::INTEGER) extends VariableDeclaration {
+            }
+        );
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            TemplateDeclaration::class => [TemplateVariable::class, new TemplateDeclaration('test', BaseType::INTEGER)],
+            OutcomeDeclaration::class  => [OutcomeVariable::class, new OutcomeDeclaration('test', BaseType::INTEGER)],
+            ResponseDeclaration::class => [ResponseVariable::class, new ResponseDeclaration('test', BaseType::INTEGER)],
+        ];
+    }
+}

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
@@ -43,6 +43,7 @@ use qtism\runtime\common\ResponseVariable;
 use qtism\runtime\common\State;
 use qtism\runtime\common\TemplateVariable;
 use qtism\runtime\common\Variable;
+use qtism\runtime\common\VariableFactory;
 use qtism\runtime\storage\binary\QtiBinaryStreamAccess;
 use qtism\runtime\storage\binary\QtiBinaryStreamAccessException;
 use qtism\runtime\storage\binary\QtiBinaryVersion;
@@ -72,7 +73,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream($binary);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
         $access->readVariableValue($variable, $valueType);
 
         switch ($valueType) {
@@ -470,7 +471,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         // Empty stream.
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a Variable value.');
@@ -488,7 +489,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage("Datatype mismatch for variable 'VAR'.");
@@ -513,7 +514,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         switch ($valueType) {
             case QtiBinaryStreamAccess::RW_DEFAULTVALUE:
@@ -889,7 +890,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $var = new ResponseVariable('VAR', Cardinality::SINGLE, BaseType::INTEGER);
         $type = QtiBinaryStreamAccess::RW_VALUE;
@@ -925,7 +926,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $bin = implode('', [$position, $state, $navigationMode, $submissionMode, $attempting, $hasItemSessionControl, $numAttempts, $duration, $completionStatus, $hasTimeReference, $timeReference, $varCount, $score, $response, $shufflingCount]);
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
 
         $version = $this->createVersionMock(QtiBinaryVersion::CURRENT_VERSION);
@@ -997,7 +998,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $bin = implode('', $binArray);
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'templateDeclaration', 'itemSessionControl']);
 
         $version = $this->createVersionMock(QtiBinaryVersion::CURRENT_VERSION);
@@ -1031,7 +1032,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $session = $this->createAssessmentItemSession($doc->getDocumentComponent()->getComponentByIdentifier('Q02'));
         $session->beginItemSession();
@@ -1062,7 +1063,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'templateDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $session = $this->createAssessmentItemSession($doc->getDocumentComponent()->getComponentByIdentifier('Q01'));
         $session->beginItemSession();
@@ -1094,7 +1095,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $session = $this->createAssessmentItemSession($doc->getDocumentComponent()->getComponentByIdentifier('Q02'));
         $session->beginItemSession();
@@ -1128,7 +1129,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         // Make the item session control a non-default one.
         $itemSessionControl = new ItemSessionControl();
@@ -1160,7 +1161,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $doc->getDocumentComponent()->getComponentByIdentifier('Q02')->getResponseDeclarations()['RESPONSE']->setCorrectResponse(
             new CorrectResponse(
@@ -1195,7 +1196,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $shufflingGroup = new ShufflingGroup(new IdentifierCollection(['ChoiceA', 'ChoiceB', 'ChoiceC']));
         $shufflingGroup->setFixedIdentifiers(new IdentifierCollection(['ChoiceB']));
@@ -1230,7 +1231,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $wrongSeeker = new AssessmentTestSeeker($doc2->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $session = $this->createAssessmentItemSession($doc->getDocumentComponent()->getComponentByIdentifier('Q01'));
         $session->beginItemSession();
@@ -1249,7 +1250,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $session = $this->createAssessmentItemSession($doc->getDocumentComponent()->getComponentByIdentifier('Q02'));
         $session->beginItemSession();
@@ -1279,7 +1280,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $routeItem = $access->readRouteItem($seeker);
         $this::assertEquals('Q03', $routeItem->getAssessmentItemRef()->getIdentifier());
@@ -1299,7 +1300,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'assessmentSection', 'testPart', 'outcomeDeclaration', 'responseDeclaration', 'branchRule', 'preCondition']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         // Get route item at index 2 which is the route item describing
         // item occurence 0 of Q03.
@@ -1336,7 +1337,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $pendingResponses = $access->readPendingResponses($seeker);
         $state = $pendingResponses->getState();
@@ -1359,7 +1360,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'assessmentSection', 'testPart', 'outcomeDeclaration', 'responseDeclaration', 'branchRule', 'preCondition']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $factory = new SessionManager(new FileSystemFileManager());
         $session = $factory->createAssessmentTestSession($doc->getDocumentComponent());
@@ -1394,7 +1395,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $shufflingGroup = $access->readShufflingGroup();
         $this::assertEquals(['id1', 'id2', 'id3'], $shufflingGroup->getIdentifiers()->getArrayCopy());
@@ -1405,7 +1406,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a shufflingGroup.');
@@ -1420,7 +1421,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $access->writeShufflingGroup($shufflingGroup);
         $stream->rewind();
@@ -1437,7 +1438,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing a shufflingGroup.');
@@ -1464,7 +1465,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $shufflingState = $access->readShufflingState();
         $this::assertEquals('RESPONSE', $shufflingState->getResponseIdentifier());
@@ -1478,7 +1479,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a shufflingState.');
@@ -1495,7 +1496,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $shuffling = new Shuffling('RESPONSE', $shufflingGroups);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
         $access->writeShufflingState($shuffling);
 
         $stream->rewind();
@@ -1518,7 +1519,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing a shufflingState.');
@@ -1531,7 +1532,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a Record Field.');
@@ -1543,7 +1544,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing a Record Field.');
@@ -1556,7 +1557,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading an identifier.');
@@ -1568,7 +1569,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing an identifier.');
@@ -1581,7 +1582,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a point.');
@@ -1593,7 +1594,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing a point.');
@@ -1606,7 +1607,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a pair.');
@@ -1618,7 +1619,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing a pair.');
@@ -1631,7 +1632,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a directedPair.');
@@ -1643,7 +1644,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing a directedPair.');
@@ -1656,7 +1657,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a duration.');
@@ -1668,7 +1669,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing a duration.');
@@ -1681,7 +1682,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a URI.');
@@ -1693,7 +1694,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing a URI.');
@@ -1706,7 +1707,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading an intOrIdentifier.');
@@ -1718,7 +1719,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while writing an intOrIdentifier.');

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
@@ -7,6 +7,7 @@ use qtism\common\storage\BinaryStreamAccessException;
 use qtism\common\storage\MemoryStream;
 use qtism\common\storage\MemoryStreamException;
 use qtism\common\storage\StreamAccessException;
+use qtism\runtime\common\VariableFactory;
 use qtism\runtime\storage\binary\QtiBinaryStreamAccess;
 use qtism\runtime\storage\binary\QtiBinaryVersion;
 use qtismtest\QtiSmTestCase;
@@ -20,7 +21,7 @@ class QtiBinaryVersionTest extends QtiSmTestCase
     {
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $subject = new QtiBinaryVersion();
         $subject->persist($access);
@@ -167,6 +168,6 @@ class QtiBinaryVersionTest extends QtiSmTestCase
         }
         $stream = new MemoryStream($binary);
         $stream->open();
-        return new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        return new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
     }
 }


### PR DESCRIPTION
- feat: introduce `VariableFactoryInterface` and its implementation, allowing to instantiate any `Variable` from its `VariableDeclaration
- fix: skip redundant `Variable` instantiation and initialization upon `QtiBinaryStreamAccess::readAssessmentItemSession()` execution, and read the variable directly from the session state

This is not a _major_ improvement, but those variable's objects instantiation and initialization does take some time indeed, and I cannot call that time insignificant (around 10% of the `move` action request processing).
Perhaps, further improvement is possible, involving lazy initialization of the variable's internals.

Legacy release backport is #276.