### PR TITLE
fix: provide new flag for skip validation with check on empty response

### DIFF
--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -766,10 +766,11 @@ class AssessmentItemSession extends State
      * @param State $responses (optional) A State composed by the candidate's responses to the item.
      * @param bool $responseProcessing (optional) Whether to execute the responseProcessing or not.
      * @param bool $forceLateSubmission (optional) Force the acceptance of late response submission. In this case, responses that are received out of the time frame indicated by the time limits in force are accepted anyway.
+     * @param bool $forceResponseSave (opional) Force save response even if it empty or validation required
      * @throws AssessmentItemSessionException If the time limits in force are not respected, an error occurs during response processing, a state violation occurs.
      * @throws PhpStorageException
      */
-    public function endAttempt(State $responses = null, $responseProcessing = true, $forceLateSubmission = false, $ignoreAllowSkippingCheck = false)
+    public function endAttempt(State $responses = null, $responseProcessing = true, $forceLateSubmission = false, $forceResponseSave = false)
     {
         // Flag to indicate if time is exceed or not.
         $maxTimeExceeded = false;
@@ -792,8 +793,8 @@ class AssessmentItemSession extends State
 
         // Apply the responses (if provided) to the current state.
         if ($responses !== null) {
-            $this->checkResponseValidityConstraints($responses);
-            if (!$ignoreAllowSkippingCheck) {
+            if (!$forceResponseSave) {
+                $this->checkResponseValidityConstraints($responses);
                 $this->checkAllowSkipping($responses);
             }
             $this->mergeResponses($responses);


### PR DESCRIPTION
# [TR-4673](https://oat-sa.atlassian.net/browse/TR-4673)

## Description 
When user launches the test with "Validate responses" and “maximum duration” settings enabled for an item, reaches this item and wait until timer is out (no response provided/not valid response provided) - test fails with “500 error”. "Unexpected Error. Sorry, an unexpected error happened during the test. Please contact your test administrator" message is displayed to the user. Same for “Allow skipping“.

## Preconditions
Test with enabled "Validate responses" and “maximum duration” settings is created and published (see attached file). 
Test with disabled "Allow skipping" and “maximum duration” settings is created and published

## Steps to reproduce:
1. Launch the first test from the preconditions via [LTI 1.3 ](https://devkit-oat-dev.dev.gcp-eu.taocloud.org/platform/message/launch/lti-resource-link?registration=deliverRegistration&user_type=custom&user_list=c3po&custom_user_id=m7&launch_url=https://testrunner-oat-dev.dev.gcp-eu.taocloud.org/api/v1/auth/launch-lti-1p3/48cc002a9bcb&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D%0D%0A%7D)
2. Navigate to the item with "Validate responses" settings
3. Provide no response and wait until timer is out

## Related PR
[tao-deliver-be](https://github.com/oat-sa/tao-deliver-be/pull/985)

## Demo
https://user-images.githubusercontent.com/2750628/192970702-a1ecb138-af40-46c5-8345-548aee97c558.mov

