### PR TITLE
Backport TR-1084: skip unnecessary variable instnatiatio

### DIFF
--- a/qtism/runtime/common/VariableFactory.php
+++ b/qtism/runtime/common/VariableFactory.php
@@ -44,7 +44,9 @@ final class VariableFactory implements VariableFactoryInterface
      */
     public function createFromDataModel(VariableDeclaration $variableDeclaration): Variable
     {
-        return [$this->createVariableClass($variableDeclaration), 'createFromDataModel']($variableDeclaration);
+        $variableClassName = $this->createVariableClassName($variableDeclaration);
+
+        return $variableClassName::createFromDataModel($variableDeclaration);
     }
 
     /**
@@ -52,7 +54,7 @@ final class VariableFactory implements VariableFactoryInterface
      * @return string|Variable A matching Variable class
      * @throws UnexpectedValueException If $variableDeclaration is not consistent.
      */
-    private function createVariableClass(VariableDeclaration $variableDeclaration): string
+    private function createVariableClassName(VariableDeclaration $variableDeclaration): string
     {
         $variableDeclarationClass = get_class($variableDeclaration);
 

--- a/qtism/runtime/common/VariableFactory.php
+++ b/qtism/runtime/common/VariableFactory.php
@@ -54,16 +54,18 @@ final class VariableFactory implements VariableFactoryInterface
      */
     private function createVariableClass(VariableDeclaration $variableDeclaration): string
     {
-        if (!isset(self::VARIABLE_DECLARATION_MAP[$variableDeclaration::class])) {
+        $variableDeclarationClass = get_class($variableDeclaration);
+
+        if (!isset(self::VARIABLE_DECLARATION_MAP[$variableDeclarationClass])) {
             throw new UnexpectedValueException(
                 sprintf(
                     '`%s` is an unexpected `%s` implementation.',
-                    $variableDeclaration::class,
+                    $variableDeclarationClass,
                     VariableDeclaration::class
                 )
             );
         }
 
-        return self::VARIABLE_DECLARATION_MAP[$variableDeclaration::class];
+        return self::VARIABLE_DECLARATION_MAP[$variableDeclarationClass];
     }
 }

--- a/qtism/runtime/common/VariableFactory.php
+++ b/qtism/runtime/common/VariableFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ * @license GPLv2
+ */
+
+declare(strict_types=1);
+
+namespace qtism\runtime\common;
+
+use qtism\data\state\OutcomeDeclaration;
+use qtism\data\state\ResponseDeclaration;
+use qtism\data\state\TemplateDeclaration;
+use qtism\data\state\VariableDeclaration;
+use UnexpectedValueException;
+
+final class VariableFactory implements VariableFactoryInterface
+{
+    private const VARIABLE_DECLARATION_MAP = [
+        TemplateDeclaration::class => TemplateVariable::class,
+        OutcomeDeclaration::class  => OutcomeVariable::class,
+        ResponseDeclaration::class => ResponseVariable::class,
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function createFromDataModel(VariableDeclaration $variableDeclaration): Variable
+    {
+        return [$this->createVariableClass($variableDeclaration), 'createFromDataModel']($variableDeclaration);
+    }
+
+    /**
+     * @param VariableDeclaration $variableDeclaration A VariableDeclaration object from the QTI Data Model.
+     * @return string|Variable A matching Variable class
+     * @throws UnexpectedValueException If $variableDeclaration is not consistent.
+     */
+    private function createVariableClass(VariableDeclaration $variableDeclaration): string
+    {
+        if (!isset(self::VARIABLE_DECLARATION_MAP[$variableDeclaration::class])) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    '`%s` is an unexpected `%s` implementation.',
+                    $variableDeclaration::class,
+                    VariableDeclaration::class
+                )
+            );
+        }
+
+        return self::VARIABLE_DECLARATION_MAP[$variableDeclaration::class];
+    }
+}

--- a/qtism/runtime/common/VariableFactoryInterface.php
+++ b/qtism/runtime/common/VariableFactoryInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ * @license GPLv2
+ */
+
+declare(strict_types=1);
+
+namespace qtism\runtime\common;
+
+use UnexpectedValueException;
+use qtism\data\state\VariableDeclaration;
+
+interface VariableFactoryInterface
+{
+    /**
+     * Create a runtime Variable object from its Data Model representation.
+     *
+     * @param VariableDeclaration $variableDeclaration A VariableDeclaration object from the QTI Data Model.
+     * @return Variable A Variable object.
+     * @throws UnexpectedValueException If $variableDeclaration is not consistent.
+     */
+    public function createFromDataModel(VariableDeclaration $variableDeclaration): Variable;
+}

