### PR TITLE
feat: value marshaller enclose content in CDATA section

### DIFF
--- a/src/qtism/data/storage/xml/marshalling/ValueMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ValueMarshaller.php
@@ -184,13 +184,10 @@ class ValueMarshaller extends Marshaller
     private function extractValueFromCDATASection(DOMElement $element)
     {
         $valueChildNodes = self::getChildElements($element, true);
-        if (!empty($valueChildNodes)
-            && ($node = reset($valueChildNodes))
-            && $node->nodeType === XML_CDATA_SECTION_NODE
-        ) {
-            return trim($node->nodeValue);
-        } else {
-            return trim($element->nodeValue);
+        if (empty($valueChildNodes)) {
+            return '';
         }
+
+        return trim($valueChildNodes[0]->nodeValue);
     }
 }

--- a/test/qtismtest/data/storage/xml/marshalling/TemplateDeclarationMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/TemplateDeclarationMarshallerTest.php
@@ -26,7 +26,7 @@ class TemplateDeclarationMarshallerTest extends QtiSmTestCase
 
         $dom = new DOMDocument('1.0', 'UTF-8');
         $element = $dom->importNode($element, true);
-        $this::assertEquals('<templateDeclaration identifier="tpl1" cardinality="single" baseType="identifier"><defaultValue><value>tplx</value></defaultValue></templateDeclaration>', $dom->saveXML($element));
+        $this::assertEquals('<templateDeclaration identifier="tpl1" cardinality="single" baseType="identifier"><defaultValue><value><![CDATA[tplx]]></value></defaultValue></templateDeclaration>', $dom->saveXML($element));
     }
 
     public function testUnmarshall21()
@@ -60,7 +60,7 @@ class TemplateDeclarationMarshallerTest extends QtiSmTestCase
 
         $dom = new DOMDocument('1.0', 'UTF-8');
         $element = $dom->importNode($element, true);
-        $this::assertEquals('<templateDeclaration identifier="tpl1" cardinality="single" baseType="identifier" paramVariable="false" mathVariable="false"><defaultValue><value>tplx</value></defaultValue></templateDeclaration>', $dom->saveXML($element));
+        $this::assertEquals('<templateDeclaration identifier="tpl1" cardinality="single" baseType="identifier" paramVariable="false" mathVariable="false"><defaultValue><value><![CDATA[tplx]]></value></defaultValue></templateDeclaration>', $dom->saveXML($element));
     }
 
     public function testUnmarshall20NoParamVariable()

--- a/test/qtismtest/data/storage/xml/marshalling/ValueMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/ValueMarshallerTest.php
@@ -112,7 +112,24 @@ class ValueMarshallerTest extends QtiSmTestCase
         $marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($component);
         $element = $marshaller->marshall($component);
 
-        $this::assertSame('<value>Hello &lt;b&gt;bold&lt;/b&gt;</value>', $element->ownerDocument->saveXML($element));
+        $this::assertSame('<value><![CDATA[Hello <b>bold</b>]]></value>', $element->ownerDocument->saveXML($element));
+    }
+
+    public function testUnmarshallCDATAFallback()
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1">text</value>');
+        $element = $dom->documentElement;
+
+        $marshaller = $this->getMarshallerFactory('2.1.0')->createMarshaller($element, [BaseType::STRING]);
+        $component = $marshaller->unmarshall($element);
+        $this::assertEquals('text', $component->getValue());
+
+        $dom->loadXML('<value xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"><![CDATA[text]]></value>');
+        $element = $dom->documentElement;
+
+        $component = $marshaller->unmarshall($element);
+        $this::assertEquals('text', $component->getValue());
     }
 
     public function testUnmarshallNoValueStringExpected()

--- a/test/samples/ims/items/2_2_1/choice_aria.xml
+++ b/test/samples/ims/items/2_2_1/choice_aria.xml
@@ -2,12 +2,12 @@
 <assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="choice" title="Unattended Luggage" timeDependent="false" adaptive="false" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2p1.xsd">
   <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
     <correctResponse>
