### PR TITLE
fix: allow to save event empty answer if timeout happens

### DIFF
--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -769,7 +769,7 @@ class AssessmentItemSession extends State
      * @throws AssessmentItemSessionException If the time limits in force are not respected, an error occurs during response processing, a state violation occurs.
      * @throws PhpStorageException
      */
-    public function endAttempt(State $responses = null, $responseProcessing = true, $forceLateSubmission = false)
+    public function endAttempt(State $responses = null, $responseProcessing = true, $forceLateSubmission = false, $ignoreAllowSkippingCheck = false)
     {
         // Flag to indicate if time is exceed or not.
         $maxTimeExceeded = false;
@@ -793,7 +793,9 @@ class AssessmentItemSession extends State
         // Apply the responses (if provided) to the current state.
         if ($responses !== null) {
             $this->checkResponseValidityConstraints($responses);
-            $this->checkAllowSkipping($responses);
+            if (!$ignoreAllowSkippingCheck) {
+                $this->checkAllowSkipping($responses);
+            }
             $this->mergeResponses($responses);
         }
 

--- a/src/qtism/runtime/tests/AssessmentTestSession.php
+++ b/src/qtism/runtime/tests/AssessmentTestSession.php
@@ -870,7 +870,7 @@ class AssessmentTestSession extends State
      * @param bool $allowLateSubmission If set to true, maximum time limits will not be taken into account.
      * @throws AssessmentTestSessionException
      */
-    public function endAttempt(State $responses, $allowLateSubmission = false)
+    public function endAttempt(State $responses, $allowLateSubmission = false, $ignoreAllowSkippingCheck = false)
     {
         if ($this->isRunning() === false) {
             $msg = 'Cannot end an attempt for the current item while the state of the test session is INITIAL or CLOSED.';
@@ -899,7 +899,7 @@ class AssessmentTestSession extends State
             }
         } else {
             try {
-                $session->endAttempt($responses, true, $allowLateSubmission);
+                $session->endAttempt($responses, true, $allowLateSubmission, $ignoreAllowSkippingCheck);
             } catch (Exception $e) {
                 throw $this->transformException($e);
             }

--- a/test/qtismtest/runtime/expressions/VariableProcessorTest.php
+++ b/test/qtismtest/runtime/expressions/VariableProcessorTest.php
@@ -106,12 +106,12 @@ class VariableProcessorTest extends QtiSmTestCase
         $variableExpr = $this->createComponentFromXml('<variable identifier="Q01.var2" weightIdentifier="weight1"/>');
         $variableProcessor->setExpression($variableExpr);
         $result = $variableProcessor->process();
-        $this::assertEquals(11.11, $result[0]->getValue());
-        $this::assertEquals(13.31, $result[1]->getValue());
+        $this::assertEquals(11.11, round($result[0]->getValue(), 2));
+        $this::assertEquals(13.31, round($result[1]->getValue(), 2));
         // The value in the state must be unchanged.
         $stateVal = $assessmentTestSession['Q01.var2'];
-        $this::assertEquals(10.1, $stateVal[0]->getValue());
-        $this::assertEquals(12.1, $stateVal[1]->getValue());
+        $this::assertEquals(10.1, round($stateVal[0]->getValue(), 2));
+        $this::assertEquals(12.1, round($stateVal[1]->getValue(), 2));
     }
 
     public function testMultipleOccurences()

--- a/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
@@ -262,6 +262,22 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         }
     }
 
+    public function testIgnoreSkippingForbiddenSimple()
+    {
+        $itemSession = $this->instantiateBasicAssessmentItemSession();
+        $itemSessionControl = new ItemSessionControl();
+        $itemSessionControl->setAllowSkipping(false);
+        $itemSession->setItemSessionControl($itemSessionControl);
+        $itemSession->beginItemSession();
+
+        $itemSession->beginAttempt();
+
+        // Test with empty state...
+        // no exception should be produced
+        $itemSession->endAttempt(new State([new ResponseVariable('RESPONSE', Cardinality::SINGLE, BaseType::IDENTIFIER)]), true, false, true);
+        $this->assertTrue(true);
+    }
+
     public function testSkippingForbiddenDefaultValue()
     {
         $doc = new XmlDocument();


### PR DESCRIPTION
# [TR-4673](https://oat-sa.atlassian.net/browse/TR-4673)

## Description 
When user launches the test with "Validate responses" and “maximum duration” settings enabled for an item, reaches this item and wait until timer is out (no response provided/not valid response provided) - test fails with “500 error”. "Unexpected Error. Sorry, an unexpected error happened during the test. Please contact your test administrator" message is displayed to the user. Same for “Allow skipping“.

## Preconditions
Test with enabled "Validate responses" and “maximum duration” settings is created and published (see attached file). 
Test with disabled "Allow skipping" and “maximum duration” settings is created and published

## Steps to reproduce:
1. Launch the first test from the preconditions via [LTI 1.3 ](https://devkit-oat-dev.dev.gcp-eu.taocloud.org/platform/message/launch/lti-resource-link?registration=deliverRegistration&user_type=custom&user_list=c3po&custom_user_id=m7&launch_url=https://testrunner-oat-dev.dev.gcp-eu.taocloud.org/api/v1/auth/launch-lti-1p3/48cc002a9bcb&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D%0D%0A%7D)
2. Navigate to the item with "Validate responses" settings
3. Provide no response and wait until timer is out

## Related PR
[tao-deliver-be](https://github.com/oat-sa/tao-deliver-be/pull/985)

## Demo
https://user-images.githubusercontent.com/2750628/192970702-a1ecb138-af40-46c5-8345-548aee97c558.mov

