### PR TITLE
feature: add support of 'list' type

### DIFF
--- a/test/qtismtest/runtime/pci/json/JsonUnmarshallerTest.php
+++ b/test/qtismtest/runtime/pci/json/JsonUnmarshallerTest.php
@@ -103,8 +103,8 @@ class JsonUnmarshallerTest extends QtiSmTestCase
 
         $json = sprintf(
             '{ "base" : { "%s" : {
-            "mime" : "%s", 
-            "data" : "%s", 
+            "mime" : "%s",
+            "data" : "%s",
             "name" : "%s",
             "id" : "%s" } } }',
             FileHash::FILE_HASH_KEY,
@@ -374,5 +374,30 @@ class JsonUnmarshallerTest extends QtiSmTestCase
             ['{ "liste" : { "boolean" : true } } '],
             ['{ "record" : [ { "namez" } ] '],
         ];
+    }
+
+    public function testUnmarshallListWithinRecord()
+    {
+        $unmarshaller = self::createUnmarshaller();
+        $json = '
+            {
+                "record": [
+                    { "name" : "Søyler", "list": {"string" : ["SØYLE 1: navn=1, verdi=3", "SØYLE 2: navn=1, verdi=4"] } }
+                ]
+            }
+        ';
+
+        $container = $unmarshaller->unmarshall($json);
+        $list = $container->getArrayCopy(true);
+
+        $key = "Søyler";
+
+        $this::assertTrue(array_key_exists($key, $list) );
+
+        $list = $list[$key];
+        $items = $list->getArrayCopy();
+
+        $this::assertEquals("SØYLE 1: navn=1, verdi=3", $items[0]->getValue());
+        $this::assertEquals("SØYLE 2: navn=1, verdi=4", $items[1]->getValue());
     }
 }


### PR DESCRIPTION
# [TR-1351](https://oat-sa.atlassian.net/browse/TR-1351)

<General Information>
Have added support of 'list' type and fix incorrect response in case of 'list' types

## How to test (Solar)
1. Install [composer.zip](https://github.com/oat-sa/qti-sdk/files/7419449/composer.zip)
2. Publish [the test](https://github.com/oat-sa/qti-sdk/files/7399504/tegn_diagram_-_rp_test_1616664085.zip)
3. Complete the test and see the similar response in a result (in var/results)
![image](https://user-images.githubusercontent.com/35266384/138912543-15ef1058-b411-4bb0-8ffd-04531decce47.png)
4. Run unit-tests