-      <value>ChoiceA</value>
+      <value><![CDATA[ChoiceA]]></value>
     </correctResponse>
   </responseDeclaration>
   <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
     <defaultValue>
-      <value>0</value>
+      <value><![CDATA[0]]></value>
     </defaultValue>
   </outcomeDeclaration>
   <itemBody>

--- a/test/samples/ims/items/2_2_2/choice.xml
+++ b/test/samples/ims/items/2_2_2/choice.xml
@@ -2,12 +2,12 @@
 <assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="choice" title="Unattended Luggage" timeDependent="false" adaptive="false" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2p2.xsd">
   <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
     <correctResponse>
-      <value>ChoiceA</value>
+      <value><![CDATA[ChoiceA]]></value>
     </correctResponse>
   </responseDeclaration>
   <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
     <defaultValue>
-      <value>0</value>
+      <value><![CDATA[0]]></value>
     </defaultValue>
   </outcomeDeclaration>
   <itemBody>

--- a/test/samples/ims/items/2_2_3/choice.xml
+++ b/test/samples/ims/items/2_2_3/choice.xml
@@ -2,12 +2,12 @@
 <assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="choice" title="Unattended Luggage" timeDependent="false" adaptive="false" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2p3.xsd">
   <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
     <correctResponse>
-      <value>ChoiceA</value>
+      <value><![CDATA[ChoiceA]]></value>
     </correctResponse>
   </responseDeclaration>
   <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
     <defaultValue>
-      <value>0</value>
+      <value><![CDATA[0]]></value>
     </defaultValue>
   </outcomeDeclaration>
   <itemBody>

--- a/test/samples/ims/items/2_2_4/choice.xml
+++ b/test/samples/ims/items/2_2_4/choice.xml
@@ -2,12 +2,12 @@
 <assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="choice" title="Unattended Luggage" timeDependent="false" adaptive="false" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 https://purl.imsglobal.org/spec/qti/v2p2/schema/xsd/imsqti_v2p2p4.xsd">
   <responseDeclaration identifier="RESPONSE" cardinality="single" baseType="identifier">
     <correctResponse>
-      <value>ChoiceA</value>
+      <value><![CDATA[ChoiceA]]></value>
     </correctResponse>
   </responseDeclaration>
   <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float">
     <defaultValue>
-      <value>0</value>
+      <value><![CDATA[0]]></value>
     </defaultValue>
   </outcomeDeclaration>
   <itemBody>

--- a/test/samples/results/simple-assessment-result-saved-to-string.xml
+++ b/test/samples/results/simple-assessment-result-saved-to-string.xml
@@ -7,60 +7,60 @@
   <testResult identifier="fixture-test-identifier" datestamp="2018-06-27T09:41:45+00:00">
     <responseVariable identifier="response-identifier" cardinality="single">
       <correctResponse>
-        <value>fixture-test-value1</value>
-        <value>fixture-test-value2</value>
+        <value><![CDATA[fixture-test-value1]]></value>
+        <value><![CDATA[fixture-test-value2]]></value>
       </correctResponse>
       <candidateResponse>
-        <value fieldIdentifier="test-id-1">fixture-test-value1</value>
-        <value fieldIdentifier="test-id-2">fixture-test-value2</value>
-        <value fieldIdentifier="test-id-3">fixture-test-value3</value>
+        <value fieldIdentifier="test-id-1"><![CDATA[fixture-test-value1]]></value>
+        <value fieldIdentifier="test-id-2"><![CDATA[fixture-test-value2]]></value>
+        <value fieldIdentifier="test-id-3"><![CDATA[fixture-test-value3]]></value>
       </candidateResponse>
     </responseVariable>
     <templateVariable identifier="response-identifier" cardinality="single">
-      <value>test1</value>
-      <value>test2</value>
+      <value><![CDATA[test1]]></value>
+      <value><![CDATA[test2]]></value>
     </templateVariable>
   </testResult>
   <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45+00:00" sessionStatus="final" sequenceIndex="2">
     <candidateComment>comment-fixture</candidateComment>
     <responseVariable identifier="fixture-identifier" cardinality="single" baseType="string" choiceSequence="value-id-1">
       <correctResponse>
