### PR TITLE
fix/tr-3373: update removing caret and dollar, update tests

### DIFF
--- a/qtism/runtime/expressions/operators/Utils.php
+++ b/qtism/runtime/expressions/operators/Utils.php
@@ -330,12 +330,13 @@ class Utils
      * @param string $pattern
      * @return string
      */
-    public static function prepareXsdPatternForPcre($pattern)
+    public static function prepareXsdPatternForPcre(string $pattern): string
     {
-        // XML schema always implicitly anchors the entire regular expression.
-        // Neither caret (^) nor dollar ($) sign have special meaning so they
-        // are considered normal characters.
+        // XML schema always implicitly anchors the entire regular expression
+        // Neither caret (^) nor dollar ($) sign have special meaning so they are
+        // considered as normal characters.
         // see http://www.regular-expressions.info/xml.html
+        $pattern = self::withoutStringAnchors($pattern);
         $pattern = self::escapeSymbols($pattern, ['$', '^']);
         $pattern = self::pregAddDelimiter('^' . $pattern . '$');
 
@@ -343,5 +344,12 @@ class Utils
         $pattern .= 's';
 
         return $pattern;
+    }
+
+    private static function withoutStringAnchors(string $pattern): string
+    {
+        $pattern = ltrim($pattern, '^');
+
+        return rtrim($pattern, '$');
     }
 }

--- a/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
+++ b/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
@@ -163,6 +163,14 @@ class OperatorsUtilsTest extends QtiSmTestCase
     }
 
     /**
+     * @dataProvider patternForPcreProvider
+     */
+    public function testPrepareXsdPatternForPcre($pattern, $expected)
+    {
+        $this->assertEquals($expected, OperatorsUtils::prepareXsdPatternForPcre($pattern));
+    }
+
+    /**
      * @return array
      */
     public function pregAddDelimiterProvider()
@@ -332,6 +340,26 @@ class OperatorsUtilsTest extends QtiSmTestCase
             ['/***', 'foobar', 'PCRE Engine internal error'],
             ['/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar', 'PCRE Engine backtrack limit exceeded'],
             ['/abc/u', "\xa0\xa1", 'PCRE Engine malformed UTF-8 error'],
+        ];
+    }
+
+    public function patternForPcreProvider(): array
+    {
+        return [
+            'max chars string pattern without anchors' => ['[\s\S]{0,5}', '/^[\s\S]{0,5}$/s'],
+            'max chars string pattern with anchors' => ['^[\s\S]{0,5}$', '/^[\s\S]{0,5}$/s'],
+            'digits only pattern' => ['[0,1]+', '/^[0,1]+$/s'],
+            'digits only pattern with anchors' => ['^[0,1]+$', '/^[0,1]+$/s'],
+            'string prefix without anchors' => ['test(.*)', '/^test(.*)$/s'],
+            'string prefix with anchors' => ['^test(.*)$', '/^test(.*)$/s'],
+            'max words pattern without anchors' => [
+                '(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}',
+                '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/s',
+            ],
+            'max words pattern with anchors' => [
+                '^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$',
+                '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/s',
+            ],
         ];
     }
 }

--- a/test/qtismtest/runtime/expressions/operators/PatternMatchProcessorTest.php
+++ b/test/qtismtest/runtime/expressions/operators/PatternMatchProcessorTest.php
@@ -107,7 +107,7 @@ class PatternMatchProcessorTest extends QtiSmTestCase
             [new QtiString('string'), 'shell', false],
             [new QtiString('stringString'), '.*', true], // in xml schema 2, dot matches white-spaces
             [new QtiString('^String$'), 'String', false], // No carret nor dollar in xml schema 2
-            [new QtiString('^String$'), '^String$', true],
+            [new QtiString('^String$'), '\^String\$', true],
             [new QtiString('^String'), '[^String]*', false],
             [new QtiString('aaa'), '[^String]*', true],
             [new QtiString('Str/ing'), 'Str/ing', true],


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-3373

## Summary
What is it about?
ExtendedText or InlineText with pattern: submit fails if validateResponses is set

## How to test
1. already tested

## Dependencies
No dependencies

## Sandbox environment
TODO