### PR TITLE
fix: TR-4282 remove etxtra validation if item contain several iterrac…

### DIFF
--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -797,10 +797,6 @@ class AssessmentItemSession extends State
             $this->mergeResponses($responses);
         }
 
-        if ($this->isExternallyScored($this->assessmentItem->getOutcomeDeclarations())) {
-            $responseProcessing = false;
-        }
-
         // Apply response processing.
         // As per QTI 2.1 specs, For Non-adaptive Items, the values of the outcome variables are reset to their
         // default values prior to each invocation of responseProcessing. For Adaptive Items the outcome variables

--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -1404,25 +1404,6 @@ class AssessmentItemSession extends State
     }
 
     /**
-     * Method will determine if an item is externally scored
-     * Item that contain externalScored attribute in OutcomeDeclaration is considered as item externally scored
-     *
-     * @param OutcomeDeclarationCollection $outcomeDeclarations
-     * @return bool
-     */
-    private function isExternallyScored(OutcomeDeclarationCollection $outcomeDeclarations)
-    {
-        /** @var OutcomeDeclaration $outcomeDeclaration */
-        foreach ($outcomeDeclarations as $outcomeDeclaration) {
-            if ($outcomeDeclaration->isExternallyScored()) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * @see \qtism\common\collections\AbstractCollection::__clone()
      */
     public function __clone()


### PR DESCRIPTION
[TR-4282](https://oat-sa.atlassian.net/browse/TR-4282)

Looks like that if is overhead for that case, Little down in a code we see that we load rules and no rules. If element required external score we don't have rules for it, so logic working correct.

--------

[DEMO VIDEO ](https://www.loom.com/share/3c720f3dc6184d069f97e82928ceae42)