--- a/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -60,6 +60,7 @@ use qtism\runtime\common\ResponseVariable;
 use qtism\runtime\common\State;
 use qtism\runtime\common\Utils;
 use qtism\runtime\common\Variable;
+use qtism\runtime\common\VariableFactory;
 use qtism\runtime\common\VariableFactoryInterface;
 use qtism\runtime\storage\common\AssessmentTestSeeker;
 use qtism\runtime\tests\AbstractSessionManager;
@@ -93,11 +94,14 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
      * @param FileManager $fileManager The FileManager object to handle file variable.
      * @throws StreamAccessException
      */
-    public function __construct(IStream $stream, FileManager $fileManager, VariableFactoryInterface $variableFactory)
-    {
+    public function __construct(
+        IStream $stream,
+        FileManager $fileManager,
+        VariableFactoryInterface $variableFactory = null
+    ) {
         parent::__construct($stream);
         $this->setFileManager($fileManager);
-        $this->variableFactory = $variableFactory;
+        $this->variableFactory = $variableFactory ?? new VariableFactory();
     }
 
     /**

--- a/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -46,7 +46,7 @@ use qtism\common\storage\StreamAccessException;
 use qtism\data\AssessmentSectionCollection;
 use qtism\data\rules\BranchRuleCollection;
 use qtism\data\rules\PreConditionCollection;
-use qtism\data\state\OutcomeDeclaration;
+use qtism\data\state\VariableDeclaration;
 use qtism\runtime\common\MultipleContainer;
 use qtism\runtime\common\OrderedContainer;
 use qtism\runtime\common\OutcomeVariable;
@@ -55,6 +55,7 @@ use qtism\runtime\common\ResponseVariable;
 use qtism\runtime\common\State;
 use qtism\runtime\common\Utils;
 use qtism\runtime\common\Variable;
+use qtism\runtime\common\VariableFactoryInterface;
 use qtism\runtime\storage\common\AssessmentTestSeeker;
 use qtism\runtime\tests\AbstractSessionManager;
 use qtism\runtime\tests\AssessmentItemSession;
@@ -74,10 +75,11 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
 
     const RW_CORRECTRESPONSE = 2;
 
-    /**
-     * @var FileManager
-     */
+    /** @var FileManager */
     private $fileManager;
+
+    /** @var VariableFactoryInterface */
+    private $variableFactory;
 
     /**
      * Create a new QtiBinaryStreamAccess object.
@@ -86,10 +88,11 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
      * @param FileManager $fileManager The FileManager object to handle file variable.
      * @throws StreamAccessException
      */
-    public function __construct(IStream $stream, FileManager $fileManager)
+    public function __construct(IStream $stream, FileManager $fileManager, VariableFactoryInterface $variableFactory)
     {
         parent::__construct($stream);
         $this->setFileManager($fileManager);
+        $this->variableFactory = $variableFactory;
     }
 
     /**
@@ -615,16 +618,24 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                 $isOutcome = $this->readBoolean();
                 $varPosition = $this->readShort();
 
-                $variable = null;
-
                 try {
-                    $variable = $seeker->seekComponent(($isOutcome === true) ? 'outcomeDeclaration' : 'responseDeclaration', $varPosition);
+                    /** @var VariableDeclaration $variableDeclaration */
+                    $variableDeclaration = $seeker->seekComponent(
+                        ($isOutcome === true) ? 'outcomeDeclaration' : 'responseDeclaration',
+                        $varPosition
+                    );
                 } catch (OutOfBoundsException $e) {
                     $msg = "No variable found at position ${varPosition} in the assessmentTest tree structure.";
-                    throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::ITEM_SESSION, $e);
+                    throw new QtiBinaryStreamAccessException(
+                        $msg,
+                        $this,
+                        QtiBinaryStreamAccessException::ITEM_SESSION,
+                        $e
+                    );
                 }
 
-                $variable = ($variable instanceof OutcomeDeclaration) ? OutcomeVariable::createFromDataModel($variable) : ResponseVariable::createFromDataModel($variable);
+                $variable = $session->getVariable($variableDeclaration->getIdentifier())
+                    ?? $this->variableFactory->createFromDataModel($variableDeclaration);
 
                 // If we are here, we have our variable.
                 $this->readVariableValue($variable);

