### PR TITLE
fix: Store Item Limits to DurationStore

### DIFF
--- a/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
+++ b/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
@@ -341,7 +341,7 @@ abstract class AbstractQtiBinaryStorage extends AbstractStorage
                 }
 
             $item = $assessmentTestSession->getCurrentAssessmentItemRef();
-            if ($timeLimits = $item->getTimeLimits()) {
+            if ($item && $timeLimits = $item->getTimeLimits()) {
                 if ($timeLimits->hasMaxTime()) {
                     $durationVariable = new OutcomeVariable(
                         $item->getIdentifier(),

--- a/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
+++ b/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
@@ -332,13 +332,13 @@ abstract class AbstractQtiBinaryStorage extends AbstractStorage
 
             // Build the duration store.
             $durationStore = new DurationStore();
-                $durationCount = $access->readShort();
-                for ($i = 0; $i < $durationCount; $i++) {
-                    $varName = $access->readString();
-                    $durationVariable = new OutcomeVariable($varName, Cardinality::SINGLE, BaseType::DURATION);
-                    $access->readVariableValue($durationVariable);
-                    $durationStore->setVariable($durationVariable);
-                }
+            $durationCount = $access->readShort();
+            for ($i = 0; $i < $durationCount; $i++) {
+                $varName = $access->readString();
+                $durationVariable = new OutcomeVariable($varName, Cardinality::SINGLE, BaseType::DURATION);
+                $access->readVariableValue($durationVariable);
+                $durationStore->setVariable($durationVariable);
+            }
 
             $item = $assessmentTestSession->getCurrentAssessmentItemRef();
             if ($item && $timeLimits = $item->getTimeLimits()) {

--- a/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
+++ b/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
@@ -339,31 +339,6 @@ abstract class AbstractQtiBinaryStorage extends AbstractStorage
                 $access->readVariableValue($durationVariable);
                 $durationStore->setVariable($durationVariable);
             }
-
-            $item = $assessmentTestSession->getCurrentAssessmentItemRef();
-            if ($item && $timeLimits = $item->getTimeLimits()) {
-                if ($timeLimits->hasMaxTime()) {
-                    $durationVariable = new OutcomeVariable(
-                        $item->getIdentifier(),
-                        Cardinality::SINGLE,
-                        BaseType::DURATION
-                    );
-                    $durationVariable->setValue($item->getTimeLimits()->getMaxTime());
-                    $durationStore->setVariable($durationVariable);
-                }
-
-                if ($timeLimits->hasMinTime()) {
-                    $durationVariable = new OutcomeVariable(
-                        $item->getIdentifier(),
-                        Cardinality::SINGLE,
-                        BaseType::DURATION
-                    );
-                    $durationVariable->setValue($item->getTimeLimits()->getMinTime());
-                    $durationStore->setVariable($durationVariable);
-                }
-            }
-
-
             $assessmentTestSession->setDurationStore($durationStore);
 
             $stream->close();

--- a/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
+++ b/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
@@ -340,7 +340,31 @@ abstract class AbstractQtiBinaryStorage extends AbstractStorage
                     $durationStore->setVariable($durationVariable);
                 }
 
-                $assessmentTestSession->setDurationStore($durationStore);
+            $item = $assessmentTestSession->getCurrentAssessmentItemRef();
+            if ($timeLimits = $item->getTimeLimits()) {
+                if ($timeLimits->hasMaxTime()) {
+                    $durationVariable = new OutcomeVariable(
+                        $item->getIdentifier(),
+                        Cardinality::SINGLE,
+                        BaseType::DURATION
+                    );
+                    $durationVariable->setValue($item->getTimeLimits()->getMaxTime());
+                    $durationStore->setVariable($durationVariable);
+                }
+
+                if ($timeLimits->hasMinTime()) {
+                    $durationVariable = new OutcomeVariable(
+                        $item->getIdentifier(),
+                        Cardinality::SINGLE,
+                        BaseType::DURATION
+                    );
+                    $durationVariable->setValue($item->getTimeLimits()->getMinTime());
+                    $durationStore->setVariable($durationVariable);
+                }
+            }
+
+
+            $assessmentTestSession->setDurationStore($durationStore);
 
             $stream->close();
 

--- a/src/qtism/runtime/tests/AssessmentTestSession.php
+++ b/src/qtism/runtime/tests/AssessmentTestSession.php
@@ -817,9 +817,11 @@ class AssessmentTestSession extends State
      * * The time limits in force at the test level (assessmentTest, testPart, assessmentSection) is exceeded.
      * * The current item session is closed (no more attempts, time limits exceeded).
      *
+     * @param bool $allowLateSubmission If set to true, maximum time limits will not be taken into account.
+     *
      * @throws AssessmentTestSessionException
      */
-    public function beginAttempt()
+    public function beginAttempt($allowLateSubmission = false)
     {
         if ($this->isRunning() === false) {
             $msg = 'Cannot begin an attempt for the current item while the state of the test session is INITIAL or CLOSED.';
@@ -827,7 +829,11 @@ class AssessmentTestSession extends State
         }
 
         // Are the time limits in force (at the test level) respected?
-        $this->checkTimeLimits();
+        // -- Are time limits in force respected?
+        if ($allowLateSubmission === false) {
+            $this->checkTimeLimits();
+        }
+
 
         // Time limits are OK! Let's try to begin the attempt.
         $routeItem = $this->getCurrentRouteItem();


### PR DESCRIPTION
# Issue found [here](https://oat-sa.atlassian.net/browse/TR-4418)

##  Description
During creating DurationStore for Assessment Session we skip to add duration for AsessmentItem it happens because `$access`  follow to elements inside items not on its properties. 

## Development impact
1. Extend duration store with item limits data if it set for item. 

## Demo 
https://www.loom.com/share/f6d938a834754daeae6f83d884db6fb1
