### PR TITLE
Feat: allow skipping non-presented items to unblock default values for all remaining items on test timeout

### DIFF
--- a/qtism/runtime/tests/AssessmentItemSession.php
+++ b/qtism/runtime/tests/AssessmentItemSession.php
@@ -928,7 +928,7 @@ class AssessmentItemSession extends State
             $msg = "Skipping item '${itemIdentifier}' is not allowed.";
             throw new AssessmentItemSessionException($msg, $this, AssessmentItemSessionException::SKIPPING_FORBIDDEN);
         } else {
-            // Detect all response variables and submit them with their default value or NULL. state 3
+            // Detect all response variables and submit them with their default value or NULL.
             foreach ($this->getAssessmentItem()->getResponseDeclarations() as $responseDeclaration) {
                 $this->getVariable($responseDeclaration->getIdentifier())->applyDefaultValue();
             }

--- a/qtism/runtime/tests/AssessmentTestSession.php
+++ b/qtism/runtime/tests/AssessmentTestSession.php
@@ -1381,30 +1381,33 @@ class AssessmentTestSession extends State
     /**
      * Skip the current item.
      *
+     * @param bool $allowUntouchedItems whether to allow skipping items in state INITIAL (not ever seen yet by the TT)
+     *
      * @throws AssessmentTestSessionException If the test session is not running or it is the last route item of the testPart but the SIMULTANEOUS submission mode is in force and not all responses were provided.
      * @qtism-test-interaction
      * @qtism-test-duration-update
      */
-    public function skip()
+    public function skip($allowUntouchedItems = false)
     {
         if ($this->isRunning() === false) {
             $msg = 'Cannot skip the current item while the state of the test session is INITIAL or CLOSED.';
             throw new AssessmentTestSessionException($msg, AssessmentTestSessionException::STATE_VIOLATION);
         }
 
-        $item = $this->getCurrentAssessmentItemRef();
+        $item = $this->getCurrentAssessmentItemRef(); // aga
         $occurence = $this->getCurrentAssessmentItemRefOccurence();
         $session = $this->getItemSession($item, $occurence);
 
         try {
             // Might throw an AssessmentItemSessionException.
-            $session->skip();
+            $session->skip($allowUntouchedItems);
 
             if ($this->getCurrentSubmissionMode() === SubmissionMode::SIMULTANEOUS) {
                 // Store the responses for a later processing at the end of the test part.
                 $pendingResponses = new PendingResponses($session->getResponseVariables(false), $item, $occurence);
                 $this->addPendingResponses($pendingResponses);
             } else {
+                // SHOULDBEHERE
                 $this->submitItemResults($session, $occurence);
                 $this->outcomeProcessing();
             }
@@ -1452,7 +1455,7 @@ class AssessmentTestSession extends State
      * @qtism-test-interaction
      * @qtism-test-duration-update
      */
-    public function endAttempt(State $responses, $allowLateSubmission = false)
+    public function endAttempt(State $responses, $allowLateSubmission = true)
     {
         if ($this->isRunning() === false) {
             $msg = 'Cannot end an attempt for the current item while the state of the test session is INITIAL or CLOSED.';

--- a/qtism/runtime/tests/AssessmentTestSession.php
+++ b/qtism/runtime/tests/AssessmentTestSession.php
@@ -1394,7 +1394,7 @@ class AssessmentTestSession extends State
             throw new AssessmentTestSessionException($msg, AssessmentTestSessionException::STATE_VIOLATION);
         }
 
-        $item = $this->getCurrentAssessmentItemRef(); // aga
+        $item = $this->getCurrentAssessmentItemRef();
         $occurence = $this->getCurrentAssessmentItemRefOccurence();
         $session = $this->getItemSession($item, $occurence);
 
@@ -1407,7 +1407,6 @@ class AssessmentTestSession extends State
                 $pendingResponses = new PendingResponses($session->getResponseVariables(false), $item, $occurence);
                 $this->addPendingResponses($pendingResponses);
             } else {
-                // SHOULDBEHERE
                 $this->submitItemResults($session, $occurence);
                 $this->outcomeProcessing();
             }
@@ -1455,7 +1454,7 @@ class AssessmentTestSession extends State
      * @qtism-test-interaction
      * @qtism-test-duration-update
      */
-    public function endAttempt(State $responses, $allowLateSubmission = true)
+    public function endAttempt(State $responses, $allowLateSubmission = false)
     {
         if ($this->isRunning() === false) {
             $msg = 'Cannot end an attempt for the current item while the state of the test session is INITIAL or CLOSED.';

--- a/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
@@ -655,4 +655,27 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $this::assertTrue($itemSession->isResponded());
         $this::assertTrue($itemSession->isResponded(false));
     }
+
+    public function testItAllowsToFinishUntouchedItemsWhenConfiguredSo()
+    {
+        $itemSession = $this->instantiateBasicAssessmentItemSession();
+        $itemSession->beginItemSession();
+
+        $allowUntouchedItems = true;
+
+        // assert there's no AssessmentItemSessionException
+        $this->assertNull($itemSession->endAttempt(null, true, false, $allowUntouchedItems));
+    }
+
+    public function testItDoesNotAllowToFinishUntouchedItemsWhenConfiguredSo()
+    {
+        $itemSession = $this->instantiateBasicAssessmentItemSession();
+        $itemSession->beginItemSession();
+
+        $allowUntouchedItems = false;
+
+        $this->expectException(AssessmentItemSessionException::class);
+
+        $itemSession->endAttempt(null, true, false, $allowUntouchedItems);
+    }
 }


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/TR-1432

Allow skipping non-presented items to unblock submitting default responses on test timeout