--- a/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -738,7 +738,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     public function readRouteItem(AssessmentTestSeeker $seeker, QtiBinaryVersion $version)
     {
         try {
-            $occurence = $this->readTinyInt();
+            $occurrence = $this->readTinyInt();
             /** @var AssessmentItemRef $itemRef */
             $itemRef = $seeker->seekComponent('assessmentItemRef', $this->readShort());
 
@@ -775,7 +775,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             }
 
             $routeItem = new RouteItem($itemRef, $sections, $testPart, $seeker->getAssessmentTest());
-            $routeItem->setOccurence($occurence);
+            $routeItem->setOccurence($occurrence);
             $routeItem->setBranchRules($branchRules);
             $routeItem->setPreConditions($preConditions);
 
@@ -858,10 +858,10 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             /** @var AssessmentItemRef $itemRef */
             $itemRef = $seeker->seekComponent('assessmentItemRef', $this->readShort());
 
-            // Read the occurence number.
-            $occurence = $this->readTinyInt();
+            // Read the occurrence number.
+            $occurrence = $this->readTinyInt();
 
-            return new PendingResponses($state, $itemRef, $occurence);
+            return new PendingResponses($state, $itemRef, $occurrence);
         } catch (BinaryStreamAccessException $e) {
             $msg = 'An error occurred while reading some pending responses.';
             throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::PENDING_RESPONSES, $e);
@@ -883,7 +883,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
         try {
             $state = $pendingResponses->getState();
             $itemRef = $pendingResponses->getAssessmentItemRef();
-            $occurence = $pendingResponses->getOccurence();
+            $occurrence = $pendingResponses->getOccurence();
 
             // Write the state.
             $responseDeclarations = $itemRef->getResponseDeclarations();
@@ -904,8 +904,8 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             // Write the assessmentItemRef.
             $this->writeShort($seeker->seekPosition($itemRef));
 
-            // Write the occurence number.
-            $this->writeTinyInt($occurence);
+            // Write the occurrence number.
+            $this->writeTinyInt($occurrence);
         } catch (BinaryStreamAccessException $e) {
             $msg = 'An error occurred while reading some pending responses.';
             throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::PENDING_RESPONSES, $e);

