### PR TITLE
feat: allow custom attributes for BodyElement to support lang and dir

### DIFF
--- a/qtism/data/content/BodyElement.php
+++ b/qtism/data/content/BodyElement.php
@@ -145,6 +145,9 @@ abstract class BodyElement extends QtiComponent
      */
     private $ariaHidden = false;
 
+    /** @var array */
+    private $attributes = [];
+
     /**
      * Create a new BodyElement object.
      *
@@ -622,5 +625,15 @@ abstract class BodyElement extends QtiComponent
     public function hasAriaHidden()
     {
         return $this->ariaHidden !== false;
+    }
+
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    public function setAttribute(string $attribute, string $value): void
+    {
+        $this->attributes[$attribute] = $value;
     }
 }

--- a/qtism/data/content/BodyElement.php
+++ b/qtism/data/content/BodyElement.php
@@ -37,6 +37,11 @@ use qtism\data\QtiComponent;
  */
 abstract class BodyElement extends QtiComponent
 {
+    public const ALLOWED_ATTRIBUTES = [
+        'dir',
+        'lang',
+    ];
+
     /**
      * From IMS QTI:
      *
@@ -632,8 +637,17 @@ abstract class BodyElement extends QtiComponent
         return $this->attributes;
     }
 
+    public function getAttribute(string $attribute): ?string
+    {
+        return $this->attributes[$attribute] ?? null;
+    }
+
     public function setAttribute(string $attribute, string $value): void
     {
+        if (!in_array($attribute, self::ALLOWED_ATTRIBUTES, true)) {
+            throw new InvalidArgumentException(sprintf('BodyElement attribute "%s" is not supported', $attribute));
+        }
+
         $this->attributes[$attribute] = $value;
     }
 }

--- a/qtism/data/storage/xml/marshalling/Marshaller.php
+++ b/qtism/data/storage/xml/marshalling/Marshaller.php
@@ -399,6 +399,14 @@ abstract class Marshaller
             $bodyElement->setLang($element->getAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang'));
             $bodyElement->setLabel($element->getAttribute('label'));
 
+            if ($element->hasAttribute('lang')) {
+                $this->setDOMElementAttribute($element,'lang', $element->getAttribute('lang'));
+            }
+
+            if ($element->hasAttribute('dir')) {
+                $this->setDOMElementAttribute($element,'dir', $element->getAttribute('dir'));
+            }
+
             $version = $this->getVersion();
             if (Version::compare($version, '2.2.0', '>=') === true) {
                 // aria-* attributes
@@ -483,6 +491,18 @@ abstract class Marshaller
      */
     protected function fillElement(DOMElement $element, BodyElement $bodyElement)
     {
+        //FIXME @TODO Remove experiment
+        //FIXME
+        if ($element->hasAttribute('lang')) {
+            $this->setDOMElementAttribute($element,'lang', $element->getAttribute('lang'));
+        }
+
+        if ($element->hasAttribute('dir')) {
+            $this->setDOMElementAttribute($element,'dir', $element->getAttribute('dir'));
+        }
+        //FIXME
+        //FIXME
+
         if (($id = $bodyElement->getId()) !== '') {
             $element->setAttribute('id', $id);
         }

--- a/qtism/data/storage/xml/marshalling/Marshaller.php
+++ b/qtism/data/storage/xml/marshalling/Marshaller.php
@@ -400,11 +400,11 @@ abstract class Marshaller
             $bodyElement->setLabel($element->getAttribute('label'));
 
             if ($element->hasAttribute('lang')) {
-                $this->setDOMElementAttribute($element,'lang', $element->getAttribute('lang'));
+                $bodyElement->setAttribute('lang', $element->getAttribute('lang'));
             }
 
             if ($element->hasAttribute('dir')) {
-                $this->setDOMElementAttribute($element,'dir', $element->getAttribute('dir'));
+                $bodyElement->setAttribute('dir', $element->getAttribute('dir'));
             }
 
             $version = $this->getVersion();
@@ -491,18 +491,6 @@ abstract class Marshaller
      */
     protected function fillElement(DOMElement $element, BodyElement $bodyElement)
     {
-        //FIXME @TODO Remove experiment
-        //FIXME
-        if ($element->hasAttribute('lang')) {
-            $this->setDOMElementAttribute($element,'lang', $element->getAttribute('lang'));
-        }
-
-        if ($element->hasAttribute('dir')) {
-            $this->setDOMElementAttribute($element,'dir', $element->getAttribute('dir'));
-        }
-        //FIXME
-        //FIXME
-
         if (($id = $bodyElement->getId()) !== '') {
             $element->setAttribute('id', $id);
         }
@@ -573,6 +561,10 @@ abstract class Marshaller
 
                 if (($ariaHidden = $bodyElement->getAriaHidden()) !== false) {
                     $element->setAttribute('aria-hidden', 'true');
+                }
+
+                foreach ($bodyElement->getAttributes() as $attribute => $attributeValue) {
+                    $element->setAttribute($attribute, $attributeValue);
                 }
             }
         }

--- a/qtism/data/storage/xml/marshalling/RecursiveMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/RecursiveMarshaller.php
@@ -212,20 +212,6 @@ abstract class RecursiveMarshaller extends Marshaller
         $this->resetMark();
         $this->resetProcessed();
 
-        //FIXME @TODO Remove experiment
-        //FIXME
-        $element = $this->createElement($component);
-
-        if ($element->hasAttribute('lang')) {
-            $this->setDOMElementAttribute($element,'lang', $element->getAttribute('lang'));
-        }
-
-        if ($element->hasAttribute('dir')) {
-            $this->setDOMElementAttribute($element,'dir', $element->getAttribute('dir'));
-        }
-        //FIXME
-        //FIXME
-
         $this->pushTrail($component);
 
         while ($this->countTrail() > 0) {
@@ -279,18 +265,6 @@ abstract class RecursiveMarshaller extends Marshaller
         $this->resetFinal();
         $this->resetMark();
         $this->resetProcessed();
-
-        //FIXME @TODO Remove experiment
-        //FIXME
-        if ($element->hasAttribute('lang')) {
-            $this->setDOMElementAttribute($element,'lang', $element->getAttribute('lang'));
-        }
-
-        if ($element->hasAttribute('dir')) {
-            $this->setDOMElementAttribute($element,'dir', $element->getAttribute('dir'));
-        }
-        //FIXME
-        //FIXME
 
         $this->pushTrail($element);
 

--- a/qtism/data/storage/xml/marshalling/RecursiveMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/RecursiveMarshaller.php
@@ -212,6 +212,20 @@ abstract class RecursiveMarshaller extends Marshaller
         $this->resetMark();
         $this->resetProcessed();
 
+        //FIXME @TODO Remove experiment
+        //FIXME
+        $element = $this->createElement($component);
+
+        if ($element->hasAttribute('lang')) {
+            $this->setDOMElementAttribute($element,'lang', $element->getAttribute('lang'));
+        }
+
+        if ($element->hasAttribute('dir')) {
+            $this->setDOMElementAttribute($element,'dir', $element->getAttribute('dir'));
+        }
+        //FIXME
+        //FIXME
+
         $this->pushTrail($component);
 
         while ($this->countTrail() > 0) {
@@ -265,6 +279,18 @@ abstract class RecursiveMarshaller extends Marshaller
         $this->resetFinal();
         $this->resetMark();
         $this->resetProcessed();
+
+        //FIXME @TODO Remove experiment
+        //FIXME
+        if ($element->hasAttribute('lang')) {
+            $this->setDOMElementAttribute($element,'lang', $element->getAttribute('lang'));
+        }
+
+        if ($element->hasAttribute('dir')) {
+            $this->setDOMElementAttribute($element,'dir', $element->getAttribute('dir'));
+        }
+        //FIXME
+        //FIXME
 
         $this->pushTrail($element);
 

--- a/test/qtismtest/data/content/BodyElementTest.php
+++ b/test/qtismtest/data/content/BodyElementTest.php
@@ -683,4 +683,30 @@ class BodyElementTest extends QtiSmTestCase
             [new stdClass(), "'instance of stdClass' is not a valid value for attribute 'aria-hidden'."],
         ];
     }
+
+    public function testSetAttributes(): void
+    {
+        $span = new Span();
+        $span->setAttribute('lang', 'ar-AR');
+        $span->setAttribute('dir', 'rtl');
+
+        $this->assertSame(
+            [
+                'lang' => 'ar-AR',
+                'dir' => 'rtl',
+            ],
+            $span->getAttributes()
+        );
+        $this->assertSame('ar-AR', $span->getAttribute('lang'));
+        $this->assertSame('rtl', $span->getAttribute('dir'));
+    }
+
+    public function testSetInvalidAttributeWillThrowException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('BodyElement attribute "foo" is not supported');
+
+        $span = new Span();
+        $span->setAttribute('foo', 'bar');
+    }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-2337

## Problem to solve

Import/export shared stimulus and keep the "lang" and "dir" attributes is not working.

Example where the problem happens: https://github.com/oat-sa/extension-tao-mediamanager/blob/master/model/sharedStimulus/encoder/SharedStimulusMediaEncoder.php#L51 When we call XmlDocument::load() it does not keep the attributes we need. 

## Solutions

- Add possibilities for custom attributes in the BodyElement

## TODO 

- [ ] Validate solution with colleagues
- [ ] Apply unit tests

## PRs

- https://github.com/oat-sa/extension-tao-itemqti/pull/2162
- https://github.com/oat-sa/lib-tao-qti/pull/121

