### PR TITLE
bugfix/TR-3299 update condition for review mode

### DIFF
--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -703,7 +703,7 @@ class AssessmentItemSession extends State
                 $identifier = $this->getAssessmentItem()->getIdentifier();
                 $msg = "A new attempt for item '${identifier}' is not allowed. The submissionMode is simultaneous and the only accepted attempt is already begun.";
                 throw new AssessmentItemSessionException($msg, $this, AssessmentItemSessionException::ATTEMPTS_OVERFLOW);
-            } elseif ($submissionMode === SubmissionMode::INDIVIDUAL && $maxAttempts !== 0 && $numAttempts >= $maxAttempts) {
+            } elseif (($submissionMode === SubmissionMode::INDIVIDUAL && $maxAttempts !== 0 && $numAttempts >= $maxAttempts) && !$this->itemSessionControl->doesAllowReview()) {
                 $identifier = $this->getAssessmentItem()->getIdentifier();
                 $msg = "A new attempt for item '${identifier}' is not allowed. The maximum number of attempts (${maxAttempts}) is reached.";
                 throw new AssessmentItemSessionException($msg, $this, AssessmentItemSessionException::ATTEMPTS_OVERFLOW);


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-3299

## Summary
Review mode fails when first item has maxAttempts, and all of them are used

## How to test
1. as a TT user launch a test from Preconditions
2. use all attempts for Item1  
3. finish test
4. launch the same test by the same user with Review mode claims
      { "https://purl.imsglobal.org/spec/lti/claim/custom": {
        "deliverySettings.review.enabled": true,
        "deliverySettings.review.showCorrect": true,
        "deliverySettings.review.showScore": true
      }}

## Dependencies
No dependencies

## Sandbox environment
TODO