### PR TITLE
feat: allow item jump on linear test when manually set

### DIFF
--- a/src/qtism/runtime/tests/AssessmentTestSession.php
+++ b/src/qtism/runtime/tests/AssessmentTestSession.php
@@ -197,6 +197,15 @@ class AssessmentTestSession extends State
     private $config = 0;
 
     /**
+     * Whether or not allowing jump in any case.
+     *
+     * If enabled, jumps will be allowed even if the current navigation mode is linear.
+     *
+     * @var bool
+     */
+    private $alwaysAllowJumps = false;
+
+    /**
      * Create a new AssessmentTestSession object.
      *
      * @param AssessmentTest $assessmentTest The AssessmentTest object which represents the assessmenTest the context belongs to.
@@ -669,6 +678,18 @@ class AssessmentTestSession extends State
     }
 
     /**
+     * Set whether or not to always allow jumps.
+     *
+     * When turned on, jumps will be allowed even if the current navigation mode is linear.
+     *
+     * @param bool $alwaysAllowJumps
+     */
+    public function setAlwaysAllowJumps($alwaysAllowJumps)
+    {
+        $this->alwaysAllowJumps = $alwaysAllowJumps;
+    }
+
+    /**
      * Know whether or not to always allow jumps.
      *
      * When turned on, jumps will be allowed even if the current navigation mode is linear.
@@ -677,7 +698,7 @@ class AssessmentTestSession extends State
      */
     public function mustAlwaysAllowJumps()
     {
-        return (bool)($this->getConfig() & self::ALWAYS_ALLOW_JUMPS);
+        return (bool)($this->getConfig() & self::ALWAYS_ALLOW_JUMPS) || $this->alwaysAllowJumps;
     }
 
     /**

--- a/src/qtism/runtime/tests/AssessmentTestSession.php
+++ b/src/qtism/runtime/tests/AssessmentTestSession.php
@@ -698,7 +698,7 @@ class AssessmentTestSession extends State
      */
     public function mustAlwaysAllowJumps()
     {
-        return (bool)($this->getConfig() & self::ALWAYS_ALLOW_JUMPS) || $this->alwaysAllowJumps;
+        return $this->alwaysAllowJumps || (bool)($this->getConfig() & self::ALWAYS_ALLOW_JUMPS);
     }
 
     /**

--- a/test/qtismtest/runtime/tests/AssessmentTestSessionTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentTestSessionTest.php
@@ -2056,6 +2056,13 @@ class AssessmentTestSessionTest extends QtiSmAssessmentTestSessionTestCase
 
         $assessmentTestSession->jumpTo(1);
         $this::assertEquals(1, $assessmentTestSession->getRoute()->getPosition());
+
+        $assessmentTestSession = self::instantiate(self::samplesDir() . 'custom/runtime/linear_5_items.xml', false);
+        $assessmentTestSession->setAlwaysAllowJumps(true);
+        $assessmentTestSession->beginTestSession();
+
+        $assessmentTestSession->jumpTo(1);
+        $this::assertEquals(1, $assessmentTestSession->getRoute()->getPosition());
     }
 
     public function testSetSessionIdEmptyString()


### PR DESCRIPTION
[TR-1264](https://oat-sa.atlassian.net/browse/TR-1264)

Allow jump navigation on test session for linear tests when manually set