### PR TITLE
Fix TR-1412 XML-encode values – CG

### DIFF
--- a/qtism/data/storage/xml/Utils.php
+++ b/qtism/data/storage/xml/Utils.php
@@ -262,7 +262,7 @@ class Utils
         if (is_bool($value)) {
             return $value === true ? 'true' : 'false';
         }
-        return (string)$value;
+        return htmlspecialchars($value, ENT_XML1);
     }
 
     /**

--- a/qtism/data/storage/xml/Utils.php
+++ b/qtism/data/storage/xml/Utils.php
@@ -262,7 +262,7 @@ class Utils
         if (is_bool($value)) {
             return $value === true ? 'true' : 'false';
         }
-        return htmlspecialchars($value, ENT_XML1);
+        return htmlspecialchars($value, ENT_XML1, 'UTF-8');
     }
 
     /**

--- a/qtism/data/storage/xml/Utils.php
+++ b/qtism/data/storage/xml/Utils.php
@@ -119,7 +119,7 @@ class Utils
             $node = $stack->pop();
 
             if ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array($node, $traversed, true) === false) {
-                array_push($traversed, $node);
+                $traversed[] = $node;
                 $stack->push($node);
 
                 for ($i = 0; $i < $node->childNodes->length; $i++) {
@@ -139,9 +139,9 @@ class Utils
                     $newNode->appendChild(array_pop($children));
                 }
 
-                array_push($children, $newNode);
+                $children[] = $newNode;
             } else {
-                array_push($children, $node->cloneNode());
+                $children[] = $node->cloneNode();
             }
         }
 

--- a/test/qtismtest/data/storage/xml/marshalling/TemplateDeclarationMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/TemplateDeclarationMarshallerTest.php
@@ -46,4 +46,35 @@ class TemplateDeclarationMarshallerTest extends QtiSmTestCase
         $this::assertCount(1, $values);
         $this::assertEquals('tplx', $values[0]->getValue());
     }
+
+    public function testMarshallHtmlEntities21()
+    {
+        $values = new ValueCollection([new Value('non&nbsp;breaking&nbsp;space', BaseType::STRING)]);
+        $defaultValue = new DefaultValue($values);
+        $templateDeclaration = new TemplateDeclaration('tpl1', BaseType::STRING, Cardinality::SINGLE, $defaultValue);
+        $element = $this->getMarshallerFactory('2.1.0')->createMarshaller($templateDeclaration)->marshall($templateDeclaration);
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $element = $dom->importNode($element, true);
+        $this::assertEquals('<templateDeclaration identifier="tpl1" cardinality="single" baseType="string"><defaultValue><value>non&amp;nbsp;breaking&amp;nbsp;space</value></defaultValue></templateDeclaration>', $dom->saveXML($element));
+    }
+
+    public function testUnmarshallHtmlEntities21()
+    {
+        $element = $this->createDOMElement('
+	        <templateDeclaration identifier="tpl1" cardinality="single" baseType="string"><defaultValue><value>non&amp;nbsp;breaking&amp;nbsp;space</value></defaultValue></templateDeclaration>
+	    ');
+
+        $component = $this->getMarshallerFactory('2.1.0')->createMarshaller($element)->unmarshall($element);
+        $this::assertInstanceOf(TemplateDeclaration::class, $component);
+        $this::assertEquals('tpl1', $component->getIdentifier());
+        $this::assertEquals(Cardinality::SINGLE, $component->getCardinality());
+        $this::assertEquals(BaseType::STRING, $component->getBaseType());
+
+        $default = $component->getDefaultValue();
+        $this::assertInstanceOf(DefaultValue::class, $default);
+        $values = $default->getValues();
+        $this::assertCount(1, $values);
+        $this::assertEquals('non&nbsp;breaking&nbsp;space', $values[0]->getValue());
+    }
 }


### PR DESCRIPTION
## [TR-1412](https://oat-sa.atlassian.net/browse/TR-1412)

- fix: use array element addition operand instead of calling `array_push()` function within `qtism\data\storage\xml\Utils` methods
- fix: XML-encode a value before inserting it into DOM

This is a _legacy_ counterpart to #293

#### How to test
 - author a test with Extended text interaction
 - publish the test and launch the delivery as a test taker
 - answer extended text interaction item with content containing non breaking spaces ` `, finish the test
 - verify that result extraction consumer processed results without failure