### PR TITLE
Close test session next section to move invalid

### DIFF
--- a/src/qtism/runtime/tests/AssessmentTestSession.php
+++ b/src/qtism/runtime/tests/AssessmentTestSession.php
@@ -2510,6 +2510,10 @@ class AssessmentTestSession extends State
         while ($route->valid() === true && $route->current()->getAssessmentSection() === $from->getAssessmentSection()) {
             $route->next();
         }
+
+        if ($route->valid() === false && $this->isRunning() === true) {
+            $this->endTestSession();
+        }
     }
 
     /**


### PR DESCRIPTION
# [TR-4738](https://oat-sa.atlassian.net/browse/TR-4738)

## Description 
If we timeout on last section in a test we see error 

## Step to reproduce 
1. launch test from Preconditions
2. navigate to the last Item of the last Section (items in front could be answered, or left unanswered)
3. wait until the last Section’s Timer expires
4. select Finish test in confirmation dialog

## Development impact 
Validate route if move to next session is correct
If it is incorrect close test section 

## Demo
https://user-images.githubusercontent.com/2750628/194335954-ea82c4ff-a00d-4954-aba8-6761585ff103.mov
