### PR TITLE
Fix/TR-4212/Legacy/Decode HTML entities in attributes

### DIFF
--- a/qtism/data/storage/xml/Utils.php
+++ b/qtism/data/storage/xml/Utils.php
@@ -89,11 +89,7 @@ class Utils
             if ($attrNode->namespaceURI === null) {
                 $newElement->setAttribute($attrName, $attrNode->value);
             } else {
-                $newElement->setAttributeNS(
-                    $attrNode->namespaceURI,
-                    $attrNode->prefix . ':' . $attrName,
-                    $attrNode->value
-                );
+                $newElement->setAttributeNS($attrNode->namespaceURI, $attrNode->prefix . ':' . $attrName, $attrNode->value);
             }
         }
 
@@ -123,22 +119,14 @@ class Utils
         while ($stack->count() > 0) {
             $node = $stack->pop();
 
-            if ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array(
-                    $node,
-                    $traversed,
-                    true
-                ) === false) {
+            if ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array($node, $traversed, true) === false) {
                 $traversed[] = $node;
                 $stack->push($node);
 
                 for ($i = 0; $i < $node->childNodes->length; $i++) {
                     $stack->push($node->childNodes->item($i));
                 }
-            } elseif ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array(
-                    $node,
-                    $traversed,
-                    true
-                )) {
+            } elseif ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array($node, $traversed, true)) {
                 // Build hierarchical node copy from the current node. All the attributes
                 // of $node must be copied into $newNode.
                 $newNode = $node->ownerDocument->createElement($node->localName);
@@ -230,7 +218,7 @@ class Utils
                 return $attr === 'true';
         }
 
