### PR TITLE
Fix TR-4668 response variable default values completion status calculation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,4 @@ coverage:
     project:
       default:
         threshold: 1%
+    patch: off

--- a/src/qtism/runtime/common/OutcomeVariable.php
+++ b/src/qtism/runtime/common/OutcomeVariable.php
@@ -249,6 +249,8 @@ class OutcomeVariable extends Variable
                 $this->setValue(new QtiFloat(0.0));
             }
         }
+
+        $this->isInitializedFromDefaultValue = true;
     }
 
     public function __clone()

--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -40,6 +40,9 @@ use UnexpectedValueException;
  */
 abstract class Variable
 {
+    /** Whether the variable value has been defined or only initialized from the default one */
+    protected bool $isInitializedFromDefaultValue = false;
+
     /**
      * The identifier of the variable.
      *
@@ -203,13 +206,17 @@ abstract class Variable
      * @param QtiDatatype|null $value A QtiDatatype object or null.
      * @throws InvalidArgumentException If the baseType and cardinality of $value are not compliant with the Variable.
      */
-    public function setValue(QtiDatatype $value = null)
+    public function setValue(QtiDatatype $value = null): void
     {
-        if (!Utils::isBaseTypeCompliant($this->getBaseType(), $value) || !Utils::isCardinalityCompliant($this->getCardinality(), $value)) {
+        if (
+            !Utils::isBaseTypeCompliant($this->getBaseType(), $value)
+            || !Utils::isCardinalityCompliant($this->getCardinality(), $value)
+        ) {
             Utils::throwBaseTypeTypingError($this->baseType, $value);
-        } else {
-            $this->value = $value;
         }
+
+        $this->value = $value;
+        $this->isInitializedFromDefaultValue = false;
     }
 
     /**
@@ -311,6 +318,11 @@ abstract class Variable
                 throw new UnexpectedValueException($msg, 0, $e);
             }
         }
+    }
+
+    public function isInitializedFromDefaultValue(): bool
+    {
+        return $this->isInitializedFromDefaultValue;
     }
 
     /**
@@ -609,6 +621,7 @@ abstract class Variable
     public function applyDefaultValue()
     {
         $this->setValue($this->getDefaultValue());
+        $this->isInitializedFromDefaultValue = true;
     }
 
     /**

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -195,7 +195,9 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                     $variable->$setterToCall(Utils::valueToRuntime($this->$toCall(), $baseType));
                 } else {
                     // Deal with multiple values.
-                    $values = ($cardinality === Cardinality::MULTIPLE) ? new MultipleContainer($baseType) : new OrderedContainer($baseType);
+                    $values = $cardinality === Cardinality::MULTIPLE
+                        ? new MultipleContainer($baseType)
+                        : new OrderedContainer($baseType);
                     for ($i = 0; $i < $count; $i++) {
                         $isNull = $this->readBoolean();
                         $values[] = ($isNull === true) ? null : Utils::valueToRuntime($this->$toCall(), $baseType);
@@ -687,7 +689,9 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                 $this->writeBoolean(false);
                 $this->writeString($intOrIdentifier);
             } else {
-                $msg = "The intOrIdentifier value to be written must be an integer or a string, '" . gettype($intOrIdentifier) . "' given.";
+                $msg = "The intOrIdentifier value to be written must be an integer or a string, '"
+                       . gettype($intOrIdentifier)
+                       . "' given.";
                 throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::INTORIDENTIFIER);
             }
         } catch (BinaryStreamAccessException $e) {
@@ -700,7 +704,9 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
      * Read an AssessmentItemSession from the current binary stream.
      *
      * @param AbstractSessionManager $manager
-     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object from where 'assessmentItemRef', 'outcomeDeclaration' and 'responseDeclaration' QTI components will be pulled out.
+     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object from where 'assessmentItemRef',
+     *                                     'outcomeDeclaration' and 'responseDeclaration' QTI components
+     *                                     will be pulled out.
      * @param QtiBinaryVersion $version Version of the binary session storage
      * @return AssessmentItemSession
      * @throws QtiBinaryStreamAccessException
@@ -780,7 +786,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                 $hasCorrectResponse = $this->readBoolean();
 
                 // Read the intrinsic value of the variable.
-                $this->readVariableValue($variable, self::RW_VALUE);
+                $this->readVariableValue($variable);
 
                 if ($hasDefaultValue === true) {
                     $this->readVariableValue($variable, self::RW_DEFAULTVALUE);
@@ -788,6 +794,10 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
 
                 if ($hasCorrectResponse === true) {
                     $this->readVariableValue($variable, self::RW_CORRECTRESPONSE);
+                }
+
+                if ($version->storesVariableDefaultValueInitializationFlag() && $this->readBoolean()) {
+                    $variable->applyDefaultValue();
                 }
 
                 $session->setVariable($variable);
@@ -814,7 +824,8 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     /**
      * Write an AssessmetnItemSession from the current binary stream.
      *
-     * @param AssessmentTestSeeker $seeker The AssessmentTestSeeker object from where the position of components will be pulled out.
+     * @param AssessmentTestSeeker $seeker The AssessmentTestSeeker object from where the position of components
+     *                                     will be pulled out.
      * @param AssessmentItemSession $session An AssessmentItemSession object.
      * @throws QtiBinaryStreamAccessException
      */
@@ -888,14 +899,17 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                     $hasDefaultValue = !Utils::equals($variable->getDefaultValue(), $var->getDefaultValue());
                     $hasCorrectResponse = false;
 
-                    if ($varNature === 1 && !Utils::equals($variable->getCorrectResponse(), $var->getCorrectResponse())) {
+                    if (
+                        $varNature === 1
+                        && !Utils::equals($variable->getCorrectResponse(), $var->getCorrectResponse())
+                    ) {
                         $hasCorrectResponse = true;
                     }
 
                     $this->writeBoolean($hasDefaultValue);
                     $this->writeBoolean($hasCorrectResponse);
 
-                    $this->writeVariableValue($var, self::RW_VALUE);
+                    $this->writeVariableValue($var);
 
                     if ($hasDefaultValue === true) {
                         $this->writeVariableValue($var, self::RW_DEFAULTVALUE);
@@ -904,6 +918,8 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                     if ($hasCorrectResponse === true) {
                         $this->writeVariableValue($var, self::RW_CORRECTRESPONSE);
                     }
+
+                    $this->writeBoolean($var->isInitializedFromDefaultValue());
                 }
             }
 
@@ -925,7 +941,8 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     /**
      * Read a route item from the current binary stream.
      *
-     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object where components will be pulled out by position.
+     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object where components
+     *                                     will be pulled out by position.
      * @return RouteItem
      * @throws QtiBinaryStreamAccessException
      */
@@ -977,7 +994,8 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     /**
      * Write a route item in the current binary stream.
      *
-     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object in order to know tree position for involved QTI Components.
+     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object in order to know tree position
+     *                                     for involved QTI Components.
      * @param RouteItem $routeItem A RouteItem object.
      * @throws QtiBinaryStreamAccessException
      */
@@ -1020,7 +1038,8 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     /**
      * Read a PendingResponse object from the current binary stream.
      *
-     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object in order to know tree position for involved QTI Components.
+     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object in order to know tree position
+     *                                     for involved QTI Components.
      * @return PendingResponses A PendingResponses object.
      * @throws QtiBinaryStreamAccessException
      */
@@ -1049,17 +1068,28 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             return new PendingResponses($state, $itemRef, $occurrence);
         } catch (BinaryStreamAccessException $e) {
             $msg = 'An error occurred while reading some pending responses.';
-            throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::PENDING_RESPONSES, $e);
+            throw new QtiBinaryStreamAccessException(
+                $msg,
+                $this,
+                QtiBinaryStreamAccessException::PENDING_RESPONSES,
+                $e
+            );
         } catch (OutOfBoundsException $e) {
             $msg = 'A QTI component was not found in the assessmentTest tree structure.';
-            throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::PENDING_RESPONSES, $e);
+            throw new QtiBinaryStreamAccessException(
+                $msg,
+                $this,
+                QtiBinaryStreamAccessException::PENDING_RESPONSES,
+                $e
+            );
         }
     }
 
     /**
      * Write a PendingResponses object in the current binary stream.
      *
-     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object from where positions in the assessmentTest tree will be pulled out.
+     * @param AssessmentTestSeeker $seeker An AssessmentTestSeeker object from where positions
+     *                                     in the assessmentTest tree will be pulled out.
      * @param PendingResponses $pendingResponses The read PendingResponses object.
      * @throws QtiBinaryStreamAccessException
      */
