### PR TITLE
Fix/tr 4332/patternmask length validation

### DIFF
--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -350,10 +350,16 @@ class Utils
         return $pattern;
     }
 
-     private static function withoutStringAnchors(string $pattern): string
-     {
-         $pattern = ltrim($pattern, '^');
+    /**
+     * Remove start and end anchors from a pattern.
+     *
+     * @param string $pattern
+     * @return string
+     */
+    private static function withoutStringAnchors(string $pattern): string
+    {
+        $pattern = ltrim($pattern, '^');
 
-         return rtrim($pattern, '$');
-     }
+        return rtrim($pattern, '$');
+    }
 }

--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -331,23 +331,25 @@ class Utils
      * Prepare an XSD Regular Expression pattern into a PCRE compliant one.
      *
      * @param string $pattern
+     * @param string $pcreFlags
      * @return string
      */
-     public static function prepareXsdPatternForPcre(string $pattern): string
-     {
-         // XML schema always implicitly anchors the entire regular expression
-         // Neither caret (^) nor dollar ($) sign have special meaning so they are
-         // considered as normal characters.
-         // see http://www.regular-expressions.info/xml.html
-         $pattern = self::withoutStringAnchors($pattern);
-         $pattern = self::escapeSymbols($pattern, ['$', '^']);
-         $pattern = self::pregAddDelimiter('^' . $pattern . '$');
+    public static function prepareXsdPatternForPcre(string $pattern, string $pcreFlags = ''): string
+    {
+        // XML schema always implicitly anchors the entire regular expression
+        // Neither caret (^) nor dollar ($) sign have special meaning so they are
+        // considered as normal characters.
+        // see http://www.regular-expressions.info/xml.html
+        $pattern = self::withoutStringAnchors($pattern);
+        $pattern = self::escapeSymbols($pattern, ['$', '^']);
+        $pattern = self::pregAddDelimiter('^' . $pattern . '$');
 
-         // XSD regexp always case-sensitive (nothing to do), dot matches white-spaces (use PCRE_DOTALL).
-         $pattern .= 's';
+        // XSD regexp always case-sensitive (nothing to do), dot matches white-spaces (use PCRE_DOTALL).
+        $pattern .= 's';
+        $pattern .= $pcreFlags;
 
-         return $pattern;
-     }
+        return $pattern;
+    }
 
      private static function withoutStringAnchors(string $pattern): string
      {

--- a/src/qtism/runtime/expressions/operators/Utils.php
+++ b/src/qtism/runtime/expressions/operators/Utils.php
@@ -334,7 +334,7 @@ class Utils
      * @param string $pcreFlags
      * @return string
      */
-    public static function prepareXsdPatternForPcre(string $pattern, string $pcreFlags = ''): string
+    public static function prepareXsdPatternForPcre(string $pattern, string $pcreFlags = 'su'): string
     {
         // XML schema always implicitly anchors the entire regular expression
         // Neither caret (^) nor dollar ($) sign have special meaning so they are
@@ -345,7 +345,6 @@ class Utils
         $pattern = self::pregAddDelimiter('^' . $pattern . '$');
 
         // XSD regexp always case-sensitive (nothing to do), dot matches white-spaces (use PCRE_DOTALL).
-        $pattern .= 's';
         $pattern .= $pcreFlags;
 
         return $pattern;

--- a/src/qtism/runtime/tests/Utils.php
+++ b/src/qtism/runtime/tests/Utils.php
@@ -84,7 +84,13 @@ class Utils
                 $values = ($cardinality === Cardinality::SINGLE) ? [$response->getValue()] : $response->getArrayCopy();
             }
 
-            $patternMask = OperatorUtils::prepareXsdPatternForPcre($patternMask);
+            // Is the patternMask a length validator or not?
+            // If it is, apply unicode flag - this will prevent a mismatch between frontend and backend on the string lengths counted as valid
+            $lengthPattern = '/\^\[\\\\s\\\\S\]\{0,\d+\}\$/';
+            $isLengthValidator = @preg_match($lengthPattern, $patternMask) === 1;
+            $pcreFlags = $isLengthValidator ? 'u' : '';
+
+            $patternMask = OperatorUtils::prepareXsdPatternForPcre($patternMask, $pcreFlags);
 
             foreach ($values as $value) {
                 $result = @preg_match($patternMask, $value);

--- a/src/qtism/runtime/tests/Utils.php
+++ b/src/qtism/runtime/tests/Utils.php
@@ -84,13 +84,7 @@ class Utils
                 $values = ($cardinality === Cardinality::SINGLE) ? [$response->getValue()] : $response->getArrayCopy();
             }
 
-            // Is the patternMask a length validator or not?
-            // If it is, apply unicode flag - this will prevent a mismatch between frontend and backend on the string lengths counted as valid
-            $lengthPattern = '/\^\[\\\\s\\\\S\]\{0,\d+\}\$/';
-            $isLengthValidator = @preg_match($lengthPattern, $patternMask) === 1;
-            $pcreFlags = $isLengthValidator ? 'u' : '';
-
-            $patternMask = OperatorUtils::prepareXsdPatternForPcre($patternMask, $pcreFlags);
+            $patternMask = OperatorUtils::prepareXsdPatternForPcre($patternMask);
 
             foreach ($values as $value) {
                 $result = @preg_match($patternMask, $value);

--- a/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
+++ b/test/qtismtest/runtime/expressions/operators/OperatorsUtilsTest.php
@@ -353,19 +353,19 @@ class OperatorsUtilsTest extends QtiSmTestCase
     public function patternForPcreProvider(): array
     {
         return [
-            'max chars string pattern without anchors' => ['[\s\S]{0,5}', '/^[\s\S]{0,5}$/s'],
-            'max chars string pattern with anchors' => ['^[\s\S]{0,5}$', '/^[\s\S]{0,5}$/s'],
-            'digits only pattern' => ['[0,1]+', '/^[0,1]+$/s'],
-            'digits only pattern with anchors' => ['^[0,1]+$', '/^[0,1]+$/s'],
-            'string prefix without anchors' => ['test(.*)', '/^test(.*)$/s'],
-            'string prefix with anchors' => ['^test(.*)$', '/^test(.*)$/s'],
+            'max chars string pattern without anchors' => ['[\s\S]{0,5}', '/^[\s\S]{0,5}$/su'],
+            'max chars string pattern with anchors' => ['^[\s\S]{0,5}$', '/^[\s\S]{0,5}$/su'],
+            'digits only pattern' => ['[0,1]+', '/^[0,1]+$/su'],
+            'digits only pattern with anchors' => ['^[0,1]+$', '/^[0,1]+$/su'],
+            'string prefix without anchors' => ['test(.*)', '/^test(.*)$/su'],
+            'string prefix with anchors' => ['^test(.*)$', '/^test(.*)$/su'],
             'max words pattern without anchors' => [
                 '(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}',
-                '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/s',
+                '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/su',
             ],
             'max words pattern with anchors' => [
                 '^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$',
-                '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/s',
+                '/^(?:(?:[^\s\:\!\?\;\…\€]+)[\s\:\!\?\;\…\€]*){0,5}$/su',
             ],
         ];
     }

--- a/test/qtismtest/runtime/tests/TestUtilsTest.php
+++ b/test/qtismtest/runtime/tests/TestUtilsTest.php
@@ -70,6 +70,20 @@ class TestUtilsTest extends QtiSmTestCase
             [false, null, new ResponseValidityConstraint('RESPONSE', 1, 1, '/sd$[a-(')],
             [true, new QtiString('string'), new ResponseValidityConstraint('RESPONSE', 1, 1, 'string')],
             [false, new QtiString('strong'), new ResponseValidityConstraint('RESPONSE', 1, 1, 'string')],
+            // PatternMask as maxlength tests - checking the length validation and also if unicode characters are processed with length of 1.
+            [true, new QtiString('hi'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')],
+            [false, new QtiString('hey'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')],
+            [true, new QtiString('hå'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')],
+            [false, new QtiString('håj'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')],
+            [true, new QtiString('hé'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')],
+            [true, new QtiString('hæ'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')],
+            [true, new QtiString('h😊'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')],
+            [true, new QtiString('ты'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')], // ru
+            [true, new QtiString('じす'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')], // jp
+            [true, new QtiString('谢谢'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')], // zh
+            [true, new QtiString('قط'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')], // ar
+            [true, new QtiString('אב'), new ResponseValidityConstraint('RESPONSE', 1, 1, '^[\s\S]{0,2}$')], // he
+
             [true, new MultipleContainer(BaseType::STRING, [new QtiString('string'), new QtiString('string')]), new ResponseValidityConstraint('RESPONSE', 2, 2, 'string')],
             [false, new MultipleContainer(BaseType::STRING, [new QtiString('strong'), new QtiString('string')]), new ResponseValidityConstraint('RESPONSE', 2, 2, 'string')],
             [false, new MultipleContainer(BaseType::STRING, [new QtiString('string'), new QtiString('strong')]), new ResponseValidityConstraint('RESPONSE', 2, 2, 'string')],


### PR DESCRIPTION
## [TR-4332](https://oat-sa.atlassian.net/browse/TR-4332): Incorrect maxLength validation for non-latin characters in Inline text

This bug occurs when an TextEntry interaction is authored with a maximum length, resulting in the `patternMask` attribute being a regex `^[\\s\\S]{0,N}$` used for input length validation. Today, that validation is applied differently on backend and Solar frontend, which [parses](https://github.com/oat-sa/tao-deliver-fe/blob/develop/packages/item-runner/src/runner/util/patternMask.js#L31) the `maxlength` number back out of the pattern in order to check the input's length does not exceed it.

This is significant on Unicode inputs (see [byte counter](https://mothereff.in/byte-counter)):
- `a` // JS string length = 1; bytes = 1; patternMask `{0,1}` = valid
- `å` // JS string length = 1; bytes = 2; patternMask `{0,1}` = invalid
- `😊` // JS string length = 1; bytes = 4; patternMask `{0,1}` = invalid

This solution (kind of) matches backend's behaviour to frontend's by adding the Unicode `u` modifier to the BE regex, meaning that all of the above inputs match as 1 character. Therefore no input should be able to pass FE validation but fail on BE. (It could also be done by parsing out the integer and discarding the `patternMask`, if desired.)

### To test:
- run the unit test
- incorporate this into `tao-deliver-be` and take the test from the Jira ticket
  - see that Unicode inputs are validated the same on BE as FE

<img width="659" alt="Screenshot 2022-06-28 at 09 50 31" src="https://user-images.githubusercontent.com/43652944/176124365-02988c05-2623-487d-9557-95be43db31f8.png">

