### PR TITLE
fix: selection of required and not required items

### DIFF
--- a/src/qtism/runtime/tests/BasicSelection.php
+++ b/src/qtism/runtime/tests/BasicSelection.php
@@ -74,12 +74,13 @@ class BasicSelection extends AbstractSelection
 
                     if ($withReplacement === false) {
                         unset($selectionBag[$baseIndex]);
-                        $selectionBag = array_values($selectionBag);
                         $selectionBagCount--;
                         $select--;
                     }
                 }
             }
+            // reset indexes for remaining selections
+            $selectionBag = array_values($selectionBag);
 
             for ($i = 0; $i < $select; $i++) {
                 $selectedIndex = mt_rand(0, $selectionBagCount - 1);

--- a/test/qtismtest/runtime/tests/BasicSelectionTest.php
+++ b/test/qtismtest/runtime/tests/BasicSelectionTest.php
@@ -2,6 +2,8 @@
 
 namespace qtismtest\runtime\tests;
 
+use qtism\data\AssessmentItemRef;
+use qtism\data\SectionPart;
 use qtism\data\storage\xml\XmlDocument;
 use qtism\runtime\tests\BasicSelection;
 use qtism\runtime\tests\SelectableRoute;
@@ -55,6 +57,38 @@ class BasicSelectionTest extends QtiSmTestCase
 
         $this::assertFalse($routeCheck1 === true && $routeCheck2 === true);
         $this::assertTrue($routeCheck1 === true || $routeCheck2 === true);
+
+    }
+
+    public function testSelectRequired()
+    {
+        $doc = new XmlDocument();
+        $doc->load(self::samplesDir() . 'custom/runtime/selection_ordering/selection_and_ordering.xml');
+
+        $testPart = $doc->getDocumentComponent()->getComponentByIdentifier('testPart');
+
+        $s04 = $doc->getDocumentComponent()->getComponentByIdentifier('S04', true);
+        $this::assertEquals('S04', $s04->getIdentifier());
+
+        $s04RouteCollection = new SelectableRouteCollection();
+
+        /** @var SectionPart $sectionPart */
+        foreach ($s04->getSectionParts() as $sectionPart) {
+            $route = new SelectableRoute();
+            $route->addRouteItem($sectionPart, $s04, $testPart, $doc->getDocumentComponent());
+            $route->setRequired($sectionPart->isRequired());
+            $s04RouteCollection->attach($route);
+        }
+
+        $selection = new BasicSelection($s04, $s04RouteCollection);
+        $selectedRoutes = $selection->select();
+        $itemRefs = [];
+        foreach ($selectedRoutes as $r) {
+            foreach ($r->getAssessmentItemRefs() as $itemRef) {
+                $itemRefs[] = $itemRef->getIdentifier();
+            }
+        }
+        $this::assertEquals(5, count(array_unique($itemRefs)));
     }
 
     /**

--- a/test/samples/custom/runtime/selection_ordering/selection_and_ordering.xml
+++ b/test/samples/custom/runtime/selection_ordering/selection_and_ordering.xml
@@ -28,5 +28,13 @@
 			<assessmentItemRef identifier="Q11" href="./Q11.xml" fixed="false" timeDependent="false"/>
 			<assessmentItemRef identifier="Q12" href="./Q12.xml" fixed="false" timeDependent="false"/>
 		</assessmentSection>
+		<assessmentSection identifier="S04" fixed="false" title="Section S04" visible="true">
+			<selection select="5"/>
+			<assessmentItemRef identifier="Q1" required="false" href="./Q1.xml" fixed="false" timeDependent="false" />
+			<assessmentItemRef identifier="Q2" required="true" href="./Q2.xml" fixed="false" timeDependent="false" />
+			<assessmentItemRef identifier="Q3" required="false" href="./Q3.xml" fixed="false" timeDependent="false" />
+			<assessmentItemRef identifier="Q7" required="true" href="./Q7.xml" fixed="false" timeDependent="false" />
+			<assessmentItemRef identifier="Q8" required="false" href="./Q8.xml" fixed="false" timeDependent="false" />
+		</assessmentSection>
 	</testPart>
 </assessmentTest>


### PR DESCRIPTION
Fixed and issue with item/section selection algorithm. Whenever required and non-required are in the route, the selection would go wrong and required item got selected several times.
 
Related to : https://oat-sa.atlassian.net/browse/TR-3645
 
#### How to test
 
- take a test attached to the linked ticket
- make sure that the execution does not freeze during the test and can be completed, 5 items are presented
   
Companion legacy PR :
 - [ ] https://github.com/oat-sa/qti-sdk/pull/309