--- a/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -75,11 +75,9 @@ use qtism\runtime\tests\RouteItem;
  */
 class QtiBinaryStreamAccess extends BinaryStreamAccess
 {
-    const RW_VALUE = 0;
-
-    const RW_DEFAULTVALUE = 1;
-
-    const RW_CORRECTRESPONSE = 2;
+    public const RW_VALUE = 0;
+    public const RW_DEFAULTVALUE = 1;
+    public const RW_CORRECTRESPONSE = 2;
 
     /** @var FileManager */
     private $fileManager;

--- a/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -43,10 +43,15 @@ use qtism\common\storage\BinaryStreamAccess;
 use qtism\common\storage\BinaryStreamAccessException;
 use qtism\common\storage\IStream;
 use qtism\common\storage\StreamAccessException;
+use qtism\data\AssessmentItemRef;
 use qtism\data\AssessmentSectionCollection;
+use qtism\data\IAssessmentItem;
+use qtism\data\ItemSessionControl;
 use qtism\data\rules\BranchRuleCollection;
 use qtism\data\rules\PreConditionCollection;
+use qtism\data\state\ResponseDeclaration;
 use qtism\data\state\VariableDeclaration;
+use qtism\data\TestPart;
 use qtism\runtime\common\MultipleContainer;
 use qtism\runtime\common\OrderedContainer;
 use qtism\runtime\common\OutcomeVariable;
@@ -581,6 +586,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     ) {
         try {
             $itemRefPosition = $this->readShort();
+            /** @var IAssessmentItem $assessmentItemRef */
             $assessmentItemRef = $seeker->seekComponent('assessmentItemRef', $itemRefPosition);
 
             $session = $manager->createAssessmentItemSession($assessmentItemRef);
@@ -595,6 +601,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             }
 
             if ($this->readBoolean() === true) {
+                /** @var ItemSessionControl $itemSessionControl */
                 $itemSessionControl = $seeker->seekComponent('itemSessionControl', $this->readShort());
                 $session->setItemSessionControl($itemSessionControl);
             }
@@ -697,6 +704,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                 if (in_array($varId, ['numAttempts', 'duration', 'completionStatus']) === false) {
                     $var = $session->getVariable($varId);
                     $isOutcome = $var instanceof OutcomeVariable;
+                    /** @var VariableDeclaration $variableDeclaration */
                     $variableDeclaration = ($isOutcome === true) ? $itemOutcomes[$varId] : $itemResponses[$varId];
 
                     try {
@@ -731,6 +739,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     {
         try {
             $occurence = $this->readTinyInt();
+            /** @var AssessmentItemRef $itemRef */
             $itemRef = $seeker->seekComponent('assessmentItemRef', $this->readShort());
 
             // Prior to version 3, only a singe assessmentSection might be bound to the RouteItem.
@@ -738,6 +747,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                 $sections = $seeker->seekComponent('assessmentSection', $this->readShort());
             }
 
+            /** @var TestPart $testPart */
             $testPart = $seeker->seekComponent('testPart', $this->readShort());
 
             // From version 3, multiple assessmentSections might be bound to the RouteItem.
@@ -837,6 +847,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             $varCount = $this->readTinyInt();
 
             for ($i = 0; $i < $varCount; $i++) {
+                /** @var ResponseDeclaration $responseDeclaration */
                 $responseDeclaration = $seeker->seekComponent('responseDeclaration', $this->readShort());
                 $responseVariable = ResponseVariable::createFromDataModel($responseDeclaration);
                 $this->readVariableValue($responseVariable);
@@ -844,6 +855,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             }
 
             // Read the assessmentItemRef.
+            /** @var AssessmentItemRef $itemRef */
             $itemRef = $seeker->seekComponent('assessmentItemRef', $this->readShort());
 
             // Read the occurence number.

--- a/qtism/runtime/storage/binary/TemporaryQtiBinaryStorage.php
+++ b/qtism/runtime/storage/binary/TemporaryQtiBinaryStorage.php
@@ -27,6 +27,7 @@ use qtism\common\datatypes\files\FileSystemFileManager;
 use qtism\common\storage\IStream;
 use qtism\common\storage\MemoryStream;
 use qtism\common\storage\StreamAccessException;
+use qtism\runtime\common\VariableFactory;
 use qtism\runtime\tests\AssessmentTestSession;
 use RuntimeException;
 
@@ -88,6 +89,6 @@ class TemporaryQtiBinaryStorage extends AbstractQtiBinaryStorage
      */
     protected function createBinaryStreamAccess(IStream $stream)
     {
-        return new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        return new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
     }
 }

--- a/test/qtismtest/runtime/common/VariableFactoryTest.php
+++ b/test/qtismtest/runtime/common/VariableFactoryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ * @license GPLv2
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\runtime\common;
+
+use UnexpectedValueException;
+use qtism\common\enums\BaseType;
+use qtism\data\state\OutcomeDeclaration;
+use qtism\data\state\ResponseDeclaration;
+use qtism\data\state\TemplateDeclaration;
+use qtism\data\state\VariableDeclaration;
+use qtism\runtime\common\OutcomeVariable;
+use qtism\runtime\common\ResponseVariable;
+use qtism\runtime\common\TemplateVariable;
+use qtism\runtime\common\Variable;
+use qtism\runtime\common\VariableFactory;
+use qtismtest\QtiSmTestCase;
+
+class VariableFactoryTest extends QtiSmTestCase
+{
+    /** @var VariableFactory */
+    private $sut;
+
+    /**
+     * @before
+     */
+    public function setUpSut(): void
+    {
+        $this->sut = new VariableFactory();
+    }
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param string|Variable $expectedVariableClass
+     * @param VariableDeclaration $variableDeclaration
+     */
+    public function testCreateFromDataModel(
+        string $expectedVariableClass,
+        VariableDeclaration $variableDeclaration
+    ): void {
+        $this->assertEquals(
+            $expectedVariableClass::createFromDataModel($variableDeclaration),
+            $this->sut->createFromDataModel($variableDeclaration)
+        );
+    }
+
+    public function testCreateFromUnknownDataModel(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $this->sut->createFromDataModel(
+            new class ('test', BaseType::INTEGER) extends VariableDeclaration {
+            }
+        );
+    }
+
+    public function dataProvider(): array
+    {
+        return [
+            TemplateDeclaration::class => [TemplateVariable::class, new TemplateDeclaration('test', BaseType::INTEGER)],
+            OutcomeDeclaration::class  => [OutcomeVariable::class, new OutcomeDeclaration('test', BaseType::INTEGER)],
+            ResponseDeclaration::class => [ResponseVariable::class, new ResponseDeclaration('test', BaseType::INTEGER)],
+        ];
+    }
+}

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
@@ -39,6 +39,7 @@ use qtism\runtime\common\ResponseVariable;
 use qtism\runtime\common\State;
 use qtism\runtime\common\TemplateVariable;
 use qtism\runtime\common\Variable;
+use qtism\runtime\common\VariableFactory;
 use qtism\runtime\storage\binary\QtiBinaryStreamAccess;
 use qtism\runtime\storage\binary\QtiBinaryStreamAccessException;
 use qtism\runtime\storage\binary\QtiBinaryVersion;
@@ -70,7 +71,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream($binary);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
         $access->readVariableValue($variable, $valueType);
 
         switch ($valueType) {
@@ -468,7 +469,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         // Empty stream.
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a Variable value.');
@@ -486,7 +487,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage("Datatype mismatch for variable 'VAR'.");
@@ -511,7 +512,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         switch ($valueType) {
             case QtiBinaryStreamAccess::RW_DEFAULTVALUE:
@@ -907,7 +908,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $bin = implode('', [$position, $state, $navigationMode, $submissionMode, $attempting, $hasItemSessionControl, $numAttempts, $duration, $completionStatus, $timeReference, $varCount, $score, $response]);
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
 
         $version = $this->createVersionMock(2);
@@ -938,7 +939,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $session = $this->createAssessmentItemSession($doc->getDocumentComponent()->getComponentByIdentifier('Q02'));
         $session->beginItemSession();
@@ -967,7 +968,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'templateDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $session = $this->createAssessmentItemSession($doc->getDocumentComponent()->getComponentByIdentifier('Q01'));
         $session->beginItemSession();
@@ -996,7 +997,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $session = $this->createAssessmentItemSession($doc->getDocumentComponent()->getComponentByIdentifier('Q02'));
         $session->beginItemSession();
@@ -1028,7 +1029,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         // Make the item session control a non-default one.
         $itemSessionControl = new ItemSessionControl();
@@ -1060,7 +1061,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $doc->getDocumentComponent()->getComponentByIdentifier('Q02')->getResponseDeclarations()['RESPONSE']->setCorrectResponse(
             new CorrectResponse(
@@ -1098,7 +1099,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $wrongSeeker = new AssessmentTestSeeker($doc2->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $session = $this->createAssessmentItemSession($doc->getDocumentComponent()->getComponentByIdentifier('Q01'));
         $session->beginItemSession();
@@ -1126,7 +1127,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $version = $this->createVersionMock(3);
         $routeItem = $access->readRouteItem($seeker, $version);
@@ -1148,7 +1149,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'assessmentSection', 'testPart', 'outcomeDeclaration', 'responseDeclaration', 'branchRule', 'preCondition']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         // Get route item at index 2 which is the route item describing
         // item occurence 0 of Q03.
@@ -1186,7 +1187,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 
         $stream = new MemoryStream($bin);
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $pendingResponses = $access->readPendingResponses($seeker);
         $state = $pendingResponses->getState();
@@ -1209,7 +1210,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'assessmentSection', 'testPart', 'outcomeDeclaration', 'responseDeclaration', 'branchRule', 'preCondition']);
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $factory = new SessionManager();
         $session = $factory->createAssessmentTestSession($doc->getDocumentComponent());
@@ -1236,7 +1237,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a Record Field.');
@@ -1248,7 +1249,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading an identifier.');
@@ -1260,7 +1261,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a point.');
@@ -1272,7 +1273,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a pair.');
@@ -1284,7 +1285,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a directedPair.');
@@ -1296,7 +1297,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a duration.');
@@ -1308,7 +1309,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading a URI.');
@@ -1320,7 +1321,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
     {
         $stream = new MemoryStream('');
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $this->expectException(QtiBinaryStreamAccessException::class);
         $this->expectExceptionMessage('An error occurred while reading an intOrIdentifier.');

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
@@ -7,6 +7,7 @@ use qtism\common\storage\BinaryStreamAccessException;
 use qtism\common\storage\MemoryStream;
 use qtism\common\storage\MemoryStreamException;
 use qtism\common\storage\StreamAccessException;
+use qtism\runtime\common\VariableFactory;
 use qtism\runtime\storage\binary\QtiBinaryStreamAccess;
 use qtism\runtime\storage\binary\QtiBinaryVersion;
 use qtismtest\QtiSmTestCase;
@@ -20,7 +21,7 @@ class QtiBinaryVersionTest extends QtiSmTestCase
     {
         $stream = new MemoryStream();
         $stream->open();
-        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
 
         $subject = new QtiBinaryVersion();
         $subject->persist($access);
@@ -167,6 +168,6 @@ class QtiBinaryVersionTest extends QtiSmTestCase
         }
         $stream = new MemoryStream($binary);
         $stream->open();
-        return new QtiBinaryStreamAccess($stream, new FileSystemFileManager());
+        return new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
     }
 }


### PR DESCRIPTION
- feat: introduce `VariableFactoryInterface` and its implementation, allowing to instantiate any `Variable` from its `VariableDeclaration
- fix: skip redundant `Variable` instantiation and initialization upon `QtiBinaryStreamAccess::readAssessmentItemSession()` execution, and read the variable directly from the session state

This backports #274.