### PR TITLE
Fix TR-1412 XML-encode values

### DIFF
--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -124,7 +124,7 @@ class Utils
             $node = $stack->pop();
 
             if ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array($node, $traversed, true) === false) {
-                array_push($traversed, $node);
+                $traversed[] = $node;
                 $stack->push($node);
 
                 for ($i = 0; $i < $node->childNodes->length; $i++) {
@@ -144,9 +144,9 @@ class Utils
                     $newNode->appendChild(array_pop($children));
                 }
 
-                array_push($children, $newNode);
+                $children[] = $newNode;
             } else {
-                array_push($children, $node->cloneNode());
+                $children[] = $node->cloneNode();
             }
         }
 

--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -350,7 +350,7 @@ class Utils
         if (is_bool($value)) {
             return $value === true ? 'true' : 'false';
         }
-        return htmlspecialchars($value, ENT_XML1);
+        return htmlspecialchars($value, ENT_XML1, 'UTF-8');
     }
 
     /**

--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -297,7 +297,8 @@ class Utils
                 return $attr === 'true';
         }
 
-        if (in_array(Enumeration::class, class_implements($datatype), true)){
+        if (in_array(Enumeration::class, class_implements($datatype), true)) {
+            /** @var Enumeration $datatype */
             if ($attr !== null) {
                 $constant = $datatype::getConstantByName($attr);
                 // Returns the original value when it's unknown in the enumeration.
@@ -349,7 +350,7 @@ class Utils
         if (is_bool($value)) {
             return $value === true ? 'true' : 'false';
         }
-        return (string)$value;
+        return htmlspecialchars($value, ENT_XML1);
     }
 
     /**

--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -207,15 +207,14 @@ class Utils
      */
     public static function escapeXmlSpecialChars($string, $isAttribute = false)
     {
-        if ($isAttribute === false) {
-            $fullSearch = ['&', '"', "'", '<', '>'];
-            $fullReplace = ['&amp;', '&quot;', '&apos;', '&lt;', '&gt;'];
-            $string = str_replace($fullSearch, $fullReplace, $string);
-            return $string;
-        } else {
-            $string = str_replace(['&', '"'], ['&amp;', '&quot;'], $string);
-            return $string;
+        if ($isAttribute !== false) {
+            return str_replace(['&', '"'], ['&amp;', '&quot;'], $string);
         }
+
+        $fullSearch = ['&', '"', "'", '<', '>'];
+        $fullReplace = ['&amp;', '&quot;', '&apos;', '&lt;', '&gt;'];
+
+        return str_replace($fullSearch, $fullReplace, $string);
     }
 
     /**

--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -208,14 +208,12 @@ class Utils
     public static function escapeXmlSpecialChars($string, $isAttribute = false)
     {
         if ($isAttribute === false) {
-            $fullSearch = ['"', "'", '<', '>'];
-            $fullReplace = ['&quot;', '&apos;', '&lt;', '&gt;'];
-            $string = str_replace('&', '&amp;', $string);
+            $fullSearch = ['&', '"', "'", '<', '>'];
+            $fullReplace = ['&amp;', '&quot;', '&apos;', '&lt;', '&gt;'];
             $string = str_replace($fullSearch, $fullReplace, $string);
             return $string;
         } else {
-            $string = str_replace('&', '&amp;', $string);
-            $string = str_replace('"', '&quot;', $string);
+            $string = str_replace(['&', '"'], ['&amp;', '&quot;'], $string);
             return $string;
         }
     }

--- a/test/qtismtest/data/storage/xml/marshalling/TemplateDeclarationMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/TemplateDeclarationMarshallerTest.php
@@ -3,6 +3,7 @@
 namespace qtismtest\data\storage\xml\marshalling;
 
 use DOMDocument;
+use qtism\common\collections\AbstractCollection;
 use qtism\common\enums\BaseType;
 use qtism\common\enums\Cardinality;
 use qtism\data\state\DefaultValue;
@@ -46,6 +47,37 @@ class TemplateDeclarationMarshallerTest extends QtiSmTestCase
         $values = $default->getValues();
         $this::assertCount(1, $values);
         $this::assertEquals('tplx', $values[0]->getValue());
+    }
+
+    public function testMarshallHtmlEntities21()
+    {
+        $values = new ValueCollection([new Value('non&nbsp;breaking&nbsp;space', BaseType::STRING)]);
+        $defaultValue = new DefaultValue($values);
+        $templateDeclaration = new TemplateDeclaration('tpl1', BaseType::STRING, Cardinality::SINGLE, $defaultValue);
+        $element = $this->getMarshallerFactory('2.1.0')->createMarshaller($templateDeclaration)->marshall($templateDeclaration);
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $element = $dom->importNode($element, true);
+        $this::assertEquals('<templateDeclaration identifier="tpl1" cardinality="single" baseType="string"><defaultValue><value>non&amp;nbsp;breaking&amp;nbsp;space</value></defaultValue></templateDeclaration>', $dom->saveXML($element));
+    }
+
+    public function testUnmarshallHtmlEntities21()
+    {
+        $element = $this->createDOMElement('
+	        <templateDeclaration identifier="tpl1" cardinality="single" baseType="string"><defaultValue><value>non&amp;nbsp;breaking&amp;nbsp;space</value></defaultValue></templateDeclaration>
+	    ');
+
+        $component = $this->getMarshallerFactory('2.1.0')->createMarshaller($element)->unmarshall($element);
+        $this::assertInstanceOf(TemplateDeclaration::class, $component);
+        $this::assertEquals('tpl1', $component->getIdentifier());
+        $this::assertEquals(Cardinality::SINGLE, $component->getCardinality());
+        $this::assertEquals(BaseType::STRING, $component->getBaseType());
+
+        $default = $component->getDefaultValue();
+        $this::assertInstanceOf(DefaultValue::class, $default);
+        $values = $default->getValues();
+        $this::assertCount(1, $values);
+        $this::assertEquals('non&nbsp;breaking&nbsp;space', $values[0]->getValue());
     }
 
     public function testMarshall20()


### PR DESCRIPTION
## [TR-1412](https://oat-sa.atlassian.net/browse/TR-1412)

- fix: use array element addition operand instead of calling `array_push()` function within `qtism\data\storage\xml\Utils` methods
- chore: merge multiple `str_replace()` invocations into a single one in `qtism\data\storage\xml\Utils::escapeXmlSpecialChars()`
- chore: split `qtism\data\storage\xml\Utils::escapeXmlSpecialChars()` workflows
- fix: XML-encode a value before inserting it into DOM

This is an alternative solution to #291
_Legacy_ counterpart – #294
  
#### How to test
 - author a test with Extended text interaction
 - publish the test and launch the delivery as a test taker
 - answer extended text interaction item with content containing non breaking spaces ` `, finish the test
 - verify that result extraction consumer processed results without failure