-        if (in_array(Enumeration::class, class_implements($datatype), true)) {
+        if (in_array(Enumeration::class, class_implements($datatype), true)){
             if ($attr !== null) {
                 /** @var $datatype Enumeration */
                 $constant = $datatype::getConstantByName($attr);
@@ -332,9 +320,7 @@ class Utils
         $returnValue = [];
 
         for ($i = 0; $i < $children->length; $i++) {
-            if ($children->item($i)->nodeType === XML_ELEMENT_NODE || ($withText === true && ($children->item(
-                            $i
-                        )->nodeType === XML_TEXT_NODE || $children->item($i)->nodeType === XML_CDATA_SECTION_NODE))) {
+            if ($children->item($i)->nodeType === XML_ELEMENT_NODE || ($withText === true && ($children->item($i)->nodeType === XML_TEXT_NODE || $children->item($i)->nodeType === XML_CDATA_SECTION_NODE))) {
                 $returnValue[] = $children->item($i);
             }
         }

--- a/qtism/data/storage/xml/Utils.php
+++ b/qtism/data/storage/xml/Utils.php
@@ -205,7 +205,7 @@ class Utils
 
         switch ($datatype) {
             case 'string':
-                return $attr;
+                return htmlspecialchars_decode($attr);
 
             case 'integer':
                 return (int)$attr;

--- a/qtism/data/storage/xml/Utils.php
+++ b/qtism/data/storage/xml/Utils.php
@@ -89,7 +89,11 @@ class Utils
             if ($attrNode->namespaceURI === null) {
                 $newElement->setAttribute($attrName, $attrNode->value);
             } else {
-                $newElement->setAttributeNS($attrNode->namespaceURI, $attrNode->prefix . ':' . $attrName, $attrNode->value);
+                $newElement->setAttributeNS(
+                    $attrNode->namespaceURI,
+                    $attrNode->prefix . ':' . $attrName,
+                    $attrNode->value
+                );
             }
         }
 
@@ -119,14 +123,22 @@ class Utils
         while ($stack->count() > 0) {
             $node = $stack->pop();
 
-            if ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array($node, $traversed, true) === false) {
+            if ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array(
+                    $node,
+                    $traversed,
+                    true
+                ) === false) {
                 $traversed[] = $node;
                 $stack->push($node);
 
                 for ($i = 0; $i < $node->childNodes->length; $i++) {
                     $stack->push($node->childNodes->item($i));
                 }
-            } elseif ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array($node, $traversed, true)) {
+            } elseif ($node->nodeType === XML_ELEMENT_NODE && $node->childNodes->length > 0 && in_array(
+                    $node,
+                    $traversed,
+                    true
+                )) {
                 // Build hierarchical node copy from the current node. All the attributes
                 // of $node must be copied into $newNode.
                 $newNode = $node->ownerDocument->createElement($node->localName);
@@ -205,7 +217,7 @@ class Utils
 
         switch ($datatype) {
             case 'string':
-                return htmlspecialchars_decode($attr);
+                return $attr;
 
             case 'integer':
                 return (int)$attr;
@@ -218,7 +230,7 @@ class Utils
                 return $attr === 'true';
         }
 
-        if (in_array(Enumeration::class, class_implements($datatype), true)){
+        if (in_array(Enumeration::class, class_implements($datatype), true)) {
             if ($attr !== null) {
                 /** @var $datatype Enumeration */
                 $constant = $datatype::getConstantByName($attr);
@@ -244,7 +256,7 @@ class Utils
      */
     public static function setDOMElementAttribute(DOMElement $element, string $attribute, $value)
     {
-        $element->setAttribute($attribute, self::valueAsString($value));
+        $element->setAttribute($attribute, self::valueAsString($value, false));
     }
 
     /**
@@ -264,14 +276,18 @@ class Utils
      * Other variable types are optionally using string conversion.
      *
      * @param mixed $value
+     * @param bool $encode
      * @return string
      */
-    public static function valueAsString($value)
+    public static function valueAsString($value, $encode = true)
     {
         if (is_bool($value)) {
             return $value === true ? 'true' : 'false';
         }
-        return htmlspecialchars($value, ENT_XML1, 'UTF-8');
+        if ($encode) {
+            return htmlspecialchars($value, ENT_XML1, 'UTF-8');
+        }
+        return (string)$value;
     }
 
     /**
@@ -316,7 +332,9 @@ class Utils
         $returnValue = [];
 
         for ($i = 0; $i < $children->length; $i++) {
-            if ($children->item($i)->nodeType === XML_ELEMENT_NODE || ($withText === true && ($children->item($i)->nodeType === XML_TEXT_NODE || $children->item($i)->nodeType === XML_CDATA_SECTION_NODE))) {
+            if ($children->item($i)->nodeType === XML_ELEMENT_NODE || ($withText === true && ($children->item(
+                            $i
+                        )->nodeType === XML_TEXT_NODE || $children->item($i)->nodeType === XML_CDATA_SECTION_NODE))) {
                 $returnValue[] = $children->item($i);
             }
         }

--- a/test/qtismtest/data/storage/xml/XmlUtilsTest.php
+++ b/test/qtismtest/data/storage/xml/XmlUtilsTest.php
@@ -167,4 +167,37 @@ class XmlUtilsTest extends QtiSmTestCase
             [$elt, 'cardinality', Cardinality::class, null],
         ];
     }
+
+    /**
+     * @dataProvider setDOMElementAttributeProvider
+     * @param string $attribute
+     * @param string $value
+     * @param mixed $expected
+     */
+    public function testSetDOMElementAttribute($attribute, $value, $expected)
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $element = $dom->createElement('foo');
+        $dom->appendChild($element);
+
+        Utils::setDOMElementAttribute($element, $attribute, $value);
+        $result = $dom->saveXML($element);
+
+        $this::assertSame($expected, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function setDOMElementAttributeProvider()
+    {
+        return [
+            ['string', 'str&str', '<foo string="str&amp;str"/>'],
+            ['integer', 1, '<foo integer="1"/>'],
+            ['float', 1.1, '<foo float="1.1"/>'],
+            ['double', 1.1, '<foo double="1.1"/>'],
+            ['boolean', true, '<foo boolean="true"/>'],
+            ['not-existing',  null, '<foo not-existing=""/>'],
+        ];
+    }
 }

--- a/test/qtismtest/data/storage/xml/XmlUtilsTest.php
+++ b/test/qtismtest/data/storage/xml/XmlUtilsTest.php
@@ -152,7 +152,7 @@ class XmlUtilsTest extends QtiSmTestCase
     public function getDOMElementAttributeAsProvider()
     {
         $dom = new DOMDocument('1.0', 'UTF-8');
-        $dom->loadXML('<foo string="str&amp;amp;str" integer="1" float="1.1" double="1.1" boolean="true" baseType="duration" wrongEnumValue="blah"/>');
+        $dom->loadXML('<foo string="str&amp;str" integer="1" float="1.1" double="1.1" boolean="true" baseType="duration" wrongEnumValue="blah"/>');
         $elt = $dom->documentElement;
 
         return [

--- a/test/qtismtest/data/storage/xml/XmlUtilsTest.php
+++ b/test/qtismtest/data/storage/xml/XmlUtilsTest.php
@@ -3,6 +3,9 @@
 namespace qtismtest\data\storage\xml;
 
 use DOMDocument;
+use DOMElement;
+use qtism\common\enums\BaseType;
+use qtism\common\enums\Cardinality;
 use qtism\data\storage\xml\Utils;
 use qtismtest\QtiSmTestCase;
 
@@ -127,6 +130,41 @@ class XmlUtilsTest extends QtiSmTestCase
                 'http://www.imsglobal.org/xsd/imsqti_v2p0',
                 false,
             ],
+        ];
+    }
+
+    /**
+     * @dataProvider getDOMElementAttributeAsProvider
+     * @param DOMElement $element
+     * @param string $attribute
+     * @param string $datatype
+     * @param mixed $expected
+     */
+    public function testGetDOMElementAttributeAs(DOMElement $element, $attribute, $datatype, $expected)
+    {
+        $result = Utils::getDOMElementAttributeAs($element, $attribute, $datatype);
+        $this::assertSame($expected, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function getDOMElementAttributeAsProvider()
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadXML('<foo string="str&amp;amp;str" integer="1" float="1.1" double="1.1" boolean="true" baseType="duration" wrongEnumValue="blah"/>');
+        $elt = $dom->documentElement;
+
+        return [
+            [$elt, 'string', 'string', 'str&str'],
+            [$elt, 'integer', 'integer', 1],
+            [$elt, 'float', 'float', 1.1],
+            [$elt, 'double', 'double', 1.1],
+            [$elt, 'boolean', 'boolean', true],
+            [$elt, 'not-existing', '', null],
+            [$elt, 'baseType', BaseType::class, BaseType::DURATION],
+            [$elt, 'wrongEnumValue', BaseType::class, 'blah'],
+            [$elt, 'cardinality', Cardinality::class, null],
         ];
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4212

To prevent XML validation errors, the XML attributes are escaped so that some entities are encoded (`"`, `&`, `<`, `>`). This is made implicitly by the PHP built-in engine, but it is also enforced by the [attribute setter](https://github.com/oat-sa/qti-sdk/blob/5119fc6c91e3e39c36a035eaef9ee840fb573320/src/qtism/data/storage/xml/Utils.php#L353). This results in double encoding. Unfortunately, it does not look like the unescape is applied properly while reading back the XML.

~~This code change adds decoding of the HTML special chars when reading attributes.~~
This code change removes the double encoding of attributes.

How to test:
- run the unit tests (`vendor/bin/phpunit`)
- check out the branch in a TAO instance (composer: `"qtism/qtism": "dev-fix/TR-4212/legacy/decode-html-entities-in-attributes as 0.28"`)
- create/update a test, making sure to introduce social chars in the test title as well as in a section title. For example, add the sequence `<&>` to the tile.
- publish the test
- launch the test and look at the titles, they should not show encoded entities.