### PR TITLE
fix: remove checking caret & dollar, add test

### DIFF
--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -191,7 +191,7 @@ class Utils
      */
     public static function pregAddDelimiter(string $string)
     {
-        return '/'.static::escapeSymbols($string, '/').'/';
+        return '/' . static::escapeSymbols($string, '/') . '/';
     }
 
     /**

--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -82,7 +82,8 @@ class Utils
      * Compute the arithmetic mean of $sample.
      *
      * @param array An array of numeric values.
-     * @return false|number The arithmetic mean of $sample or false if any of the values of $sample is not numeric or if $sample is empty.
+     * @return false|number The arithmetic mean of $sample or false if any of the values of $sample is not numeric or
+     *     if $sample is empty.
      */
     public static function mean(array $sample)
     {
@@ -117,7 +118,7 @@ class Utils
      * returns false.
      *
      * @param array $sample An array of numeric values.
-     * @param bool $correction (optional) Apply the Bessel's correction on the computed variance.
+     * @param bool  $correction (optional) Apply the Bessel's correction on the computed variance.
      * @return false|number The variance of $sample or false if $sample is empty or contains non-numeric values.
      * @link http://en.wikipedia.org/wiki/Variance#Population_variance_and_sample_variance
      */
@@ -154,7 +155,8 @@ class Utils
     /**
      * Compute the standard deviation of $sample.
      *
-     * * To compute the population standard deviation: $sample is considered as a population if $correction equals false.
+     * * To compute the population standard deviation: $sample is considered as a population if $correction equals
+     * false.
      * * To compute the sample standard deviation: $sample is considered as sample if $correction equals true.
      *
      * IMPORTANT:
@@ -162,8 +164,9 @@ class Utils
      * returns false.
      *
      * @param array $sample An array of numeric values.
-     * @param bool $correction (optional) Whether to apply Bessel's correction.
-     * @return false|number The standard deviation of $sample or false if $sample is empty or contains non-numeric values.
+     * @param bool  $correction (optional) Whether to apply Bessel's correction.
+     * @return false|number The standard deviation of $sample or false if $sample is empty or contains non-numeric
+     *     values.
      * @link http://en.wikipedia.org/wiki/Variance#Population_variance_and_sample_variance
      */
     public static function standardDeviation(array $sample, $correction = true)
@@ -188,14 +191,14 @@ class Utils
      */
     public static function pregAddDelimiter($string)
     {
-        return '/' . static::escapeSymbols($string, '/') . '/';
+        return '/'.static::escapeSymbols($string, '/').'/';
     }
 
     /**
      * Get the amout of backslash (\) characters in $string that precede $offset.
      *
      * @param string $string
-     * @param int $offset
+     * @param int    $offset
      * @return int
      */
     public static function getPrecedingBackslashesCount($string, $offset)
@@ -218,11 +221,11 @@ class Utils
     /**
      * Escape with a backslash (\) the $symbols in $string.
      *
-     * @param string $string
+     * @param string       $string
      * @param array|string $symbols An array of symbols or a single symbol.
      * @return string The escaped string.
      */
-    public static function escapeSymbols(string $string, $symbols)
+    public static function escapeSymbols(string $string, $symbols): string
     {
         if (!is_array($symbols)) {
             $symbols = [$symbols];
@@ -238,9 +241,9 @@ class Utils
             // If the amount of preceding backslashes is even, it is not escaped.
             // If a caret is preceded by a left bracket, don't escape it
             if ((in_array($char, $symbols)) && static::getPrecedingBackslashesCount($string, $i) % 2 === 0
-                && ($i === 0 || $char !== '^' || $string[$i-1] !== '[')
+                && ($i === 0 || $char !== '^' || $string[$i - 1] !== '[')
             ) {
-                // It is not escaped, so ecape it.
+                // It is not escaped, so escape it.
                 $returnValue .= '\\';
             }
 
@@ -255,7 +258,8 @@ class Utils
      * fully qualified class name e.g. 'org\qtism\custom\Explode'.
      *
      * @param string $class A custom operator class name where namespace separator is '.' (dot).
-     * @return bool|string A fully qualified PHP class name corresponding to $class or false if the transformation failed.
+     * @return bool|string A fully qualified PHP class name corresponding to $class or false if the transformation
+     *     failed.
      */
     public static function customOperatorClassToPhpClass($class)
     {
@@ -329,15 +333,17 @@ class Utils
      * @param string $pattern
      * @return string
      */
-    public static function prepareXsdPatternForPcre($pattern)
+    public static function prepareXsdPatternForPcre($pattern): string
     {
         // XML schema always implicitly anchors the entire regular expression
         // Neither caret (^) nor dollar ($) sign have special meaning so they are
         // considered as normal characters.
         // see http://www.regular-expressions.info/xml.html
-//        $pattern = self::escapeSymbols($pattern, ['$', '^']);
-        $pattern = self::beginsCaret($pattern);
-        $pattern = self::endDollar($pattern);
+        $pattern = self::removeCaretFromBegging($pattern);
+        $pattern = self::removeDollarFromEnd($pattern);
+        $pattern = self::escapeSymbols($pattern, ['$', '^']);
+        $pattern = self::withStartOfStringToken($pattern);
+        $pattern = self::withEndOfStringToken($pattern);
         $pattern = self::pregAddDelimiter($pattern);
 
         // XSD regexp always case-sensitive (nothing to do), dot matches white-spaces (use PCRE_DOTALL).
@@ -346,7 +352,26 @@ class Utils
         return $pattern;
     }
 
-    private static function beginsCaret(string $pattern): string
+    private static function removeCaretFromBegging(string $pattern): string
+    {
+        if ($pattern[0] === '^' && ($pattern[1] === '[' || $pattern[1] === '(' || $pattern[1] === '{')) {
+            $pattern = ltrim($pattern, '^');
+        }
+
+        return $pattern;
+    }
+
+    private static function removeDollarFromEnd(string $pattern): string
+    {
+        $length = strlen($pattern) - 1;
+        if ($pattern[$length] === '$' && ($pattern[$length - 1] === ']' || $pattern[$length - 1] === ')' || $pattern[$length - 1] === '}' || $pattern[$length - 1] === '+')) {
+            $pattern = rtrim($pattern, '$');
+        }
+
+        return $pattern;
+    }
+
+    private static function withStartOfStringToken(string $pattern): string
     {
         if (substr($pattern, 0, 1) !== '^') {
             $pattern = '^'.$pattern;
@@ -355,7 +380,7 @@ class Utils
         return $pattern;
     }
 
-    private static function endDollar(string $pattern): string
+    private static function withEndOfStringToken(string $pattern): string
     {
         if ($pattern[strlen($pattern) - 1] !== '$') {
             $pattern = $pattern.'$';

--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -333,59 +333,26 @@ class Utils
      * @param string $pattern
      * @return string
      */
-    public static function prepareXsdPatternForPcre($pattern): string
-    {
-        // XML schema always implicitly anchors the entire regular expression
-        // Neither caret (^) nor dollar ($) sign have special meaning so they are
-        // considered as normal characters.
-        // see http://www.regular-expressions.info/xml.html
-        $pattern = self::removeCaretFromBegging($pattern);
-        $pattern = self::removeDollarFromEnd($pattern);
-        $pattern = self::escapeSymbols($pattern, ['$', '^']);
-        $pattern = self::withStartOfStringToken($pattern);
-        $pattern = self::withEndOfStringToken($pattern);
-        $pattern = self::pregAddDelimiter($pattern);
+     public static function prepareXsdPatternForPcre(string $pattern): string
+     {
+         // XML schema always implicitly anchors the entire regular expression
+         // Neither caret (^) nor dollar ($) sign have special meaning so they are
+         // considered as normal characters.
+         // see http://www.regular-expressions.info/xml.html
+         $pattern = self::withoutStringAnchors($pattern);
+         $pattern = self::escapeSymbols($pattern, ['$', '^']);
+         $pattern = self::pregAddDelimiter('^' . $pattern . '$');
 
-        // XSD regexp always case-sensitive (nothing to do), dot matches white-spaces (use PCRE_DOTALL).
-        $pattern .= 's';
+         // XSD regexp always case-sensitive (nothing to do), dot matches white-spaces (use PCRE_DOTALL).
+         $pattern .= 's';
 
-        return $pattern;
-    }
+         return $pattern;
+     }
 
-    private static function removeCaretFromBegging(string $pattern): string
-    {
-        if ($pattern[0] === '^' && ($pattern[1] === '[' || $pattern[1] === '(' || $pattern[1] === '{')) {
-            $pattern = ltrim($pattern, '^');
-        }
+     private static function withoutStringAnchors(string $pattern): string
+     {
+         $pattern = ltrim($pattern, '^');
 
-        return $pattern;
-    }
-
-    private static function removeDollarFromEnd(string $pattern): string
-    {
-        $length = strlen($pattern) - 1;
-        if ($pattern[$length] === '$' && ($pattern[$length - 1] === ']' || $pattern[$length - 1] === ')' || $pattern[$length - 1] === '}' || $pattern[$length - 1] === '+')) {
-            $pattern = rtrim($pattern, '$');
-        }
-
-        return $pattern;
-    }
-
-    private static function withStartOfStringToken(string $pattern): string
-    {
-        if (substr($pattern, 0, 1) !== '^') {
-            $pattern = '^'.$pattern;
-        }
-
-        return $pattern;
-    }
-
-    private static function withEndOfStringToken(string $pattern): string
-    {
-        if ($pattern[strlen($pattern) - 1] !== '$') {
-            $pattern = $pattern.'$';
-        }
-
-        return $pattern;
-    }
+         return rtrim($pattern, '$');
+     }
 }

--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -222,7 +222,7 @@ class Utils
      * @param array|string $symbols An array of symbols or a single symbol.
      * @return string The escaped string.
      */
-    public static function escapeSymbols($string, $symbols)
+    public static function escapeSymbols(string $string, $symbols)
     {
         if (!is_array($symbols)) {
             $symbols = [$symbols];
@@ -335,11 +335,31 @@ class Utils
         // Neither caret (^) nor dollar ($) sign have special meaning so they are
         // considered as normal characters.
         // see http://www.regular-expressions.info/xml.html
-        $pattern = self::escapeSymbols($pattern, ['$', '^']);
-        $pattern = self::pregAddDelimiter('^' . $pattern . '$');
+//        $pattern = self::escapeSymbols($pattern, ['$', '^']);
+        $pattern = self::beginsCaret($pattern);
+        $pattern = self::endDollar($pattern);
+        $pattern = self::pregAddDelimiter($pattern);
 
         // XSD regexp always case-sensitive (nothing to do), dot matches white-spaces (use PCRE_DOTALL).
         $pattern .= 's';
+
+        return $pattern;
+    }
+
+    private static function beginsCaret(string $pattern): string
+    {
+        if (substr($pattern, 0, 1) !== '^') {
+            $pattern = '^'.$pattern;
+        }
+
+        return $pattern;
+    }
+
+    private static function endDollar(string $pattern): string
+    {
+        if ($pattern[strlen($pattern) - 1] !== '$') {
+            $pattern = $pattern.'$';
+        }
 
         return $pattern;
     }

--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -189,7 +189,7 @@ class Utils
      * @param string $string
      * @return string|bool The delimited string or false if no appropriate delimiters can be found.
      */
-    public static function pregAddDelimiter($string)
+    public static function pregAddDelimiter(string $string)
     {
         return '/'.static::escapeSymbols($string, '/').'/';
     }

--- a/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
+++ b/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
@@ -353,15 +353,20 @@ class OperatorsUtilsTest extends QtiSmTestCase
     public function patternForPcreProvider(): array
     {
         return [
-            'max 5 chars string pattern' => ['[\s\S]{0,5}', '/^[\s\S]{0,5}$/s'],
-            'max 5 chars string pattern with caret and dollar' => ['^[\s\S]{0,5}$', '/^[\s\S]{0,5}$/s'],
-            'only digits pattern' => ['[0,1]+', '/^[0,1]+$/s'],
-            'only digits pattern v2' => ['^[0,1]+$', '/^[0,1]+$/s'],
-            'max 5 words pattern' => [
+            'max chars string pattern without anchors' => ['[\s\S]{0,5}', '/^[\s\S]{0,5}$/s'],
+            'max chars string pattern with anchors' => ['^[\s\S]{0,5}$', '/^[\s\S]{0,5}$/s'],
+            'digits only pattern' => ['[0,1]+', '/^[0,1]+$/s'],
+            'digits only pattern with anchors' => ['^[0,1]+$', '/^[0,1]+$/s'],
+            'string prefix without anchors' => ['test(.*)', '/^test(.*)$/s'],
+            'string prefix with anchors' => ['^test(.*)$', '/^test(.*)$/s'],
+            'max words pattern without anchors' => [
                 '(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}',
                 '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/s',
             ],
-            ['10$ are 10$', '/^10\\$ are 10\\$/s'],
+            'max words pattern with anchors' => [
+                '^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$',
+                '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/s',
+            ],
         ];
     }
 }

--- a/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
+++ b/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
@@ -350,16 +350,18 @@ class OperatorsUtilsTest extends QtiSmTestCase
         ];
     }
 
-    public function patternForPcreProvider()
+    public function patternForPcreProvider(): array
     {
         return [
-            'max 5 chars string pattern' => ['^[\s\S]{0,5}$', '/^[\s\S]{0,5}$/s'],
+            'max 5 chars string pattern' => ['[\s\S]{0,5}', '/^[\s\S]{0,5}$/s'],
+            'max 5 chars string pattern with caret and dollar' => ['^[\s\S]{0,5}$', '/^[\s\S]{0,5}$/s'],
             'only digits pattern' => ['[0,1]+', '/^[0,1]+$/s'],
             'only digits pattern v2' => ['^[0,1]+$', '/^[0,1]+$/s'],
             'max 5 words pattern' => [
-                '^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$',
+                '(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}',
                 '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/s',
             ],
+            ['10$ are 10$', '/^10\\$ are 10\\$/s'],
         ];
     }
 }

--- a/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
+++ b/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
@@ -163,6 +163,14 @@ class OperatorsUtilsTest extends QtiSmTestCase
     }
 
     /**
+     * @dataProvider patternForPcreProvider
+     */
+    public function testPrepareXsdPatternForPcre($pattern, $expected)
+    {
+        $this->assertEquals($expected, OperatorsUtils::prepareXsdPatternForPcre($pattern));
+    }
+
+    /**
      * @return array
      */
     public function pregAddDelimiterProvider()
@@ -333,8 +341,25 @@ class OperatorsUtilsTest extends QtiSmTestCase
         return [
             ['', 'foobar', 'PCRE Engine internal error'],
             ['/***', 'foobar', 'PCRE Engine internal error'],
-            ['/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar', 'PCRE Engine backtrack limit exceeded'],
+            [
+                '/(?:\D+|<\d+>)*[!?]/',
+                'foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar',
+                'PCRE Engine backtrack limit exceeded',
+            ],
             ['/abc/u', "\xa0\xa1", 'PCRE Engine malformed UTF-8 error'],
+        ];
+    }
+
+    public function patternForPcreProvider()
+    {
+        return [
+            'max 5 chars string pattern' => ['^[\s\S]{0,5}$', '/^[\s\S]{0,5}$/s'],
+            'only digits pattern' => ['[0,1]+', '/^[0,1]+$/s'],
+            'only digits pattern v2' => ['^[0,1]+$', '/^[0,1]+$/s'],
+            'max 5 words pattern' => [
+                '^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$',
+                '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/s',
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-3373

## Summary
What is it about?
ExtendedText or InlineText with pattern: submit fails if validateResponses is set

## How to test
1. Create item with constraint (pattern) or max words or max length
2. In test set "Validate Response"
3. Check test is working correct (in wrong variant it gives 500)

## Dependencies
No dependencies

## Sandbox environment
TODO