### PR TITLE
Fix/TR-4212/Decode HTML entities in attributes

### DIFF
--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -284,7 +284,7 @@ class Utils
 
         switch ($datatype) {
             case 'string':
-                return $attr;
+                return htmlspecialchars_decode($attr);
 
             case 'integer':
                 return (int)$attr;

--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -284,7 +284,7 @@ class Utils
 
         switch ($datatype) {
             case 'string':
-                return htmlspecialchars_decode($attr);
+                return $attr;
 
             case 'integer':
                 return (int)$attr;
@@ -323,7 +323,7 @@ class Utils
      */
     public static function setDOMElementAttribute(DOMElement $element, string $attribute, $value)
     {
-        $element->setAttribute($attribute, self::valueAsString($value));
+        $element->setAttribute($attribute, self::valueAsString($value, false));
     }
 
     /**
@@ -343,14 +343,18 @@ class Utils
      * Other variable types are optionally using string conversion.
      *
      * @param mixed $value
+     * @param bool $encode
      * @return string
      */
-    public static function valueAsString($value)
+    public static function valueAsString($value, $encode = true)
     {
         if (is_bool($value)) {
             return $value === true ? 'true' : 'false';
         }
-        return htmlspecialchars($value, ENT_XML1, 'UTF-8');
+        if ($encode) {
+            return htmlspecialchars($value, ENT_XML1, 'UTF-8');
+        }
+        return (string)$value;
     }
 
     /**

--- a/test/qtismtest/data/storage/xml/XmlUtilsTest.php
+++ b/test/qtismtest/data/storage/xml/XmlUtilsTest.php
@@ -266,6 +266,39 @@ class XmlUtilsTest extends QtiSmTestCase
         ];
     }
 
+    /**
+     * @dataProvider setDOMElementAttributeProvider
+     * @param string $attribute
+     * @param string $value
+     * @param mixed $expected
+     */
+    public function testSetDOMElementAttribute($attribute, $value, $expected)
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $element = $dom->createElement('foo');
+        $dom->appendChild($element);
+
+        Utils::setDOMElementAttribute($element, $attribute, $value);
+        $result = $dom->saveXML($element);
+
+        $this::assertSame($expected, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function setDOMElementAttributeProvider()
+    {
+        return [
+            ['string', 'str&str', '<foo string="str&amp;str"/>'],
+            ['integer', 1, '<foo integer="1"/>'],
+            ['float', 1.1, '<foo float="1.1"/>'],
+            ['double', 1.1, '<foo double="1.1"/>'],
+            ['boolean', true, '<foo boolean="true"/>'],
+            ['not-existing',  null, '<foo not-existing=""/>'],
+        ];
+    }
+
     public function testGetChildElementsByTagName()
     {
         $dom = new DOMDocument('1.0', 'UTF-8');

--- a/test/qtismtest/data/storage/xml/XmlUtilsTest.php
+++ b/test/qtismtest/data/storage/xml/XmlUtilsTest.php
@@ -250,7 +250,7 @@ class XmlUtilsTest extends QtiSmTestCase
     public function getDOMElementAttributeAsProvider()
     {
         $dom = new DOMDocument('1.0', 'UTF-8');
-        $dom->loadXML('<foo string="str&amp;amp;str" integer="1" float="1.1" double="1.1" boolean="true" baseType="duration" wrongEnumValue="blah"/>');
+        $dom->loadXML('<foo string="str&amp;str" integer="1" float="1.1" double="1.1" boolean="true" baseType="duration" wrongEnumValue="blah"/>');
         $elt = $dom->documentElement;
 
         return [

--- a/test/qtismtest/data/storage/xml/XmlUtilsTest.php
+++ b/test/qtismtest/data/storage/xml/XmlUtilsTest.php
@@ -250,11 +250,11 @@ class XmlUtilsTest extends QtiSmTestCase
     public function getDOMElementAttributeAsProvider()
     {
         $dom = new DOMDocument('1.0', 'UTF-8');
-        $dom->loadXML('<foo string="str" integer="1" float="1.1" double="1.1" boolean="true" baseType="duration" wrongEnumValue="blah"/>');
+        $dom->loadXML('<foo string="str&amp;amp;str" integer="1" float="1.1" double="1.1" boolean="true" baseType="duration" wrongEnumValue="blah"/>');
         $elt = $dom->documentElement;
 
         return [
-            [$elt, 'string', 'string', 'str'],
+            [$elt, 'string', 'string', 'str&str'],
             [$elt, 'integer', 'integer', 1],
             [$elt, 'float', 'float', 1.1],
             [$elt, 'double', 'double', 1.1],


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4212

To prevent XML validation errors, the XML attributes are escaped so that some entities are encoded (`"`, `&`, `<`, `>`). This is made implicitly by the PHP built-in engine, but it is also enforced by the [attribute setter](https://github.com/oat-sa/qti-sdk/blob/5119fc6c91e3e39c36a035eaef9ee840fb573320/src/qtism/data/storage/xml/Utils.php#L353). This results in double encoding. Unfortunately, it does not look like the unescape is applied properly while reading back the XML.

~~This code change adds decoding of the HTML special chars when reading attributes.~~
This code change removes the double encoding of attributes.

How to test:
- run the unit tests (`vendor/bin/phpunit`)
- check out the branch in a TAO instance (composer: `"qtism/qtism": "dev-fix/TR-4212/decode-html-entities-in-attributes as 16.6-dev",`)
- create/update a test, making sure to introduce social chars in the test title as well as in a section title. For example, add the sequence `<&>` to the tile.
- publish the test
- launch the test and look at the titles, they should not show encoded entities.