### PR TITLE
Add <ruby> tag to marshaling and unmarshaling

### DIFF
--- a/src/qtism/data/content/xhtml/html5/Rb.php
+++ b/src/qtism/data/content/xhtml/html5/Rb.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\data\content\xhtml\html5;
+
+use qtism\data\content\FlowStatic;
+use qtism\data\content\FlowTrait;
+use qtism\data\content\InlineCollection;
+
+class Rb extends Html5Element implements FlowStatic
+{
+    use FlowTrait;
+
+    public const QTI_CLASS_NAME = 'rb';
+
+    /**
+     * The Block components composing the SimpleBlock object.
+     *
+     * @var InlineCollection
+     * @qtism-bean-property
+     */
+    private $content;
+
+    /**
+     * Create a new figcaption object.
+     */
+    public function __construct($title = null, $role = null, $id = null, $class = null, $lang = null, $label = null)
+    {
+        parent::__construct($title, $role, $id, $class, $lang, $label);
+        $this->setContent(new InlineCollection());
+    }
+
+    public function getQtiClassName()
+    {
+        return self::QTI_CLASS_NAME;
+    }
+
+    public function getComponents()
+    {
+        return $this->getContent();
+    }
+
+    /**
+     * Set the collection of Flow objects composing the Div.
+     *
+     * @param InlineCollection $content A collection of Flow objects.
+     */
+    public function setContent(InlineCollection $content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Get the collection of Flow objects composing the Div.
+     *
+     * @return InlineCollection
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+}

--- a/src/qtism/data/content/xhtml/html5/Rp.php
+++ b/src/qtism/data/content/xhtml/html5/Rp.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\data\content\xhtml\html5;
+
+use qtism\data\content\FlowStatic;
+use qtism\data\content\FlowTrait;
+use qtism\data\content\InlineCollection;
+
+class Rp extends Html5Element implements FlowStatic
+{
+    use FlowTrait;
+
+    public const QTI_CLASS_NAME = 'rp';
+
+    /**
+     * The Block components composing the SimpleBlock object.
+     *
+     * @var InlineCollection
+     * @qtism-bean-property
+     */
+    private $content;
+
+    /**
+     * Create a new figcaption object.
+     */
+    public function __construct($title = null, $role = null, $id = null, $class = null, $lang = null, $label = null)
+    {
+        parent::__construct($title, $role, $id, $class, $lang, $label);
+        $this->setContent(new InlineCollection());
+    }
+
+    public function getQtiClassName()
+    {
+        return self::QTI_CLASS_NAME;
+    }
+
+    public function getComponents()
+    {
+        return $this->getContent();
+    }
+
+    /**
+     * Set the collection of Flow objects composing the Div.
+     *
+     * @param InlineCollection $content A collection of Flow objects.
+     */
+    public function setContent(InlineCollection $content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Get the collection of Flow objects composing the Div.
+     *
+     * @return InlineCollection
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+}

--- a/src/qtism/data/content/xhtml/html5/Rt.php
+++ b/src/qtism/data/content/xhtml/html5/Rt.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\data\content\xhtml\html5;
+
+use qtism\data\content\FlowStatic;
+use qtism\data\content\FlowTrait;
+use qtism\data\content\InlineCollection;
+
+class Rt extends Html5Element implements FlowStatic
+{
+    use FlowTrait;
+
+    public const QTI_CLASS_NAME = 'rt';
+
+    /**
+     * The Block components composing the SimpleBlock object.
+     *
+     * @var InlineCollection
+     * @qtism-bean-property
+     */
+    private $content;
+
+    /**
+     * Create a new figcaption object.
+     */
+    public function __construct($title = null, $role = null, $id = null, $class = null, $lang = null, $label = null)
+    {
+        parent::__construct($title, $role, $id, $class, $lang, $label);
+        $this->setContent(new InlineCollection());
+    }
+
+    public function getQtiClassName()
+    {
+        return self::QTI_CLASS_NAME;
+    }
+
+    public function getComponents()
+    {
+        return $this->getContent();
+    }
+
+    /**
+     * Set the collection of Flow objects composing the Div.
+     *
+     * @param InlineCollection $content A collection of Flow objects.
+     */
+    public function setContent(InlineCollection $content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Get the collection of Flow objects composing the Div.
+     *
+     * @return InlineCollection
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+}

--- a/src/qtism/data/content/xhtml/html5/Ruby.php
+++ b/src/qtism/data/content/xhtml/html5/Ruby.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\data\content\xhtml\html5;
+
+use qtism\data\content\FlowCollection;
+use qtism\data\content\FlowStatic;
+use qtism\data\content\FlowTrait;
+
+class Ruby extends Html5Element implements FlowStatic
+{
+    use FlowTrait;
+
+    public const QTI_CLASS_NAME = 'ruby';
+
+    /**
+     * The Block components composing the SimpleBlock object.
+     *
+     * @var FlowCollection
+     * @qtism-bean-property
+     */
+    private $content;
+
+    /**
+     * Create a new figure object.
+     */
+    public function __construct($title = null, $role = null, $id = null, $class = null, $lang = null, $label = null)
+    {
+        parent::__construct($title, $role, $id, $class, $lang, $label);
+        $this->setContent(new FlowCollection());
+    }
+
+    public function getQtiClassName()
+    {
+        return self::QTI_CLASS_NAME;
+    }
+
+    public function getComponents()
+    {
+        return $this->getContent();
+    }
+
+    /**
+     * Set the collection of Flow objects composing the Div.
+     *
+     * @param FlowCollection $content A collection of Flow objects.
+     */
+    public function setContent(FlowCollection $content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Get the collection of Flow objects composing the Div.
+     *
+     * @return FlowCollection
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+}

--- a/src/qtism/data/storage/xml/marshalling/ContentMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ContentMarshaller.php
@@ -54,6 +54,10 @@ use qtism\data\content\TemplateBlock;
 use qtism\data\content\TemplateInline;
 use qtism\data\content\xhtml\html5\Figcaption;
 use qtism\data\content\xhtml\html5\Figure;
+use qtism\data\content\xhtml\html5\Rb;
+use qtism\data\content\xhtml\html5\Rp;
+use qtism\data\content\xhtml\html5\Rt;
+use qtism\data\content\xhtml\html5\Ruby;
 use qtism\data\content\xhtml\lists\Dl;
 use qtism\data\content\xhtml\lists\DlElement;
 use qtism\data\content\xhtml\lists\Li;
@@ -144,6 +148,10 @@ abstract class ContentMarshaller extends RecursiveMarshaller
         'i',
         'kbd',
         'q',
+        Ruby::QTI_CLASS_NAME,
+        Rb::QTI_CLASS_NAME,
+        Rp::QTI_CLASS_NAME,
+        Rt::QTI_CLASS_NAME,
         'samp',
         'small',
         'span',
@@ -181,7 +189,7 @@ abstract class ContentMarshaller extends RecursiveMarshaller
         'feedbackBlock',
         'bdo',
         Figure::QTI_CLASS_NAME_FIGURE,
-        Figcaption::QTI_CLASS_NAME_FIGCAPTION
+        Figcaption::QTI_CLASS_NAME_FIGCAPTION,
     ];
 
     /**
@@ -297,6 +305,14 @@ abstract class ContentMarshaller extends RecursiveMarshaller
             return $component->getContent()->getArrayCopy();
         } elseif ($component instanceof Figcaption) {
             return $component->getContent()->getArrayCopy();
+        } elseif ($component instanceof Ruby) {
+            return $component->getContent()->getArrayCopy();
+        } elseif ($component instanceof Rb) {
+            return $component->getContent()->getArrayCopy();
+        } elseif ($component instanceof Rp) {
+            return $component->getContent()->getArrayCopy();
+        } elseif ($component instanceof Rt) {
+            return $component->getContent()->getArrayCopy();
         }
     }
 
@@ -352,6 +368,8 @@ abstract class ContentMarshaller extends RecursiveMarshaller
             return $this->getChildElementsByTagName($element, 'simpleAssociableChoice');
         } elseif ($localName === Figure::QTI_CLASS_NAME_FIGURE) {
             return $this->getChildElementsByTagName($element, [Figcaption::QTI_CLASS_NAME_FIGCAPTION, Img::QTI_CLASS_NAME_IMG]);
+        } elseif ($localName === Ruby::QTI_CLASS_NAME) {
+            return $this->getChildElementsByTagName($element, [Rb::QTI_CLASS_NAME, Rp::QTI_CLASS_NAME, Rt::QTI_CLASS_NAME]);
         } elseif ($localName === 'gapImg') {
             return $this->getChildElementsByTagName($element, 'object');
         } else {

--- a/src/qtism/data/storage/xml/marshalling/Html5RbMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/Html5RbMarshaller.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\data\content\InlineCollection;
+use qtism\data\content\xhtml\html5\Rb;
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+
+class Html5RbMarshaller extends Html5ContentMarshaller
+{
+    public function getExpectedQtiClassName()
+    {
+        return Rb::QTI_CLASS_NAME;
+    }
+
+    /**
+     * @param QtiComponent&Rb $component
+     * @param QtiComponentCollection $children
+     * @return mixed
+     * @throws UnmarshallingException
+     */
+    protected function unmarshallChildrenKnown(DOMElement $element, QtiComponentCollection $children)
+    {
+        $component = parent::unmarshallChildrenKnown($element, $children);
+
+        if ($component->hasId()) {
+            $this->setDOMElementAttribute($element, 'id', $component->getId());
+        }
+
+        if ($component->hasClass()) {
+            $this->setDOMElementAttribute($element, 'class', $component->getClass());
+        }
+
+        return $component;
+    }
+
+    /**
+     * @param QtiComponent $component
+     * @param array $elements
+     * @return DOMElement
+     */
+    protected function marshallChildrenKnown(QtiComponent $component, array $elements)
+    {
+        $element = parent::marshallChildrenKnown($component, $elements);
+
+        if ($component->hasId()) {
+            $this->setDOMElementAttribute($element, 'id', $component->getId());
+        }
+
+        if ($component->hasClass()) {
+            $this->setDOMElementAttribute($element, 'class', $component->getClass());
+        }
+
+        return $element;
+    }
+
+    protected static function getContentCollectionClassName()
+    {
+        return InlineCollection::class;
+    }
+}

--- a/src/qtism/data/storage/xml/marshalling/Html5RpMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/Html5RpMarshaller.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\data\content\InlineCollection;
+use qtism\data\content\xhtml\html5\Rp;
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+
+class Html5RpMarshaller extends Html5ContentMarshaller
+{
+    public function getExpectedQtiClassName()
+    {
+        return Rp::QTI_CLASS_NAME;
+    }
+
+    /**
+     * @param QtiComponent&Rp $component
+     * @param QtiComponentCollection $children
+     * @return mixed
+     * @throws UnmarshallingException
+     */
+    protected function unmarshallChildrenKnown(DOMElement $element, QtiComponentCollection $children)
+    {
+        $component = parent::unmarshallChildrenKnown($element, $children);
+
+        if ($component->hasId()) {
+            $this->setDOMElementAttribute($element, 'id', $component->getId());
+        }
+
+        if ($component->hasClass()) {
+            $this->setDOMElementAttribute($element, 'class', $component->getClass());
+        }
+
+        return $component;
+    }
+
+    /**
+     * @param QtiComponent $component
+     * @param array $elements
+     * @return DOMElement
+     */
+    protected function marshallChildrenKnown(QtiComponent $component, array $elements)
+    {
+        $element = parent::marshallChildrenKnown($component, $elements);
+
+        if ($component->hasId()) {
+            $this->setDOMElementAttribute($element, 'id', $component->getId());
+        }
+
+        if ($component->hasClass()) {
+            $this->setDOMElementAttribute($element, 'class', $component->getClass());
+        }
+
+        return $element;
+    }
+
+    protected static function getContentCollectionClassName()
+    {
+        return InlineCollection::class;
+    }
+}

--- a/src/qtism/data/storage/xml/marshalling/Html5RtMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/Html5RtMarshaller.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\data\content\InlineCollection;
+use qtism\data\content\xhtml\html5\Rt;
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+
+class Html5RtMarshaller extends Html5ContentMarshaller
+{
+    public function getExpectedQtiClassName()
+    {
+        return Rt::QTI_CLASS_NAME;
+    }
+
+    /**
+     * @param QtiComponent&Rt $component
+     * @param QtiComponentCollection $children
+     * @return mixed
+     * @throws UnmarshallingException
+     */
+    protected function unmarshallChildrenKnown(DOMElement $element, QtiComponentCollection $children)
+    {
+        $component = parent::unmarshallChildrenKnown($element, $children);
+
+        if ($component->hasId()) {
+            $this->setDOMElementAttribute($element, 'id', $component->getId());
+        }
+
+        if ($component->hasClass()) {
+            $this->setDOMElementAttribute($element, 'class', $component->getClass());
+        }
+
+        return $component;
+    }
+
+    /**
+     * @param QtiComponent $component
+     * @param array $elements
+     * @return DOMElement
+     */
+    protected function marshallChildrenKnown(QtiComponent $component, array $elements)
+    {
+        $element = parent::marshallChildrenKnown($component, $elements);
+
+        if ($component->hasId()) {
+            $this->setDOMElementAttribute($element, 'id', $component->getId());
+        }
+
+        if ($component->hasClass()) {
+            $this->setDOMElementAttribute($element, 'class', $component->getClass());
+        }
+
+        return $element;
+    }
+
+    protected static function getContentCollectionClassName()
+    {
+        return InlineCollection::class;
+    }
+}

--- a/src/qtism/data/storage/xml/marshalling/Html5RubyMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/Html5RubyMarshaller.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\data\storage\xml\marshalling;
+
+use DOMElement;
+use qtism\data\content\FlowCollection;
+use qtism\data\content\xhtml\html5\Ruby;
+use qtism\data\QtiComponent;
+use qtism\data\QtiComponentCollection;
+
+class Html5RubyMarshaller extends Html5ContentMarshaller
+{
+    public function getExpectedQtiClassName()
+    {
+        return Ruby::QTI_CLASS_NAME;
+    }
+
+    /**
+     *
+     * @param QtiComponent&Ruby $component
+     * @param QtiComponentCollection $children
+     * @return mixed
+     * @throws UnmarshallingException
+     */
+    protected function unmarshallChildrenKnown(DOMElement $element, QtiComponentCollection $children)
+    {
+        $component = parent::unmarshallChildrenKnown($element, $children);
+
+        if ($component->hasId()) {
+            $this->setDOMElementAttribute($element, 'id', $component->getId());
+        }
+
+        if ($component->hasClass()) {
+            $this->setDOMElementAttribute($element, 'class', $component->getClass());
+        }
+
+        return $component;
+    }
+
+    /**
+     * @param QtiComponent $component
+     * @param array $elements
+     * @return DOMElement
+     */
+    protected function marshallChildrenKnown(QtiComponent $component, array $elements)
+    {
+        $element = parent::marshallChildrenKnown($component, $elements);
+
+        if ($component->hasId()) {
+            $this->setDOMElementAttribute($element, 'id', $component->getId());
+        }
+
+        if ($component->hasClass()) {
+            $this->setDOMElementAttribute($element, 'class', $component->getClass());
+        }
+
+        return $element;
+    }
+
+    protected static function getContentCollectionClassName()
+    {
+        return FlowCollection::class;
+    }
+}

--- a/src/qtism/data/storage/xml/marshalling/Qti22MarshallerFactory.php
+++ b/src/qtism/data/storage/xml/marshalling/Qti22MarshallerFactory.php
@@ -26,6 +26,10 @@ namespace qtism\data\storage\xml\marshalling;
 use qtism\common\utils\Reflection;
 use qtism\data\content\xhtml\html5\Figcaption;
 use qtism\data\content\xhtml\html5\Figure;
+use qtism\data\content\xhtml\html5\Rb;
+use qtism\data\content\xhtml\html5\Rp;
+use qtism\data\content\xhtml\html5\Rt;
+use qtism\data\content\xhtml\html5\Ruby;
 use ReflectionClass;
 
 /**
@@ -45,6 +49,10 @@ class Qti22MarshallerFactory extends MarshallerFactory
         $this->addMappingEntry('bdo', SimpleInlineMarshaller::class);
         $this->addMappingEntry(Figure::QTI_CLASS_NAME_FIGURE, Html5FigureMarshaller::class);
         $this->addMappingEntry(Figcaption::QTI_CLASS_NAME_FIGCAPTION, Html5FigcaptionMarshaller::class);
+        $this->addMappingEntry(Ruby::QTI_CLASS_NAME, Html5RubyMarshaller::class);
+        $this->addMappingEntry(Rb::QTI_CLASS_NAME, Html5RbMarshaller::class);
+        $this->addMappingEntry(Rp::QTI_CLASS_NAME, Html5RpMarshaller::class);
+        $this->addMappingEntry(Rt::QTI_CLASS_NAME, Html5RtMarshaller::class);
     }
 
     /**

--- a/src/qtism/runtime/rendering/markup/xhtml/RbRenderer.php
+++ b/src/qtism/runtime/rendering/markup/xhtml/RbRenderer.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\runtime\rendering\markup\xhtml;
+
+use qtism\data\content\xhtml\html5\Rb;
+use qtism\data\QtiComponent;
+use DOMDocumentFragment;
+
+class RbRenderer extends Html5ElementRenderer
+{
+    /**
+     * @param QtiComponent&Rb $component
+     */
+    protected function appendAttributes(DOMDocumentFragment $fragment, QtiComponent $component, $base = '')
+    {
+        parent::appendAttributes($fragment, $component, $base);
+
+        /** @var Rb $component */
+        if ($component->hasId()) {
+            $fragment->firstChild->setAttribute('id', $component->getId());
+        }
+        if ($component->hasClass()) {
+            $fragment->firstChild->setAttribute('class', $component->getClass());
+        }
+    }
+}

--- a/src/qtism/runtime/rendering/markup/xhtml/RpRenderer.php
+++ b/src/qtism/runtime/rendering/markup/xhtml/RpRenderer.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\runtime\rendering\markup\xhtml;
+
+use qtism\data\content\xhtml\html5\Rp;
+use qtism\data\QtiComponent;
+use DOMDocumentFragment;
+
+class RpRenderer extends Html5ElementRenderer
+{
+    /**
+     * @param QtiComponent&Rp $component
+     */
+    protected function appendAttributes(DOMDocumentFragment $fragment, QtiComponent $component, $base = '')
+    {
+        parent::appendAttributes($fragment, $component, $base);
+
+        /** @var Rp $component */
+        if ($component->hasId()) {
+            $fragment->firstChild->setAttribute('id', $component->getId());
+        }
+        if ($component->hasClass()) {
+            $fragment->firstChild->setAttribute('class', $component->getClass());
+        }
+    }
+}

--- a/src/qtism/runtime/rendering/markup/xhtml/RtRenderer.php
+++ b/src/qtism/runtime/rendering/markup/xhtml/RtRenderer.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\runtime\rendering\markup\xhtml;
+
+use qtism\data\content\xhtml\html5\Rt;
+use qtism\data\QtiComponent;
+use DOMDocumentFragment;
+
+class RtRenderer extends Html5ElementRenderer
+{
+    /**
+     * @param QtiComponent&Rt $component
+     */
+    protected function appendAttributes(DOMDocumentFragment $fragment, QtiComponent $component, $base = '')
+    {
+        parent::appendAttributes($fragment, $component, $base);
+
+        /** @var Rt $component */
+        if ($component->hasId()) {
+            $fragment->firstChild->setAttribute('id', $component->getId());
+        }
+        if ($component->hasClass()) {
+            $fragment->firstChild->setAttribute('class', $component->getClass());
+        }
+    }
+}

--- a/src/qtism/runtime/rendering/markup/xhtml/RubyRenderer.php
+++ b/src/qtism/runtime/rendering/markup/xhtml/RubyRenderer.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\runtime\rendering\markup\xhtml;
+
+use qtism\data\content\xhtml\html5\Ruby;
+use qtism\data\QtiComponent;
+use DOMDocumentFragment;
+
+class RubyRenderer extends Html5ElementRenderer
+{
+    /**
+     * @param QtiComponent&Ruby $component
+     */
+    protected function appendAttributes(DOMDocumentFragment $fragment, QtiComponent $component, $base = '')
+    {
+        parent::appendAttributes($fragment, $component, $base);
+
+        /** @var Ruby $component */
+        if ($component->hasId()) {
+            $fragment->firstChild->setAttribute('id', $component->getId());
+        }
+        if ($component->hasClass()) {
+            $fragment->firstChild->setAttribute('class', $component->getClass());
+        }
+    }
+}

--- a/src/qtism/runtime/rendering/markup/xhtml/XhtmlRenderingEngine.php
+++ b/src/qtism/runtime/rendering/markup/xhtml/XhtmlRenderingEngine.php
@@ -25,6 +25,10 @@ namespace qtism\runtime\rendering\markup\xhtml;
 
 use qtism\data\content\xhtml\html5\Figcaption;
 use qtism\data\content\xhtml\html5\Figure;
+use qtism\data\content\xhtml\html5\Rb;
+use qtism\data\content\xhtml\html5\Rt;
+use qtism\data\content\xhtml\html5\Rp;
+use qtism\data\content\xhtml\html5\Ruby;
 use qtism\runtime\rendering\markup\AbstractMarkupRenderingEngine;
 
 /**
@@ -149,6 +153,10 @@ class XhtmlRenderingEngine extends AbstractMarkupRenderingEngine
         $this->registerRenderer('printedVariable', new PrintedVariableRenderer());
         $this->registerRenderer('prompt', new PromptRenderer());
         $this->registerRenderer('q', new QRenderer());
+        $this->registerRenderer(Ruby::QTI_CLASS_NAME, new RubyRenderer());
+        $this->registerRenderer(Rb::QTI_CLASS_NAME, new RbRenderer());
+        $this->registerRenderer(Rt::QTI_CLASS_NAME, new RtRenderer());
+        $this->registerRenderer(Rp::QTI_CLASS_NAME, new RpRenderer());
         $this->registerRenderer('rubricBlock', new RubricBlockRenderer());
         $this->registerRenderer('selectPointInteraction', new SelectPointInteractionRenderer());
         $this->registerRenderer('simpleAssociableChoice', new SimpleAssociableChoiceRenderer());

--- a/test/qtismtest/data/content/xhtml/html5/RbTest.php
+++ b/test/qtismtest/data/content/xhtml/html5/RbTest.php
@@ -27,6 +27,8 @@ use qtismtest\QtiSmTestCase;
 
 class RbTest extends QtiSmTestCase
 {
+    const SUBJECT_QTI_CLASS_NAME = 'rb';
+
     public function testCreateWithValues(): void
     {
         $id = 'testid';
@@ -50,6 +52,6 @@ class RbTest extends QtiSmTestCase
     {
         $subject = new Rb();
 
-        self::assertEquals(Rb::QTI_CLASS_NAME, $subject->getQtiClassName());
+        self::assertEquals(self::SUBJECT_QTI_CLASS_NAME, $subject->getQtiClassName());
     }
 }

--- a/test/qtismtest/data/content/xhtml/html5/RbTest.php
+++ b/test/qtismtest/data/content/xhtml/html5/RbTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\data\content\xhtml\html5;
+
+use qtism\data\content\xhtml\html5\Rb;
+use qtismtest\QtiSmTestCase;
+
+class RbTest extends QtiSmTestCase
+{
+    public function testCreateWithValues(): void
+    {
+        $id = 'testid';
+        $class = 'test_class';
+
+        $subject = new Rb(null, null, $id, $class);
+
+        self::assertEquals($id, $subject->getId());
+        self::assertEquals($class, $subject->getClass());
+    }
+
+    public function testCreateWithDefaultValues(): void
+    {
+        $subject = new Rb();
+
+        self::assertEquals('', $subject->getId());
+        self::assertEquals('', $subject->getClass());
+    }
+
+    public function testGetQtiClassName(): void
+    {
+        $subject = new Rb();
+
+        self::assertEquals(Rb::QTI_CLASS_NAME, $subject->getQtiClassName());
+    }
+}

--- a/test/qtismtest/data/content/xhtml/html5/RpTest.php
+++ b/test/qtismtest/data/content/xhtml/html5/RpTest.php
@@ -27,6 +27,8 @@ use qtismtest\QtiSmTestCase;
 
 class RpTest extends QtiSmTestCase
 {
+    const SUBJECT_QTI_CLASS_NAME = 'rp';
+
     public function testCreateWithValues(): void
     {
         $id = 'testid';
@@ -50,6 +52,6 @@ class RpTest extends QtiSmTestCase
     {
         $subject = new Rp();
 
-        self::assertEquals(Rp::QTI_CLASS_NAME, $subject->getQtiClassName());
+        self::assertEquals(self::SUBJECT_QTI_CLASS_NAME, $subject->getQtiClassName());
     }
 }

--- a/test/qtismtest/data/content/xhtml/html5/RpTest.php
+++ b/test/qtismtest/data/content/xhtml/html5/RpTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\data\content\xhtml\html5;
+
+use qtism\data\content\xhtml\html5\Rp;
+use qtismtest\QtiSmTestCase;
+
+class RpTest extends QtiSmTestCase
+{
+    public function testCreateWithValues(): void
+    {
+        $id = 'testid';
+        $class = 'test_class';
+
+        $subject = new Rp(null, null, $id, $class);
+
+        self::assertEquals($id, $subject->getId());
+        self::assertEquals($class, $subject->getClass());
+    }
+
+    public function testCreateWithDefaultValues(): void
+    {
+        $subject = new Rp();
+
+        self::assertEquals('', $subject->getId());
+        self::assertEquals('', $subject->getClass());
+    }
+
+    public function testGetQtiClassName(): void
+    {
+        $subject = new Rp();
+
+        self::assertEquals(Rp::QTI_CLASS_NAME, $subject->getQtiClassName());
+    }
+}

--- a/test/qtismtest/data/content/xhtml/html5/RtTest.php
+++ b/test/qtismtest/data/content/xhtml/html5/RtTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\data\content\xhtml\html5;
+
+use qtism\data\content\xhtml\html5\Rt;
+use qtismtest\QtiSmTestCase;
+
+class RtTest extends QtiSmTestCase
+{
+    public function testCreateWithValues(): void
+    {
+        $id = 'testid';
+        $class = 'test_class';
+
+        $subject = new Rt(null, null, $id, $class);
+
+        self::assertEquals($id, $subject->getId());
+        self::assertEquals($class, $subject->getClass());
+    }
+
+    public function testCreateWithDefaultValues(): void
+    {
+        $subject = new Rt();
+
+        self::assertEquals('', $subject->getId());
+        self::assertEquals('', $subject->getClass());
+    }
+
+    public function testGetQtiClassName(): void
+    {
+        $subject = new Rt();
+
+        self::assertEquals(Rt::QTI_CLASS_NAME, $subject->getQtiClassName());
+    }
+}

--- a/test/qtismtest/data/content/xhtml/html5/RtTest.php
+++ b/test/qtismtest/data/content/xhtml/html5/RtTest.php
@@ -27,6 +27,8 @@ use qtismtest\QtiSmTestCase;
 
 class RtTest extends QtiSmTestCase
 {
+    const SUBJECT_QTI_CLASS_NAME = 'rt';
+
     public function testCreateWithValues(): void
     {
         $id = 'testid';
@@ -50,6 +52,6 @@ class RtTest extends QtiSmTestCase
     {
         $subject = new Rt();
 
-        self::assertEquals(Rt::QTI_CLASS_NAME, $subject->getQtiClassName());
+        self::assertEquals(self::SUBJECT_QTI_CLASS_NAME, $subject->getQtiClassName());
     }
 }

--- a/test/qtismtest/data/content/xhtml/html5/RubyTest.php
+++ b/test/qtismtest/data/content/xhtml/html5/RubyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\data\content\xhtml\html5;
+
+use qtism\data\content\xhtml\html5\Ruby;
+use qtismtest\QtiSmTestCase;
+
+class RubyTest extends QtiSmTestCase
+{
+    public function testCreateWithValues(): void
+    {
+        $id = 'testid';
+        $class = 'test_class';
+
+        $subject = new Ruby(null, null, $id, $class);
+
+        self::assertEquals($id, $subject->getId());
+        self::assertEquals($class, $subject->getClass());
+    }
+
+    public function testCreateWithDefaultValues(): void
+    {
+        $subject = new Ruby();
+
+        self::assertEquals('', $subject->getId());
+        self::assertEquals('', $subject->getClass());
+    }
+
+    public function testGetQtiClassName(): void
+    {
+        $subject = new Ruby();
+
+        self::assertEquals(Ruby::QTI_CLASS_NAME, $subject->getQtiClassName());
+    }
+}

--- a/test/qtismtest/data/content/xhtml/html5/RubyTest.php
+++ b/test/qtismtest/data/content/xhtml/html5/RubyTest.php
@@ -27,6 +27,8 @@ use qtismtest\QtiSmTestCase;
 
 class RubyTest extends QtiSmTestCase
 {
+    const SUBJECT_QTI_CLASS_NAME = 'ruby';
+
     public function testCreateWithValues(): void
     {
         $id = 'testid';
@@ -50,6 +52,6 @@ class RubyTest extends QtiSmTestCase
     {
         $subject = new Ruby();
 
-        self::assertEquals(Ruby::QTI_CLASS_NAME, $subject->getQtiClassName());
+        self::assertEquals(self::SUBJECT_QTI_CLASS_NAME, $subject->getQtiClassName());
     }
 }

--- a/test/qtismtest/data/storage/xml/marshalling/Html5RbMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/Html5RbMarshallerTest.php
@@ -30,13 +30,15 @@ use qtism\data\storage\xml\marshalling\MarshallingException;
 
 class Html5RbMarshallerTest extends Html5ElementMarshallerTest
 {
+    const SUBJECT_QTI_CLASS_NAME = 'rb';
+
     /**
      * @throws MarshallerNotFoundException
      * @throws MarshallingException
      */
     public function testMarshallerDoesNotExistInQti21(): void
     {
-        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Rb(), Rb::QTI_CLASS_NAME);
+        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Rb(), self::SUBJECT_QTI_CLASS_NAME);
     }
 
     /**
@@ -50,10 +52,10 @@ class Html5RbMarshallerTest extends Html5ElementMarshallerTest
 
         $expected = sprintf(
             '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
-            $this->namespaceTag(Rb::QTI_CLASS_NAME),
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
             $id,
             $class,
-            $this->prefixTag(Rb::QTI_CLASS_NAME)
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $object = new Rb(null, null, $id, $class);
@@ -70,8 +72,8 @@ class Html5RbMarshallerTest extends Html5ElementMarshallerTest
     {
         $expected = sprintf(
             '<%s>text content</%s>',
-            $this->namespaceTag(Rb::QTI_CLASS_NAME),
-            $this->prefixTag(Rb::QTI_CLASS_NAME)
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $object = new Rb();
@@ -88,10 +90,10 @@ class Html5RbMarshallerTest extends Html5ElementMarshallerTest
         $this->assertHtml5UnmarshallingOnlyInQti22AndAbove(
             sprintf(
                 '<%s></%s>',
-                $this->namespaceTag(Rb::QTI_CLASS_NAME),
-                $this->prefixTag(Rb::QTI_CLASS_NAME)
+                $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+                $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
             ),
-            Rb::QTI_CLASS_NAME
+            self::SUBJECT_QTI_CLASS_NAME
         );
     }
 
@@ -105,10 +107,10 @@ class Html5RbMarshallerTest extends Html5ElementMarshallerTest
 
         $xml = sprintf(
             '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
-            $this->namespaceTag(Rb::QTI_CLASS_NAME),
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
             $id,
             $class,
-            $this->prefixTag(Rb::QTI_CLASS_NAME)
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $expected = new Rb(null, null, $id, $class);
@@ -121,8 +123,8 @@ class Html5RbMarshallerTest extends Html5ElementMarshallerTest
     {
         $xml = sprintf(
             '<%s>text content</%s>',
-            $this->namespaceTag(Rb::QTI_CLASS_NAME),
-            $this->prefixTag(Rb::QTI_CLASS_NAME)
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $expected = new Rb();

--- a/test/qtismtest/data/storage/xml/marshalling/Html5RbMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/Html5RbMarshallerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\data\content\InlineCollection;
+use qtism\data\content\TextRun;
+use qtism\data\content\xhtml\html5\Rb;
+use qtism\data\storage\xml\marshalling\MarshallerNotFoundException;
+use qtism\data\storage\xml\marshalling\MarshallingException;
+
+class Html5RbMarshallerTest extends Html5ElementMarshallerTest
+{
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshallerDoesNotExistInQti21(): void
+    {
+        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Rb(), Rb::QTI_CLASS_NAME);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshall22(): void
+    {
+        $id = 'id';
+        $class = 'testclass';
+
+        $expected = sprintf(
+            '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
+            $this->namespaceTag(Rb::QTI_CLASS_NAME),
+            $id,
+            $class,
+            $this->prefixTag(Rb::QTI_CLASS_NAME)
+        );
+
+        $object = new Rb(null, null, $id, $class);
+        $object->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertMarshalling($expected, $object);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshall22WithDefaultValues(): void
+    {
+        $expected = sprintf(
+            '<%s>text content</%s>',
+            $this->namespaceTag(Rb::QTI_CLASS_NAME),
+            $this->prefixTag(Rb::QTI_CLASS_NAME)
+        );
+
+        $object = new Rb();
+        $object->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertMarshalling($expected, $object);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     */
+    public function testUnMarshallerDoesNotExistInQti21(): void
+    {
+        $this->assertHtml5UnmarshallingOnlyInQti22AndAbove(
+            sprintf(
+                '<%s></%s>',
+                $this->namespaceTag(Rb::QTI_CLASS_NAME),
+                $this->prefixTag(Rb::QTI_CLASS_NAME)
+            ),
+            Rb::QTI_CLASS_NAME
+        );
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     */
+    public function testUnmarshall22(): void
+    {
+        $id = 'id';
+        $class = 'testclass';
+
+        $xml = sprintf(
+            '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
+            $this->namespaceTag(Rb::QTI_CLASS_NAME),
+            $id,
+            $class,
+            $this->prefixTag(Rb::QTI_CLASS_NAME)
+        );
+
+        $expected = new Rb(null, null, $id, $class);
+        $expected->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertUnmarshalling($expected, $xml);
+    }
+
+    public function testUnmarshall22WithDefaultValues(): void
+    {
+        $xml = sprintf(
+            '<%s>text content</%s>',
+            $this->namespaceTag(Rb::QTI_CLASS_NAME),
+            $this->prefixTag(Rb::QTI_CLASS_NAME)
+        );
+
+        $expected = new Rb();
+        $expected->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertUnmarshalling($expected, $xml);
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/Html5RpMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/Html5RpMarshallerTest.php
@@ -30,13 +30,15 @@ use qtism\data\storage\xml\marshalling\MarshallingException;
 
 class Html5RpMarshallerTest extends Html5ElementMarshallerTest
 {
+    const SUBJECT_QTI_CLASS_NAME = 'rp';
+
     /**
      * @throws MarshallerNotFoundException
      * @throws MarshallingException
      */
     public function testMarshallerDoesNotExistInQti21(): void
     {
-        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Rp(), Rp::QTI_CLASS_NAME);
+        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Rp(), self::SUBJECT_QTI_CLASS_NAME);
     }
 
     /**
@@ -50,10 +52,10 @@ class Html5RpMarshallerTest extends Html5ElementMarshallerTest
 
         $expected = sprintf(
             '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
-            $this->namespaceTag(Rp::QTI_CLASS_NAME),
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
             $id,
             $class,
-            $this->prefixTag(Rp::QTI_CLASS_NAME)
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $object = new Rp(null, null, $id, $class);
@@ -70,8 +72,8 @@ class Html5RpMarshallerTest extends Html5ElementMarshallerTest
     {
         $expected = sprintf(
             '<%s>text content</%s>',
-            $this->namespaceTag(Rp::QTI_CLASS_NAME),
-            $this->prefixTag(Rp::QTI_CLASS_NAME)
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $object = new Rp();
@@ -88,10 +90,10 @@ class Html5RpMarshallerTest extends Html5ElementMarshallerTest
         $this->assertHtml5UnmarshallingOnlyInQti22AndAbove(
             sprintf(
                 '<%s></%s>',
-                $this->namespaceTag(Rp::QTI_CLASS_NAME),
-                $this->prefixTag(Rp::QTI_CLASS_NAME)
+                $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+                $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
             ),
-            Rp::QTI_CLASS_NAME
+            self::SUBJECT_QTI_CLASS_NAME
         );
     }
 
@@ -105,10 +107,10 @@ class Html5RpMarshallerTest extends Html5ElementMarshallerTest
 
         $xml = sprintf(
             '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
-            $this->namespaceTag(Rp::QTI_CLASS_NAME),
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
             $id,
             $class,
-            $this->prefixTag(Rp::QTI_CLASS_NAME)
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $expected = new Rp(null, null, $id, $class);
@@ -121,8 +123,8 @@ class Html5RpMarshallerTest extends Html5ElementMarshallerTest
     {
         $xml = sprintf(
             '<%s>text content</%s>',
-            $this->namespaceTag(Rp::QTI_CLASS_NAME),
-            $this->prefixTag(Rp::QTI_CLASS_NAME)
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $expected = new Rp();

--- a/test/qtismtest/data/storage/xml/marshalling/Html5RpMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/Html5RpMarshallerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\data\content\InlineCollection;
+use qtism\data\content\TextRun;
+use qtism\data\content\xhtml\html5\Rp;
+use qtism\data\storage\xml\marshalling\MarshallerNotFoundException;
+use qtism\data\storage\xml\marshalling\MarshallingException;
+
+class Html5RpMarshallerTest extends Html5ElementMarshallerTest
+{
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshallerDoesNotExistInQti21(): void
+    {
+        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Rp(), Rp::QTI_CLASS_NAME);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshall22(): void
+    {
+        $id = 'id';
+        $class = 'testclass';
+
+        $expected = sprintf(
+            '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
+            $this->namespaceTag(Rp::QTI_CLASS_NAME),
+            $id,
+            $class,
+            $this->prefixTag(Rp::QTI_CLASS_NAME)
+        );
+
+        $object = new Rp(null, null, $id, $class);
+        $object->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertMarshalling($expected, $object);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshall22WithDefaultValues(): void
+    {
+        $expected = sprintf(
+            '<%s>text content</%s>',
+            $this->namespaceTag(Rp::QTI_CLASS_NAME),
+            $this->prefixTag(Rp::QTI_CLASS_NAME)
+        );
+
+        $object = new Rp();
+        $object->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertMarshalling($expected, $object);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     */
+    public function testUnMarshallerDoesNotExistInQti21(): void
+    {
+        $this->assertHtml5UnmarshallingOnlyInQti22AndAbove(
+            sprintf(
+                '<%s></%s>',
+                $this->namespaceTag(Rp::QTI_CLASS_NAME),
+                $this->prefixTag(Rp::QTI_CLASS_NAME)
+            ),
+            Rp::QTI_CLASS_NAME
+        );
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     */
+    public function testUnmarshall22(): void
+    {
+        $id = 'id';
+        $class = 'testclass';
+
+        $xml = sprintf(
+            '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
+            $this->namespaceTag(Rp::QTI_CLASS_NAME),
+            $id,
+            $class,
+            $this->prefixTag(Rp::QTI_CLASS_NAME)
+        );
+
+        $expected = new Rp(null, null, $id, $class);
+        $expected->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertUnmarshalling($expected, $xml);
+    }
+
+    public function testUnmarshall22WithDefaultValues(): void
+    {
+        $xml = sprintf(
+            '<%s>text content</%s>',
+            $this->namespaceTag(Rp::QTI_CLASS_NAME),
+            $this->prefixTag(Rp::QTI_CLASS_NAME)
+        );
+
+        $expected = new Rp();
+        $expected->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertUnmarshalling($expected, $xml);
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/Html5RtMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/Html5RtMarshallerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\data\content\InlineCollection;
+use qtism\data\content\TextRun;
+use qtism\data\content\xhtml\html5\Rt;
+use qtism\data\storage\xml\marshalling\MarshallerNotFoundException;
+use qtism\data\storage\xml\marshalling\MarshallingException;
+
+class Html5RtMarshallerTest extends Html5ElementMarshallerTest
+{
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshallerDoesNotExistInQti21(): void
+    {
+        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Rt(), Rt::QTI_CLASS_NAME);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshall22(): void
+    {
+        $id = 'id';
+        $class = 'testclass';
+
+        $expected = sprintf(
+            '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
+            $this->namespaceTag(Rt::QTI_CLASS_NAME),
+            $id,
+            $class,
+            $this->prefixTag(Rt::QTI_CLASS_NAME)
+        );
+
+        $object = new Rt(null, null, $id, $class);
+        $object->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertMarshalling($expected, $object);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshall22WithDefaultValues(): void
+    {
+        $expected = sprintf(
+            '<%s>text content</%s>',
+            $this->namespaceTag(Rt::QTI_CLASS_NAME),
+            $this->prefixTag(Rt::QTI_CLASS_NAME)
+        );
+
+        $object = new Rt();
+        $object->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertMarshalling($expected, $object);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     */
+    public function testUnMarshallerDoesNotExistInQti21(): void
+    {
+        $this->assertHtml5UnmarshallingOnlyInQti22AndAbove(
+            sprintf(
+                '<%s></%s>',
+                $this->namespaceTag(Rt::QTI_CLASS_NAME),
+                $this->prefixTag(Rt::QTI_CLASS_NAME)
+            ),
+            Rt::QTI_CLASS_NAME
+        );
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     */
+    public function testUnmarshall22(): void
+    {
+        $id = 'id';
+        $class = 'testclass';
+
+        $xml = sprintf(
+            '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
+            $this->namespaceTag(Rt::QTI_CLASS_NAME),
+            $id,
+            $class,
+            $this->prefixTag(Rt::QTI_CLASS_NAME)
+        );
+
+        $expected = new Rt(null, null, $id, $class);
+        $expected->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertUnmarshalling($expected, $xml);
+    }
+
+    public function testUnmarshall22WithDefaultValues(): void
+    {
+        $xml = sprintf(
+            '<%s>text content</%s>',
+            $this->namespaceTag(Rt::QTI_CLASS_NAME),
+            $this->prefixTag(Rt::QTI_CLASS_NAME)
+        );
+
+        $expected = new Rt();
+        $expected->setContent(new InlineCollection([new TextRun('text content')]));
+
+        $this->assertUnmarshalling($expected, $xml);
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/Html5RtMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/Html5RtMarshallerTest.php
@@ -30,13 +30,15 @@ use qtism\data\storage\xml\marshalling\MarshallingException;
 
 class Html5RtMarshallerTest extends Html5ElementMarshallerTest
 {
+    const SUBJECT_QTI_CLASS_NAME = 'rt';
+
     /**
      * @throws MarshallerNotFoundException
      * @throws MarshallingException
      */
     public function testMarshallerDoesNotExistInQti21(): void
     {
-        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Rt(), Rt::QTI_CLASS_NAME);
+        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Rt(), self::SUBJECT_QTI_CLASS_NAME);
     }
 
     /**
@@ -50,10 +52,10 @@ class Html5RtMarshallerTest extends Html5ElementMarshallerTest
 
         $expected = sprintf(
             '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
-            $this->namespaceTag(Rt::QTI_CLASS_NAME),
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
             $id,
             $class,
-            $this->prefixTag(Rt::QTI_CLASS_NAME)
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $object = new Rt(null, null, $id, $class);
@@ -70,8 +72,8 @@ class Html5RtMarshallerTest extends Html5ElementMarshallerTest
     {
         $expected = sprintf(
             '<%s>text content</%s>',
-            $this->namespaceTag(Rt::QTI_CLASS_NAME),
-            $this->prefixTag(Rt::QTI_CLASS_NAME)
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $object = new Rt();
@@ -88,10 +90,10 @@ class Html5RtMarshallerTest extends Html5ElementMarshallerTest
         $this->assertHtml5UnmarshallingOnlyInQti22AndAbove(
             sprintf(
                 '<%s></%s>',
-                $this->namespaceTag(Rt::QTI_CLASS_NAME),
-                $this->prefixTag(Rt::QTI_CLASS_NAME)
+                $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+                $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
             ),
-            Rt::QTI_CLASS_NAME
+            self::SUBJECT_QTI_CLASS_NAME
         );
     }
 
@@ -105,10 +107,10 @@ class Html5RtMarshallerTest extends Html5ElementMarshallerTest
 
         $xml = sprintf(
             '<%1$s id="%2$s" class="%3$s">text content</%4$s>',
-            $this->namespaceTag(Rt::QTI_CLASS_NAME),
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
             $id,
             $class,
-            $this->prefixTag(Rt::QTI_CLASS_NAME)
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $expected = new Rt(null, null, $id, $class);
@@ -121,8 +123,8 @@ class Html5RtMarshallerTest extends Html5ElementMarshallerTest
     {
         $xml = sprintf(
             '<%s>text content</%s>',
-            $this->namespaceTag(Rt::QTI_CLASS_NAME),
-            $this->prefixTag(Rt::QTI_CLASS_NAME)
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $expected = new Rt();

--- a/test/qtismtest/data/storage/xml/marshalling/Html5RubyMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/Html5RubyMarshallerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtismtest\data\storage\xml\marshalling;
+
+use qtism\data\content\FlowCollection;
+use qtism\data\content\InlineCollection;
+use qtism\data\content\TextRun;
+use qtism\data\content\xhtml\html5\Rb;
+use qtism\data\content\xhtml\html5\Rt;
+use qtism\data\content\xhtml\html5\Rp;
+use qtism\data\content\xhtml\html5\Ruby;
+use qtism\data\storage\xml\marshalling\MarshallerNotFoundException;
+use qtism\data\storage\xml\marshalling\MarshallingException;
+
+class Html5RubyMarshallerTest extends Html5ElementMarshallerTest
+{
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshallerDoesNotExistInQti21(): void
+    {
+        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Ruby(), Ruby::QTI_CLASS_NAME);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshall22(): void
+    {
+        $id = 'id';
+        $class = 'testclass';
+
+        $expected = sprintf(
+            '<%1$s id="%2$s" class="%3$s><%4$s>真</%4$s><%5$s>まこと</%5$s><%6$s>真</%6$s><%7$s>真</%7$s></%1$s>',
+            $this->namespaceTag(Ruby::QTI_CLASS_NAME),
+            $id,
+            $class,
+            $this->prefixTag(Ruby::QTI_CLASS_NAME),
+            $this->prefixTag(Rb::QTI_CLASS_NAME),
+            $this->prefixTag(Rt::QTI_CLASS_NAME),
+            $this->prefixTag(Rp::QTI_CLASS_NAME)
+        );
+
+        $rb = new Rb();
+        $rb->setContent(new InlineCollection([new TextRun('まこと')]));
+
+        $rt = new Rt();
+        $rt->setContent(new InlineCollection([new TextRun('真')]));
+
+        $rp = new Rp();
+        $rp->setContent(new InlineCollection([new TextRun('真')]));
+
+        $object = new Ruby(null, null, $id, $class);
+        $object->setContent(new FlowCollection([$rb, $rt, $rp]));
+
+        $this->assertMarshalling($expected, $object);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     * @throws MarshallingException
+     */
+    public function testMarshall22WithDefaultValues(): void
+    {
+        $expected = sprintf(
+            '<%s/>',
+            $this->namespaceTag(Ruby::QTI_CLASS_NAME)
+        );
+
+        $ruby = new Ruby();
+
+        $this->assertMarshalling($expected, $ruby);
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     */
+    public function testUnMarshallerDoesNotExistInQti21(): void
+    {
+        $this->assertHtml5UnmarshallingOnlyInQti22AndAbove(
+            sprintf(
+                '<%s></%s>',
+                $this->namespaceTag(Ruby::QTI_CLASS_NAME),
+                $this->prefixTag(Ruby::QTI_CLASS_NAME)
+            ),
+            Ruby::QTI_CLASS_NAME
+        );
+    }
+
+    /**
+     * @throws MarshallerNotFoundException
+     */
+    public function testUnmarshall22(): void
+    {
+        $id = 'id';
+        $class = 'testclass';
+
+        $xml = sprintf(
+            '<%1$s id="%2$s" class="%3$s"></%4$s>',
+            $this->namespaceTag(Ruby::QTI_CLASS_NAME),
+            $id,
+            $class,
+            $this->prefixTag(Ruby::QTI_CLASS_NAME)
+        );
+
+        $expected = new Ruby(null, null, $id, $class);
+
+        $this->assertUnmarshalling($expected, $xml);
+    }
+
+    public function testUnmarshall22WithDefaultValues(): void
+    {
+        $xml = sprintf(
+            '<%s></%s>',
+            $this->namespaceTag(Ruby::QTI_CLASS_NAME),
+            $this->prefixTag(Ruby::QTI_CLASS_NAME)
+        );
+
+        $expected = new Ruby();
+
+        $this->assertUnmarshalling($expected, $xml);
+    }
+}

--- a/test/qtismtest/data/storage/xml/marshalling/Html5RubyMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/Html5RubyMarshallerTest.php
@@ -34,13 +34,15 @@ use qtism\data\storage\xml\marshalling\MarshallingException;
 
 class Html5RubyMarshallerTest extends Html5ElementMarshallerTest
 {
+    const SUBJECT_QTI_CLASS_NAME = 'ruby';
+
     /**
      * @throws MarshallerNotFoundException
      * @throws MarshallingException
      */
     public function testMarshallerDoesNotExistInQti21(): void
     {
-        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Ruby(), Ruby::QTI_CLASS_NAME);
+        $this->assertHtml5MarshallingOnlyInQti22AndAbove(new Ruby(), self::SUBJECT_QTI_CLASS_NAME);
     }
 
     /**
@@ -54,13 +56,13 @@ class Html5RubyMarshallerTest extends Html5ElementMarshallerTest
 
         $expected = sprintf(
             '<%1$s id="%2$s" class="%3$s"><%4$s>真</%4$s><%5$s>まこと</%5$s><%6$s>真</%6$s></%7$s>',
-            $this->namespaceTag(Ruby::QTI_CLASS_NAME),
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
             $id,
             $class,
             $this->prefixTag(Rt::QTI_CLASS_NAME),
             $this->prefixTag(Rb::QTI_CLASS_NAME),
             $this->prefixTag(Rp::QTI_CLASS_NAME),
-            $this->prefixTag(Ruby::QTI_CLASS_NAME)
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $rb = new Rb();
@@ -86,7 +88,7 @@ class Html5RubyMarshallerTest extends Html5ElementMarshallerTest
     {
         $expected = sprintf(
             '<%s/>',
-            $this->namespaceTag(Ruby::QTI_CLASS_NAME)
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $ruby = new Ruby();
@@ -102,10 +104,10 @@ class Html5RubyMarshallerTest extends Html5ElementMarshallerTest
         $this->assertHtml5UnmarshallingOnlyInQti22AndAbove(
             sprintf(
                 '<%s></%s>',
-                $this->namespaceTag(Ruby::QTI_CLASS_NAME),
-                $this->prefixTag(Ruby::QTI_CLASS_NAME)
+                $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+                $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
             ),
-            Ruby::QTI_CLASS_NAME
+            self::SUBJECT_QTI_CLASS_NAME
         );
     }
 
@@ -119,10 +121,10 @@ class Html5RubyMarshallerTest extends Html5ElementMarshallerTest
 
         $xml = sprintf(
             '<%1$s id="%2$s" class="%3$s"></%4$s>',
-            $this->namespaceTag(Ruby::QTI_CLASS_NAME),
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
             $id,
             $class,
-            $this->prefixTag(Ruby::QTI_CLASS_NAME)
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $expected = new Ruby(null, null, $id, $class);
@@ -134,8 +136,8 @@ class Html5RubyMarshallerTest extends Html5ElementMarshallerTest
     {
         $xml = sprintf(
             '<%s></%s>',
-            $this->namespaceTag(Ruby::QTI_CLASS_NAME),
-            $this->prefixTag(Ruby::QTI_CLASS_NAME)
+            $this->namespaceTag(self::SUBJECT_QTI_CLASS_NAME),
+            $this->prefixTag(self::SUBJECT_QTI_CLASS_NAME)
         );
 
         $expected = new Ruby();

--- a/test/qtismtest/data/storage/xml/marshalling/Html5RubyMarshallerTest.php
+++ b/test/qtismtest/data/storage/xml/marshalling/Html5RubyMarshallerTest.php
@@ -53,14 +53,14 @@ class Html5RubyMarshallerTest extends Html5ElementMarshallerTest
         $class = 'testclass';
 
         $expected = sprintf(
-            '<%1$s id="%2$s" class="%3$s><%4$s>真</%4$s><%5$s>まこと</%5$s><%6$s>真</%6$s><%7$s>真</%7$s></%1$s>',
+            '<%1$s id="%2$s" class="%3$s"><%4$s>真</%4$s><%5$s>まこと</%5$s><%6$s>真</%6$s></%7$s>',
             $this->namespaceTag(Ruby::QTI_CLASS_NAME),
             $id,
             $class,
-            $this->prefixTag(Ruby::QTI_CLASS_NAME),
-            $this->prefixTag(Rb::QTI_CLASS_NAME),
             $this->prefixTag(Rt::QTI_CLASS_NAME),
-            $this->prefixTag(Rp::QTI_CLASS_NAME)
+            $this->prefixTag(Rb::QTI_CLASS_NAME),
+            $this->prefixTag(Rp::QTI_CLASS_NAME),
+            $this->prefixTag(Ruby::QTI_CLASS_NAME)
         );
 
         $rb = new Rb();
@@ -73,7 +73,7 @@ class Html5RubyMarshallerTest extends Html5ElementMarshallerTest
         $rp->setContent(new InlineCollection([new TextRun('真')]));
 
         $object = new Ruby(null, null, $id, $class);
-        $object->setContent(new FlowCollection([$rb, $rt, $rp]));
+        $object->setContent(new FlowCollection([ $rt, $rb, $rp]));
 
         $this->assertMarshalling($expected, $object);
     }

--- a/test/qtismtest/runtime/expressions/VariableProcessorTest.php
+++ b/test/qtismtest/runtime/expressions/VariableProcessorTest.php
@@ -106,8 +106,8 @@ class VariableProcessorTest extends QtiSmTestCase
         $variableExpr = $this->createComponentFromXml('<variable identifier="Q01.var2" weightIdentifier="weight1"/>');
         $variableProcessor->setExpression($variableExpr);
         $result = $variableProcessor->process();
-        $this::assertEquals(11.11, $result[0]->getValue());
-        $this::assertEquals(13.31, $result[1]->getValue());
+        $this::assertEquals(11.11, round($result[0]->getValue(), 2));
+        $this::assertEquals(13.31, round($result[1]->getValue(), 2));
         // The value in the state must be unchanged.
         $stateVal = $assessmentTestSession['Q01.var2'];
         $this::assertEquals(10.1, $stateVal[0]->getValue());

--- a/test/samples/custom/items/2_2/ruby_html5.xml
+++ b/test/samples/custom/items/2_2/ruby_html5.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example adapted from the PET Handbook, copyright University of Cambridge ESOL Examinations -->
+<!-- The example combines shuffle with the fixation of one simpleChoice in place -->
+<!-- Ruby markup is defined in NS hq5 (HTML5 for QTI), which is referenced in the main QTI 2.2 XSD -->
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:m="http://www.w3.org/1998/Math/MathML"
+                xmlns:qh5="http://www.imsglobal.org/xsd/imsqtiv2p2_html5_v1p0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd"
+                identifier="ruby" title="ruby 1" label="ruby 1" xml:lang="en-US"
+                adaptive="false" timeDependent="false" toolName="TAO" toolVersion="2022.01">
+  <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="identifier"/>
+  <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" normalMaximum="0"/>
+  <outcomeDeclaration identifier="MAXSCORE" cardinality="single" baseType="float">
+    <defaultValue>
+      <value>0</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <itemBody>
+    <div class="grid-row">
+      <div class="col-12">
+        <p>村田</p>
+        <qh5:ruby>
+          <qh5:rb>真</qh5:rb>
+          <qh5:rt>まこと</qh5:rt>
+        </qh5:ruby>
+        <p>の出身地はどこですか</p>
+      </div>
+    </div>
+    <choiceInteraction responseIdentifier="RESPONSE" shuffle="true" max-choices="1">
+      <prompt>選びなさい</prompt>
+      <simpleChoice identifier="ChoiceHK">
+        <qh5:ruby>
+          <qh5:rb>北海道</qh5:rb>
+          <qh5:rp>ほっかいどう</qh5:rp>
+        </qh5:ruby>
+      </simpleChoice>
+      <simpleChoice identifier="ChoiceTH">東北</simpleChoice>
+      <simpleChoice identifier="ChoiceHR">北陸</simpleChoice>
+      <simpleChoice identifier="ChoiceKT">関東</simpleChoice>
+      <simpleChoice identifier="ChoiceKST">甲信越</simpleChoice>
+      <simpleChoice identifier="ChoiceKK">近畿</simpleChoice>
+      <simpleChoice identifier="ChoiceKS">関西</simpleChoice>
+      <simpleChoice identifier="ChoiceSK">四国</simpleChoice>
+      <simpleChoice identifier="ChoiceTC">中国</simpleChoice>
+      <simpleChoice identifier="ChoiceKY">九州</simpleChoice>
+    </choiceInteraction>
+  </itemBody>
+  <responseProcessing template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/match_correct"/>
+</assessmentItem>


### PR DESCRIPTION
# [TR-4502](https://oat-sa.atlassian.net/browse/TR-4502)

## Description 
Since Ruby tags are a standard HTML5 feature, they are natively [supported by all major web browsers](https://caniuse.com/?search=ruby). This means that manually adding Ruby to the QTI XML markup should already works out of the box in the Test Runner. However there seems to be a blocker in our package publication (QTI marshalling of HTML5 ruby tags) that prevents publishing a test that contains item(s) with Ruby markup.

## Aceptence criteria
Marshallers/unmarshallers for the following Ruby tags are added in QTI-SDK:
<ruby>
<rb>
<rt>
<rp>

## Development impact 
Add tag description classes
Add new Marshaling 
Add new UnMarshaling 
Add test for cover new elements 


## Other PRs in context
[JsonCompilation](https://github.com/oat-sa/lib-qti-item-json-compilation/pull/53)
[QTI-SDK-LEGACY](https://github.com/oat-sa/qti-sdk/pull/331)

## Demo 
https://user-images.githubusercontent.com/2750628/191988794-9fb769a9-33be-4d15-8ce9-6d58ee1c5c9d.mov
