### PR TITLE
feat: wrap processing exception into collection before to throw them

### DIFF
--- a/qtism/runtime/common/ProcessingCollectionException.php
+++ b/qtism/runtime/common/ProcessingCollectionException.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\runtime\common;
+
+use RuntimeException;
+
+/**
+ * A collection of ProcessingException to be thrown
+ */
+class ProcessingCollectionException extends RuntimeException
+{
+    /** @var ProcessingException[] */
+    private $processingExceptions;
+
+    public function addProcessingExceptions(ProcessingException $exception): void
+    {
+        $this->processingExceptions[] = $exception;
+    }
+
+    public function getProcessingExceptions(): array
+    {
+        return $this->processingExceptions;
+    }
+}

--- a/test/qtismtest/runtime/processing/ResponseProcessingEngineTest.php
+++ b/test/qtismtest/runtime/processing/ResponseProcessingEngineTest.php
@@ -9,7 +9,7 @@ use qtism\common\enums\BaseType;
 use qtism\common\enums\Cardinality;
 use qtism\runtime\common\MultipleContainer;
 use qtism\runtime\common\OutcomeVariable;
-use qtism\runtime\common\ProcessingException;
+use qtism\runtime\common\ProcessingCollectionException;
 use qtism\runtime\common\ResponseVariable;
 use qtism\runtime\common\State;
 use qtism\runtime\processing\ResponseProcessingEngine;
@@ -128,9 +128,17 @@ class ResponseProcessingEngineTest extends QtiSmTestCase
 
         $engine = new ResponseProcessingEngine($responseProcessing);
 
-        $this->expectException(RuleProcessingException::class);
-        $this->expectExceptionCode(RuleProcessingException::EXIT_RESPONSE);
-        $engine->process();
+        try {
+            $engine->process();
+        } catch (\Throwable $processingCollectionException) {}
+
+        self::assertInstanceOf(ProcessingCollectionException::class, $processingCollectionException);
+        self::assertEquals('Unexpected error(s) occurred while processing response', $processingCollectionException->getMessage());
+
+        $processingException = $processingCollectionException->getProcessingExceptions()[0];
+
+        self::assertEquals(RuleProcessingException::EXIT_RESPONSE, $processingException->getCode());
+        self::assertInstanceOf(RuleProcessingException::class, $processingException);
     }
 
     public function testSetOutcomeValueWithSum()


### PR DESCRIPTION
[TR-1260](https://oat-sa.atlassian.net/browse/TR-1260)

The goal of this PR is to backport the response processing behaviour on error, ignoring broken process rules to skip the erroneous outcome value generation but continue the remaining ones