@@ -1082,7 +1112,11 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                     $this->writeVariableValue($responseVariable);
                 } else {
                     $msg = "No response variable with identifier '${respId}' found in related assessmentItemRef.";
-                    throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::PENDING_RESPONSES);
+                    throw new QtiBinaryStreamAccessException(
+                        $msg,
+                        $this,
+                        QtiBinaryStreamAccessException::PENDING_RESPONSES
+                    );
                 }
             }
 
@@ -1093,10 +1127,20 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             $this->writeTinyInt($occurrence);
         } catch (BinaryStreamAccessException $e) {
             $msg = 'An error occurred while reading some pending responses.';
-            throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::PENDING_RESPONSES, $e);
+            throw new QtiBinaryStreamAccessException(
+                $msg,
+                $this,
+                QtiBinaryStreamAccessException::PENDING_RESPONSES,
+                $e
+            );
         } catch (OutOfBoundsException $e) {
             $msg = 'A QTI component position could not be found in the assessmentTest tree structure.';
-            throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::PENDING_RESPONSES, $e);
+            throw new QtiBinaryStreamAccessException(
+                $msg,
+                $this,
+                QtiBinaryStreamAccessException::PENDING_RESPONSES,
+                $e
+            );
         }
     }
 

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -689,9 +689,10 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                 $this->writeBoolean(false);
                 $this->writeString($intOrIdentifier);
             } else {
-                $msg = "The intOrIdentifier value to be written must be an integer or a string, '"
-                       . gettype($intOrIdentifier)
-                       . "' given.";
+                $msg = sprintf(
+                    'The intOrIdentifier value to be written must be an integer or a string, \'%s\' given.',
+                    gettype($intOrIdentifier)
+                );
                 throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::INTORIDENTIFIER);
             }
         } catch (BinaryStreamAccessException $e) {

--- a/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
@@ -21,6 +21,8 @@
  * @license GPLv2
  */
 
+declare(strict_types=1);
+
 namespace qtism\runtime\storage\binary;
 
 use qtism\common\storage\BinaryStreamAccessException;
@@ -32,51 +34,32 @@ class QtiBinaryVersion
 {
     /**
      * The QTI binary data version number.
-     *
-     * @var int
      */
-    const CURRENT_VERSION = 11;
+    public const CURRENT_VERSION = self::VERSION_VARIABLE_WITH_DEFAULT_VALUE_INITIALIZATION_FLAG;
 
     /**
      * The QTI Sdk branch to select behaviour of the binary storage.
      * 'M' denotes Master. 'L' denotes Legacy.
-     *
-     * @var string
      */
-    const CURRENT_BRANCH = 'M';
+    public const CURRENT_BRANCH = 'M';
 
     /**
-     * These constants make the different versions a bit more self explanatory.
+     * These constants make the different versions a bit more self-explanatory.
      */
-    const VERSION_VARIABLE_COUNT_INTEGER = 11;
+    public const VERSION_VARIABLE_WITH_DEFAULT_VALUE_INITIALIZATION_FLAG = 12;
+    public const VERSION_VARIABLE_COUNT_INTEGER = 11;
+    public const VERSION_FIRST_MASTER = 10;
+    public const VERSION_POSITION_INTEGER = 9;
+    public const VERSION_ALWAYS_ALLOW_JUMPS = 8;
+    public const VERSION_TRACK_PATH = 7;
+    public const VERSION_FORCE_BRANCHING_PRECONDITIONS = 6;
+    public const VERSION_LAST_ACTION = 5;
+    public const VERSION_DURATIONS = 4;
+    public const VERSION_MULTIPLE_SECTIONS = 3;
+    public const VERSION_ATTEMPTING = 2;
 
-    const VERSION_FIRST_MASTER = 10;
-
-    const VERSION_POSITION_INTEGER = 9;
-
-    const VERSION_ALWAYS_ALLOW_JUMPS = 8;
-
-    const VERSION_TRACK_PATH = 7;
-
-    const VERSION_FORCE_BRANCHING_PRECONDITIONS = 6;
-
-    const VERSION_LAST_ACTION = 5;
-
-    const VERSION_DURATIONS = 4;
-
-    const VERSION_MULTIPLE_SECTIONS = 3;
-
-    const VERSION_ATTEMPTING = 2;
-
-    /**
-     * @var int
-     */
-    private $version;
-
-    /**
-     * @var string
-     */
-    private $branch;
+    private int $version;
+    private string $branch;
 
     /**
      * Writes version into binary storage.
@@ -127,6 +110,11 @@ class QtiBinaryVersion
     public function isCurrentVersion(): bool
     {
         return $this->version === self::CURRENT_VERSION;
+    }
+
+    public function storesVariableDefaultValueInitializationFlag(): bool
+    {
+        return $this->version >= self::VERSION_VARIABLE_WITH_DEFAULT_VALUE_INITIALIZATION_FLAG;
     }
 
     /**

--- a/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryVersion.php
@@ -126,7 +126,7 @@ class QtiBinaryVersion
      */
     public function isCurrentVersion(): bool
     {
-        return $this->version = self::CURRENT_VERSION;
+        return $this->version === self::CURRENT_VERSION;
     }
 
     /**

--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -1105,7 +1105,7 @@ class AssessmentItemSession extends State
      *
      * Whether the item of the session has been attempted (at least once) and for which responses were given.
      *
-     * @param bool $partially (optional) Whether or not consider partially responded sessions as responded.
+     * @param bool $partially (optional) Whether to consider partially responded sessions as responded.
      * @return bool
      */
     public function isResponded($partially = true)

--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -1118,21 +1118,23 @@ class AssessmentItemSession extends State
         foreach ($this->getKeys() as $k) {
             $var = $this->getVariable($k);
 
-            if ($var instanceof ResponseVariable && in_array($k, $excludedResponseVariables) === false) {
-                $value = $var->getValue();
-                $defaultValue = $var->getDefaultValue();
+            if (!$var instanceof ResponseVariable || in_array($k, $excludedResponseVariables, true)) {
+                continue;
+            }
 
-                if (Utils::isNull($value) === true) {
-                    if (Utils::isNull($defaultValue) === (($partially) ? false : true)) {
-                        return (($partially) ? true : false);
-                    }
-                } elseif ($value->equals($defaultValue) === (($partially) ? false : true)) {
-                    return (($partially) ? true : false);
+            $value = $var->getValue();
+            $defaultValue = $var->getDefaultValue();
+
+            if (Utils::isNull($value)) {
+                if (Utils::isNull($defaultValue) === !$partially) {
+                    return (bool)$partially;
                 }
+            } elseif ($value->equals($defaultValue) === !$partially) {
+                return (bool)$partially;
             }
         }
 
-        return (($partially) ? false : true);
+        return !$partially;
     }
 
     /**

--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -1114,27 +1114,21 @@ class AssessmentItemSession extends State
             return false;
         }
 
+        $result = true;
         $excludedResponseVariables = ['numAttempts', 'duration'];
-        foreach ($this->getKeys() as $k) {
-            $var = $this->getVariable($k);
-
-            if (!$var instanceof ResponseVariable || in_array($k, $excludedResponseVariables, true)) {
+        foreach ($this as $key => $var) {
+            if (!$var instanceof ResponseVariable || in_array($key, $excludedResponseVariables, true)) {
                 continue;
             }
 
-            $value = $var->getValue();
-            $defaultValue = $var->getDefaultValue();
-
-            if (Utils::isNull($value)) {
-                if (Utils::isNull($defaultValue) === !$partially) {
-                    return (bool)$partially;
-                }
-            } elseif ($value->equals($defaultValue) === !$partially) {
-                return (bool)$partially;
+            if ($var->isInitializedFromDefaultValue() || Utils::isNull($var->getValue())) {
+                $result = false;
+            } elseif ($partially) {
+                return true;
             }
         }
 
-        return !$partially;
+        return $result;
     }
 
     /**

--- a/test/qtismtest/runtime/common/OutcomeVariableTest.php
+++ b/test/qtismtest/runtime/common/OutcomeVariableTest.php
@@ -71,10 +71,11 @@ class OutcomeVariableTest extends QtiSmTestCase
         // If I apply the default value, 0 should be inside because
         // baseType is integer, cardinality single, and no default value
         // was given.
-        $variable->setDefaultValue(null);
+        $variable->setDefaultValue();
         $variable->applyDefaultValue();
         $this::assertInstanceOf(QtiInteger::class, $variable->getValue());
         $this::assertEquals(0, $variable->getValue()->getValue());
+        $this::assertTrue($variable->isInitializedFromDefaultValue());
     }
 
     public function testCardinalityMultiple()

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -66,8 +66,10 @@ class ResponseVariableTest extends QtiSmTestCase
         $this::assertTrue($responseVariable->isNull());
 
         $defaultValue = $responseVariable->getDefaultValue();
-        $this::assertInstanceOf(OrderedContainer::class, $defaultValue);
-        $this::assertCount(3, $defaultValue);
+        $this::assertEquals(
+            $defaultValue,
+            new OrderedContainer(BaseType::PAIR, [new QtiPair('A', 'B'), new QtiPair('C', 'D'), new QtiPair('E', 'F')])
+        );
 
         $mapping = $responseVariable->getMapping();
         $this::assertInstanceOf(Mapping::class, $mapping);
@@ -97,12 +99,18 @@ class ResponseVariableTest extends QtiSmTestCase
         $responseVariable->initialize();
         $this::assertInstanceOf(OrderedContainer::class, $responseVariable->getValue());
         $this::assertTrue($responseVariable->isNull());
+        $this::assertFalse($responseVariable->isInitializedFromDefaultValue());
 
         // If I apply the default value...
         $responseVariable->applyDefaultValue();
         $this::assertInstanceOf(OrderedContainer::class, $responseVariable->getValue());
         $this::assertCount(3, $responseVariable->getValue());
-        $this::assertTrue($responseVariable->getValue()->equals(new OrderedContainer(BaseType::PAIR, [new QtiPair('A', 'B'), new QtiPair('C', 'D'), new QtiPair('E', 'F')])));
+        $this::assertTrue($responseVariable->getValue()->equals($defaultValue));
+        $this::assertTrue($responseVariable->isInitializedFromDefaultValue());
+
+        // If I set value once more...
+        $responseVariable->setValue($defaultValue);
+        $this::assertFalse($responseVariable->isInitializedFromDefaultValue());
     }
 
     public function testIsCorrectWithNullCorrectResponse()

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
@@ -106,7 +106,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
             $this::assertTrue($expectedValue->equals($variable->$getterToCall()));
         } else {
             // can't happen.
-            $this::assertTrue(false);
+            $this::fail();
         }
     }
 
@@ -565,7 +565,7 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
             $this::assertTrue($readValue->equals($originalValue));
         } else {
             // Unknown datatype.
-            $this::assertTrue(false);
+            $this::fail();
         }
     }
 
@@ -919,8 +919,19 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $timeReference = pack('l', 1378302030); //  Wednesday, September 4th 2013, 13:40:30 (GMT)
         $varCount = pack('l', 2); // 2 variables (SCORE & RESPONSE).
 
-        $score = pack('S', 0) . pack('S', 8) . "\x00" . "\x00" . "\x00" . "\x01" . pack('d', 1.0); // 9th (8 + 1) outcomeDeclaration.
-        $response = pack('S', 1) . pack('S', 0) . "\x00" . "\x00" . "\x00" . "\x01" . pack('S', 7) . 'ChoiceA'; // 1st (0 + 1) responseDeclaration.
+        // 9th (8 + 1) outcomeDeclaration.
+        $score = pack('S', 0)
+                 . pack('S', 8)
+                 . "\x00\x00\x00\x01"
+                 . pack('d', 1.0)
+                 . "\x00";
+        // 1st (0 + 1) responseDeclaration.
+        $response = pack('S', 1)
+                    . pack('S', 0)
+                    . "\x00\x00\x00\x01"
+                    . pack('S', 7)
+                    . 'ChoiceA'
+                    . "\x00";
 
         $shufflingCount = "\x00"; // No shuffling states.
         $bin = implode('', [$position, $state, $navigationMode, $submissionMode, $attempting, $hasItemSessionControl, $numAttempts, $duration, $completionStatus, $hasTimeReference, $timeReference, $varCount, $score, $response, $shufflingCount]);
@@ -1001,6 +1012,97 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
         $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'templateDeclaration', 'itemSessionControl']);
 
+        $version = $this->createVersionMock(QtiBinaryVersion::VERSION_VARIABLE_COUNT_INTEGER);
+        $session = $access->readAssessmentItemSession(new SessionManager(new FileSystemFileManager()), $seeker, $version);
+
+        $this::assertEquals('Q01', $session->getAssessmentItem()->getIdentifier());
+        $this::assertEquals(AssessmentItemSessionState::CLOSED, $session->getState());
+        $this::assertEquals(NavigationMode::NONLINEAR, $session->getNavigationMode());
+        $this::assertEquals(SubmissionMode::SIMULTANEOUS, $session->getSubmissionMode());
+        $this::assertFalse($session->isAttempting(false));
+        $this::assertEquals(1, $session['numAttempts']->getValue());
+        $this::assertEquals('PT20S', $session['duration']->__toString());
+        $this::assertEquals('complete', $session['completionStatus']->getValue());
+        $this::assertInstanceOf(OutcomeVariable::class, $session->getVariable('SCORE'));
+        $this::assertInstanceOf(QtiFloat::class, $session['SCORE']);
+        $this::assertEquals(1.0, $session['SCORE']->getValue());
+        $this::assertInstanceOf(ResponseVariable::class, $session->getVariable('RESPONSE'));
+        $this::assertSame(BaseType::IDENTIFIER, $session->getVariable('RESPONSE')->getBaseType());
+        $this::assertInstanceOf(QtiString::class, $session['RESPONSE']);
+        $this::assertEquals('ChoiceA', $session['RESPONSE']->getValue());
+        $this::assertInstanceOf(TemplateVariable::class, $session->getVariable('TPL'));
+        $this::assertInstanceOf(QtiInteger::class, $session['TPL']);
+        $this::assertSame(10, $session['TPL']->getValue());
+    }
+
+    /**
+     * @depends testReadAssessmentItemSession1
+     */
+    public function testReadAssessmentItemSession3()
+    {
+        $doc = new XmlCompactDocument();
+        $doc->load(self::samplesDir() . 'custom/runtime/templatevariables_in_items.xml');
+
+        $position = pack('S', 0); // Q01
+        $state = "\x04"; // CLOSED
+        $navigationMode = "\x01"; // NONLINEAR
+        $submissionMode = "\x01"; // SIMULTANEOUS
+        $attempting = "\x00"; // false
+        $hasItemSessionControl = "\x00"; // false
+        $numAttempts = "\x01"; // 1
+        $duration = pack('S', 5) . 'PT20S'; // 20 seconds recorded.
+        $completionStatus = pack('S', 8) . 'complete';
+        $hasTimeReference = "\x01"; // true
+        $timeReference = pack('l', 1378302030); //  Wednesday, September 4th 2013, 13:40:30 (GMT)
+        $varCount = pack('l', 3); // 3 variables (SCORE & RESPONSE & TPL)
+
+        // 1st (0 + 1) outcomeDeclaration.
+        $score = pack('S', 0)
+                 . pack('S', 0)
+                 . "\x00\x00\x00\x01"
+                 . pack('d', 1.0)
+                 . "\x00";
+        // 1st (0 + 1) responseDeclaration.
+        $response = pack('S', 1)
+                    . pack('S', 0)
+                    . "\x00\x00\x00\x01"
+                    . pack('S', 7)
+                    . 'ChoiceA'
+                    . "\x00";
+        // 1st (0 + 1) templateDeclaration.
+        $template = pack('S', 2)
+                    . pack('S', 0)
+                    . "\x00\x00\x00\x01"
+                    . pack('l', 10)
+                    . "\x00";
+
+        $shufflingCount = "\x00"; // No shuffling states.
+
+        $binArray = [
+            $position,
+            $state,
+            $navigationMode,
+            $submissionMode,
+            $attempting,
+            $hasItemSessionControl,
+            $numAttempts,
+            $duration,
+            $completionStatus,
+            $hasTimeReference,
+            $timeReference,
+            $varCount,
+            $score,
+            $response,
+            $template,
+            $shufflingCount,
+        ];
+
+        $bin = implode('', $binArray);
+        $stream = new MemoryStream($bin);
+        $stream->open();
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
+        $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'templateDeclaration', 'itemSessionControl']);
+
         $version = $this->createVersionMock(QtiBinaryVersion::CURRENT_VERSION);
         $session = $access->readAssessmentItemSession(new SessionManager(new FileSystemFileManager()), $seeker, $version);
 
@@ -1022,6 +1124,54 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $this::assertInstanceOf(TemplateVariable::class, $session->getVariable('TPL'));
         $this::assertInstanceOf(QtiInteger::class, $session['TPL']);
         $this::assertSame(10, $session['TPL']->getValue());
+    }
+
+    public function testReadAssessmentItemSession4()
+    {
+        $doc = new XmlCompactDocument();
+        $doc->load(self::samplesDir() . 'custom/runtime/itemsubset.xml');
+
+        $position = pack('S', 0); // Q01
+        $state = "\x01"; // INTERACTING
+        $navigationMode = "\x00"; // LINEAR
+        $submissionMode = "\x00"; // INDIVIDUAL
+        $attempting = "\x00"; // false -> Here we assume we're in version >= 2.
+        $hasItemSessionControl = "\x00"; // false
+        $numAttempts = "\x02"; // 2
+        $duration = pack('S', 4) . 'PT0S'; // 0 seconds recorded yet.
+        $completionStatus = pack('S', 10) . 'incomplete';
+        $hasTimeReference = "\x01"; // true
+        $timeReference = pack('l', 1378302030); //  Wednesday, September 4th 2013, 13:40:30 (GMT)
+        $varCount = pack('l', 2); // 2 variables (SCORE & RESPONSE).
+
+        $score = pack('S', 0) . pack('S', 8) . "\x00" . "\x00" . "\x00" . "\x01" . pack('d', 1.0); // 9th (8 + 1) outcomeDeclaration.
+        $response = pack('S', 1) . pack('S', 0) . "\x00" . "\x00" . "\x00" . "\x01" . pack('S', 7) . 'ChoiceA'; // 1st (0 + 1) responseDeclaration.
+
+        $shufflingCount = "\x00"; // No shuffling states.
+        $bin = implode('', [$position, $state, $navigationMode, $submissionMode, $attempting, $hasItemSessionControl, $numAttempts, $duration, $completionStatus, $hasTimeReference, $timeReference, $varCount, $score, $response, $shufflingCount]);
+        $stream = new MemoryStream($bin);
+        $stream->open();
+        $access = new QtiBinaryStreamAccess($stream, new FileSystemFileManager(), new VariableFactory());
+        $seeker = new AssessmentTestSeeker($doc->getDocumentComponent(), ['assessmentItemRef', 'outcomeDeclaration', 'responseDeclaration', 'itemSessionControl']);
+
+        $version = $this->createVersionMock(QtiBinaryVersion::VERSION_VARIABLE_COUNT_INTEGER);
+        $session = $access->readAssessmentItemSession(new SessionManager(new FileSystemFileManager()), $seeker, $version);
+
+        $this::assertEquals('Q01', $session->getAssessmentItem()->getIdentifier());
+        $this::assertEquals(AssessmentItemSessionState::INTERACTING, $session->getState());
+        $this::assertEquals(NavigationMode::LINEAR, $session->getNavigationMode());
+        $this::assertEquals(SubmissionMode::INDIVIDUAL, $session->getSubmissionMode());
+        $this::assertFalse($session->isAttempting());
+        $this::assertEquals(2, $session['numAttempts']->getValue());
+        $this::assertEquals('PT0S', $session['duration']->__toString());
+        $this::assertEquals('incomplete', $session['completionStatus']->getValue());
+        $this::assertInstanceOf(OutcomeVariable::class, $session->getVariable('scoring'));
+        $this::assertInstanceOf(QtiFloat::class, $session['scoring']);
+        $this::assertEquals(1.0, $session['scoring']->getValue());
+        $this::assertInstanceOf(ResponseVariable::class, $session->getVariable('RESPONSE'));
+        $this::assertEquals(BaseType::IDENTIFIER, $session->getVariable('RESPONSE')->getBaseType());
+        $this::assertInstanceOf(QtiString::class, $session['RESPONSE']);
+        $this::assertEquals('ChoiceA', $session['RESPONSE']->getValue());
     }
 
     public function testWriteAssessmentItemSession1()

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
@@ -8,6 +8,7 @@ use qtism\common\datatypes\files\FileHash;
 use qtism\common\datatypes\files\FileSystemFile;
 use qtism\common\datatypes\files\FileSystemFileManager;
 use qtism\common\datatypes\QtiBoolean;
+use qtism\common\datatypes\QtiDatatype;
 use qtism\common\datatypes\QtiDirectedPair;
 use qtism\common\datatypes\QtiDuration;
 use qtism\common\datatypes\QtiFloat;
@@ -1059,13 +1060,18 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         // 1st (0 + 1) outcomeDeclaration.
         $score = pack('S', 0)
                  . pack('S', 0)
-                 . "\x00\x00\x00\x01"
+                 . "\x01\x00\x00\x01"
+                 . pack('d', 1.0)
+                 . "\x00\x01"
                  . pack('d', 1.0)
                  . "\x00";
         // 1st (0 + 1) responseDeclaration.
         $response = pack('S', 1)
                     . pack('S', 0)
-                    . "\x00\x00\x00\x01"
+                    . "\x00\x01\x00\x01"
+                    . pack('S', 7)
+                    . 'ChoiceA'
+                    . "\x00\x01"
                     . pack('S', 7)
                     . 'ChoiceA'
                     . "\x00";
@@ -1110,16 +1116,20 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $this::assertEquals(AssessmentItemSessionState::CLOSED, $session->getState());
         $this::assertEquals(NavigationMode::NONLINEAR, $session->getNavigationMode());
         $this::assertEquals(SubmissionMode::SIMULTANEOUS, $session->getSubmissionMode());
-        $this::assertFalse($session->isAttempting(false));
+        $this::assertFalse($session->isAttempting());
         $this::assertEquals(1, $session['numAttempts']->getValue());
         $this::assertEquals('PT20S', $session['duration']->__toString());
         $this::assertEquals('complete', $session['completionStatus']->getValue());
         $this::assertInstanceOf(OutcomeVariable::class, $session->getVariable('SCORE'));
         $this::assertInstanceOf(QtiFloat::class, $session['SCORE']);
         $this::assertEquals(1.0, $session['SCORE']->getValue());
+        $this::assertInstanceOf(QtiDatatype::class, $session->getVariable('SCORE')->getDefaultValue());
+        $this::assertEquals(1.0, $session->getVariable('SCORE')->getDefaultValue()->getValue());
         $this::assertInstanceOf(ResponseVariable::class, $session->getVariable('RESPONSE'));
         $this::assertSame(BaseType::IDENTIFIER, $session->getVariable('RESPONSE')->getBaseType());
         $this::assertInstanceOf(QtiString::class, $session['RESPONSE']);
+        $this->assertInstanceOf(ResponseVariable::class, $session->getVariable('RESPONSE'));
+        $this::assertEquals('ChoiceA', $session->getVariable('RESPONSE')->getCorrectResponse()->getValue());
         $this::assertEquals('ChoiceA', $session['RESPONSE']->getValue());
         $this::assertInstanceOf(TemplateVariable::class, $session->getVariable('TPL'));
         $this::assertInstanceOf(QtiInteger::class, $session['TPL']);

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
@@ -37,7 +37,7 @@ class QtiBinaryVersionTest extends QtiSmTestCase
         $subject = new QtiBinaryVersion();
         $subject->retrieve($access);
 
-        $this::assertEquals(QtiBinaryVersion::CURRENT_VERSION, $subject->isCurrentVersion());
+        $this::assertTrue($subject->isCurrentVersion());
         $this::assertTrue($subject->isLegacy());
         $this::assertFalse($subject->isMaster());
     }

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryVersionTest.php
@@ -94,6 +94,8 @@ class QtiBinaryVersionTest extends QtiSmTestCase
                 QtiBinaryVersion::VERSION_POSITION_INTEGER => 'storesPositionAndRouteCountAsInteger',
                 QtiBinaryVersion::VERSION_FIRST_MASTER => 'isInBothBranches',
                 QtiBinaryVersion::VERSION_VARIABLE_COUNT_INTEGER => 'storesVariableCountAsInteger',
