### PR TITLE
Fix/tr 1605/preconditions assessmentsection level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 vendor
 *.geany
 *.idea
+.phpunit.result.cache

--- a/qtism/runtime/tests/AbstractSessionManager.php
+++ b/qtism/runtime/tests/AbstractSessionManager.php
@@ -247,8 +247,10 @@ abstract class AbstractSessionManager
                             $route->getLastRouteItem()->addBranchRules($current->getBranchRules());
 
                             // Do the same as for branch rules for pre conditions, except that they must be
-                            // attached on the first item of the route.
-                            $route->getFirstRouteItem()->addPreConditions($current->getPreConditions());
+                            // attached on all the items of the selected route.
+                            foreach ($route as $selectableRouteItem) {
+                                $selectableRouteItem->addPreConditions($current->getPreConditions());
+                            }
                         }
 
                         array_push($routeStack, $route);

--- a/test/qtismtest/runtime/tests/AssessmentTestSessionPreConditionsTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentTestSessionPreConditionsTest.php
@@ -163,4 +163,78 @@ class AssessmentTestSessionPreConditionsTest extends QtiSmAssessmentTestSessionT
 
         $this::assertFalse($testSession->isRunning());
     }
+
+    /**
+     * @throws \qtism\data\storage\php\PhpStorageException
+     * @throws \qtism\data\storage\xml\XmlStorageException
+     * @throws \qtism\runtime\tests\AssessmentItemSessionException
+     * @throws \qtism\runtime\tests\AssessmentTestSessionException
+     */
+    public function testSectionLevelByTakingS02()
+    {
+        // Expected flow: Q01, Q02, Q03
+        $testSession = self::instantiate(self::samplesDir() . 'custom/runtime/preconditions/preconditions_sections_level_linear.xml');
+        $testSession->beginTestSession();
+
+        // We are on Q01, where we select the next flow by responding 'GotoS02' or 'GotoS03'.
+        $this::assertEquals('Q01', $testSession->getCurrentAssessmentItemRef()->getIdentifier());
+
+        // Let's go to Section 'S02'.
+        $testSession->beginAttempt();
+        $testSession->endAttempt(new State([new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER, new QtiIdentifier('GotoS02'))]));
+        $testSession->moveNext();
+        $this::assertTrue($testSession['Q01.RESPONSE']->equals(new QtiIdentifier('GotoS02')));
+        $this::assertEquals('S02', $testSession->getCurrentAssessmentSection()->getIdentifier());
+        $this::assertEquals('Q02', $testSession->getCurrentAssessmentItemRef()->getIdentifier());
+
+        // Let's take Section 'S02'. We should arrive at the end of the test, not taking S03 (protected by preCondition).
+        $testSession->beginAttempt();
+        $testSession->endAttempt(new State());
+        $testSession->moveNext();
+        $this::assertEquals('S02', $testSession->getCurrentAssessmentSection()->getIdentifier());
+        $this::assertEquals('Q03', $testSession->getCurrentAssessmentItemRef()->getIdentifier());
+        $testSession->beginAttempt();
+        $testSession->endAttempt(new State());
+        $testSession->moveNext();
+
+        // The test session should be finished.
+        $this::assertFalse($testSession->isRunning());
+    }
+
+    /**
+     * @throws \qtism\data\storage\php\PhpStorageException
+     * @throws \qtism\data\storage\xml\XmlStorageException
+     * @throws \qtism\runtime\tests\AssessmentItemSessionException
+     * @throws \qtism\runtime\tests\AssessmentTestSessionException
+     */
+    public function testSectionLevelByTakingS03()
+    {
+        // Expected flow: Q01, Q04, Q05
+        $testSession = self::instantiate(self::samplesDir() . 'custom/runtime/preconditions/preconditions_sections_level_linear.xml');
+        $testSession->beginTestSession();
+
+        // We are on Q01, where we select the next flow by responding 'GotoS02' or 'GotoS03'.
+        $this::assertEquals('Q01', $testSession->getCurrentAssessmentItemRef()->getIdentifier());
+
+        // Let's go to Section 'S03'.
+        $testSession->beginAttempt();
+        $testSession->endAttempt(new State([new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER, new QtiIdentifier('GotoS03'))]));
+        $testSession->moveNext();
+        $this::assertTrue($testSession['Q01.RESPONSE']->equals(new QtiIdentifier('GotoS03')));
+        $this::assertEquals('S03', $testSession->getCurrentAssessmentSection()->getIdentifier());
+        $this::assertEquals('Q04', $testSession->getCurrentAssessmentItemRef()->getIdentifier());
+
+        // Let's take Section 'S03'. We should arrive at the end of the test, not taking S02 (protected by preCondition).
+        $testSession->beginAttempt();
+        $testSession->endAttempt(new State());
+        $testSession->moveNext();
+        $this::assertEquals('S03', $testSession->getCurrentAssessmentSection()->getIdentifier());
+        $this::assertEquals('Q05', $testSession->getCurrentAssessmentItemRef()->getIdentifier());
+        $testSession->beginAttempt();
+        $testSession->endAttempt(new State());
+        $testSession->moveNext();
+
+        // The test session should be finished.
+        $this::assertFalse($testSession->isRunning());
+    }
 }