-        <value>fixture-value1</value>
-        <value>fixture-value2</value>
+        <value><![CDATA[fixture-value1]]></value>
+        <value><![CDATA[fixture-value2]]></value>
       </correctResponse>
       <candidateResponse>
-        <value fieldIdentifier="value-id-1">fixture-value1</value>
-        <value fieldIdentifier="value-id-2">fixture-value2</value>
-        <value fieldIdentifier="value-id-3">fixture-value3</value>
+        <value fieldIdentifier="value-id-1"><![CDATA[fixture-value1]]></value>
+        <value fieldIdentifier="value-id-2"><![CDATA[fixture-value2]]></value>
+        <value fieldIdentifier="value-id-3"><![CDATA[fixture-value3]]></value>
       </candidateResponse>
     </responseVariable>
     <outcomeVariable identifier="fixture-identifier" cardinality="single" baseType="string" view="candidate" interpretation="fixture-interpretation" longInterpretation="http://fixture-interpretation" normalMinimum="2" normalMaximum="3" masteryValue="4">
-      <value>fixture-value1</value>
-      <value>fixture-value2</value>
-      <value>fixture-value3</value>
+      <value><![CDATA[fixture-value1]]></value>
+      <value><![CDATA[fixture-value2]]></value>
+      <value><![CDATA[fixture-value3]]></value>
     </outcomeVariable>
     <templateVariable identifier="fixture-identifier" cardinality="single" baseType="string">
-      <value>fixture-value1</value>
-      <value>fixture-value2</value>
-      <value>fixture-value3</value>
+      <value><![CDATA[fixture-value1]]></value>
+      <value><![CDATA[fixture-value2]]></value>
+      <value><![CDATA[fixture-value3]]></value>
     </templateVariable>
   </itemResult>
   <itemResult identifier="fixture-identifier" datestamp="2018-06-27T09:41:45+00:00" sessionStatus="final" sequenceIndex="2">
     <responseVariable identifier="fixture-identifier" cardinality="single" baseType="string" choiceSequence="value-id-1">
       <correctResponse>
-        <value>fixture-value1</value>
-        <value>fixture-value2</value>
+        <value><![CDATA[fixture-value1]]></value>
+        <value><![CDATA[fixture-value2]]></value>
       </correctResponse>
       <candidateResponse>
-        <value fieldIdentifier="value-id-1">fixture-value1</value>
-        <value fieldIdentifier="value-id-2">fixture-value2</value>
-        <value fieldIdentifier="value-id-3">fixture-value3</value>
+        <value fieldIdentifier="value-id-1"><![CDATA[fixture-value1]]></value>
+        <value fieldIdentifier="value-id-2"><![CDATA[fixture-value2]]></value>
+        <value fieldIdentifier="value-id-3"><![CDATA[fixture-value3]]></value>
       </candidateResponse>
     </responseVariable>
     <outcomeVariable identifier="fixture-identifier" cardinality="single" baseType="string" view="candidate" interpretation="fixture-interpretation" longInterpretation="http://fixture-interpretation" normalMinimum="2" normalMaximum="3" masteryValue="4">
-      <value>fixture-value1</value>
-      <value>fixture-value2</value>
-      <value>fixture-value3</value>
+      <value><![CDATA[fixture-value1]]></value>
+      <value><![CDATA[fixture-value2]]></value>
+      <value><![CDATA[fixture-value3]]></value>
     </outcomeVariable>
   </itemResult>
 </assessmentResult>


### PR DESCRIPTION
XML handling would break if xml not compatible html characters are used, like `&nbsp;`.
 
Related to : https://oat-sa.atlassian.net/browse/TR-1412

XML storage Value marshaller updated to enclose content in CDATA section.
  
#### How to test
 - author a test with Extended text interaction
 - publish the test and launch the delivery as a test taker
 - answer extended text interaction item with content containing non breaking spaces ` `, finish the test
 - verify that result extraction consumer processed results without failure
  