+                QtiBinaryVersion::VERSION_VARIABLE_WITH_DEFAULT_VALUE_INITIALIZATION_FLAG =>
+                    'storesVariableDefaultValueInitializationFlag',
             ]
         );
     }
@@ -130,6 +132,8 @@ class QtiBinaryVersionTest extends QtiSmTestCase
             [
                 QtiBinaryVersion::VERSION_FIRST_MASTER => 'isInBothBranches',
                 QtiBinaryVersion::VERSION_VARIABLE_COUNT_INTEGER => 'storesVariableCountAsInteger',
+                QtiBinaryVersion::VERSION_VARIABLE_WITH_DEFAULT_VALUE_INITIALIZATION_FLAG =>
+                    'storesVariableDefaultValueInitializationFlag',
             ]
         );
     }

--- a/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentItemSessionTest.php
@@ -683,13 +683,18 @@ class AssessmentItemSessionTest extends QtiSmAssessmentItemTestCase
         $itemSession->endCandidateSession();
     }
 
-    public function testIsRespondedValueNullDefaultNotNull()
+    public function testIsRespondedValueReflectsNonDefaultValues()
     {
+        $value = new QtiIdentifier('ChoiceA');
         $itemSession = $this->instantiateBasicAssessmentItemSession();
         $itemSession->beginItemSession();
         $itemSession->beginAttempt();
-        $itemSession->getVariable('RESPONSE')->setDefaultValue(new QtiIdentifier('ChoiceA'));
+        $itemSession->getVariable('RESPONSE')->setDefaultValue($value);
 
+        $this::assertFalse($itemSession->isResponded());
+        $this::assertFalse($itemSession->isResponded(false));
+
+        $itemSession->getVariable('RESPONSE')->setValue($value);
         $this::assertTrue($itemSession->isResponded());
         $this::assertTrue($itemSession->isResponded(false));
     }


### PR DESCRIPTION
# [TR-4668](https://oat-sa.atlassian.net/browse/TR-4668)

https://user-images.githubusercontent.com/2943256/195177302-c34c72d9-fea9-47ab-8b1a-11b99759a637.mov

## How to test

1. Have a non-linear navigation _readonly_ PCI-containing delivery execution (e.g. with a Text-Reader PCI)
2. Launch it as a non-anonymous user
3. Submit an item with the PCI
4. Close the delivery execution
5. Relaunch the same delivery execution as the same user again
6. Check the submitted item state, it should remain in the _completed_ state

## Test environment
[The fix is available on OAT dev](https://devkit-oat-dev.dev.gcp-eu.taocloud.org/platform/message/launch/lti-resource-link?registration=deliverRegistration&user_type=custom&user_list=c3po&custom_user_id=MODIFY_ME&launch_url=https://testrunner-oat-dev.dev.gcp-eu.taocloud.org/api/v1/auth/launch-lti-1p3/de3c99c941d9&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D%0D%0A%7D)