--- a/test/samples/custom/runtime/preconditions/preconditions_sections_level_linear.xml
+++ b/test/samples/custom/runtime/preconditions/preconditions_sections_level_linear.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.taotesting.com/xsd/qticompact_v2p1.xsd"
+                identifier="preconditions_sections_level_linear" title="PreConditions Sections Level Linear">
+    <testPart identifier="P01" navigationMode="linear" submissionMode="individual">
+        <assessmentSection identifier="S01" fixed="false" title="Section1" visible="true">
+            <branchRule target="S02">
+                <match>
+                    <variable identifier="Q01.RESPONSE"/>
+                    <baseValue baseType="identifier">GotoS02</baseValue>
+                </match>
+            </branchRule>
+            <branchRule target="S03">
+                <match>
+                    <variable identifier="Q01.RESPONSE"/>
+                    <baseValue baseType="identifier">GotoS03</baseValue>
+                </match>
+            </branchRule>
+            <assessmentItemRef identifier="Q01" href="./Q01.xml" fixed="false" timeDependent="false">
+                <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier"/>
+            </assessmentItemRef>
+        </assessmentSection>
+        <assessmentSection identifier="S02" title="Section2" visible="true">
+            <preCondition>
+                <match>
+                    <variable identifier="Q01.RESPONSE"/>
+                    <baseValue baseType="identifier">GotoS02</baseValue>
+                </match>
+            </preCondition>
+            <assessmentItemRef identifier="Q02" href="./Q02.xml" timeDependent="false"/>
+            <assessmentItemRef identifier="Q03" href="./Q03.xml" timeDependent="false"/>
+        </assessmentSection>
+        <assessmentSection identifier="S03" title="Section3" visible="true">
+            <preCondition>
+                <match>
+                    <variable identifier="Q01.RESPONSE"/>
+                    <baseValue baseType="identifier">GotoS03</baseValue>
+                </match>
+            </preCondition>
+            <assessmentItemRef identifier="Q04" href="./Q04.xml" timeDependent="false"/>
+            <assessmentItemRef identifier="Q05" href="./Q05.xml" timeDependent="false"/>
+        </assessmentSection>
+    </testPart>
+</assessmentTest>


### PR DESCRIPTION
### Description

This PR appears in the context of resolving AUT-753, TR-1607, TR-1605 and TR-1606. It seems this bug fix will solve them all in a row :crossed_fingers: !

Long story short, the `preConditions`, to whatever they were bound to (`assessmentSection` or `assessmentItemRef`), were always behaving being bound to an `assessentItemRef`. As a result, a `preCondition` returning true, bound to an `assessmentSection` was leading to always behave as it was bound to the first `assessmentItemRef` of the `assessmentSection`.

This is now solved at the `assessmentTestSession` instantiation level, where the `preConditions` are applied to all `routeItems` that are children to the `sectionPart` (parent class of `assessmentSection` and `assessmentItemRef`) the `preCondition` belong to.

Enjoy :sweat_smile:  !

### Appendix

**General:** 
the existing unit tests were all about `assessmentItemRef` based `preCondition`s. They continue to validate the appropriate behaviour of the routing engine.

**Hints about the changes:**
* `qtism/runtime/tests/AbstractSessionManager.php`: this is where the magic occurs. Basically, the instantiation is all about flattening the Assessment Graph (it's an N-ary tree so, yes, a Graph) while performing a Dept First Search (DFS Left -> Right) traversal. Instead of applying the `preCondition`s on the first item of the sub-routes (flatten `sectionPart`s) while going up in `sectionPart`s, we apply them on all the children. Yes, logic, but still there for 8 years :sweat_smile: !

* `test/qtismtest/runtime/tests/AssessmentTestSessionPreConditionsTest.php`: this is where the testing of the beast occurs. A first section (`S01`) contains a branchRule in order to go in a second (`S02`) OR third (`S03`) section, depending on your response. The two sections are "guarded" by `assessmentSection` level `preCondition`.

* ` test/samples/custom/runtime/preconditions/preconditions_sections_level_linear.xml`: Assessment Material to be executed to simulate the AssessmentTestSession tested in the Test Case mentioned above.