### PR TITLE
Abstracted Filesystem Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"ext-libxml": "*",
 		"ext-mbstring": "*",
 		"ext-simplexml": "*",
-		"league/flysystem": "^1.0",
+		"league/flysystem": "^1.0|^2.0|^3.0",
 		"oat-sa/lib-beeme": "0.2.0",
 		"wp-cli/php-cli-tools": "0.10.3"
 	},

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
 		"ext-mbstring": "*",
 		"ext-simplexml": "*",
 		"league/flysystem": "^1.0|^2.0|^3.0",
+		"league/mime-type-detection": "^1.0",
 		"oat-sa/lib-beeme": "0.2.0",
 		"wp-cli/php-cli-tools": "0.10.3"
 	},

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -122,12 +122,15 @@ class XmlDocument extends QtiDocument
         }
 
         // Support backwards compatibility of old Flysystem v1 Filesystems being passed into this class
-        if (FilesystemFactory::isFlysystemV1Installed() && $filesystem instanceof Filesystem) {
+        if ($filesystem instanceof Filesystem && FilesystemFactory::isFlysystemV1Installed()) {
             $filesystem = new FlysystemV1Filesystem($filesystem);
-        }
-
-        if (!$filesystem instanceof FilesystemInterface) {
-            throw new RuntimeException('Invalid filesystem provided.  Instance of FilesystemInterface required');
+        } elseif (!$filesystem instanceof FilesystemInterface) {
+            throw new RuntimeException(
+                sprintf(
+                    'Invalid filesystem provided.  Instance of %s required',
+                    FilesystemInterface::class,
+                )
+            );
         }
 
         $this->filesystem = $filesystem;

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -29,8 +29,6 @@ use DOMElement;
 use DOMException;
 use Exception;
 use InvalidArgumentException;
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use LogicException;
 use qtism\common\dom\SerializableDomDocument;
@@ -42,6 +40,10 @@ use qtism\data\QtiComponent;
 use qtism\data\QtiComponentCollection;
 use qtism\data\QtiComponentIterator;
 use qtism\data\QtiDocument;
+use qtism\data\storage\xml\filesystem\FilesystemFactory;
+use qtism\data\storage\xml\filesystem\FilesystemInterface;
+use qtism\data\storage\xml\filesystem\FilesystemException;
+use qtism\data\storage\xml\filesystem\FlysystemV1Filesystem;
 use qtism\data\storage\xml\marshalling\MarshallerNotFoundException;
 use qtism\data\storage\xml\marshalling\MarshallingException;
 use qtism\data\storage\xml\marshalling\UnmarshallingException;
@@ -49,6 +51,7 @@ use qtism\data\storage\xml\versions\QtiVersion;
 use qtism\data\TestPart;
 use ReflectionClass;
 use ReflectionException;
+use RuntimeException;
 
 /**
  * This class represents a QTI-XML Document.
@@ -74,7 +77,7 @@ class XmlDocument extends QtiDocument
      * The Filesystem implementation in use. Contains null
      * in case of old fashioned local file system implementation.
      *
-     * @var null|Filesystem
+     * @var null|FilesystemInterface
      */
     private $filesystem;
 
@@ -110,13 +113,23 @@ class XmlDocument extends QtiDocument
      * all subsequent creations of related XmlDocument objects will use this Filesystem
      * implementation.
      *
-     * @param Filesystem|null $filesystem
+     * @param Filesystem|FilesystemInterface|null $filesystem
      */
-    public function setFilesystem(Filesystem $filesystem = null)
+    public function setFilesystem($filesystem = null)
     {
-        if ($filesystem === null) {
-            $filesystem = new Filesystem(new Local('/'));
+        if (!$filesystem) {
+            $filesystem = FilesystemFactory::local();
         }
+
+        // Support backwards compatibility of old Flysystem v1 Filesystems being passed into this class
+        if (FilesystemFactory::isFlysystemV1Installed() && $filesystem instanceof Filesystem) {
+            $filesystem = new FlysystemV1Filesystem($filesystem);
+        }
+
+        if (!$filesystem instanceof FilesystemInterface) {
+            throw new RuntimeException('Invalid filesystem provided.  Instance of FilesystemInterface required');
+        }
+
         $this->filesystem = $filesystem;
     }
 
@@ -126,9 +139,9 @@ class XmlDocument extends QtiDocument
      * Get the Filesystem implementation currently in use. Returns null
      * in case of the local file system is in use.
      *
-     * @return Filesystem
+     * @return FilesystemInterface|null
      */
-    protected function getFilesystem()
+    protected function getFilesystem(): FilesystemInterface
     {
         if ($this->filesystem === null) {
             $this->setFilesystem();
@@ -402,7 +415,7 @@ class XmlDocument extends QtiDocument
     {
         try {
             return $this->getFilesystem()->read($url);
-        } catch (FileNotFoundException $e) {
+        } catch (FilesystemException $e) {
             throw new XmlStorageException(
                 "Cannot load QTI file at path '${url}'. It does not exist or is not readable.",
                 XmlStorageException::RESOLUTION,
@@ -420,7 +433,7 @@ class XmlDocument extends QtiDocument
     protected function saveToFile(string $url, string $content): bool
     {
         try {
-            return $this->getFilesystem()->put($url, $content);
+            return $this->getFilesystem()->write($url, $content);
         } catch (Exception $e) {
             throw new XmlStorageException(
                 "An error occurred while saving QTI-XML file at '${url}'. Maybe the save location is not reachable?",

--- a/src/qtism/data/storage/xml/filesystem/FilesystemException.php
+++ b/src/qtism/data/storage/xml/filesystem/FilesystemException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace qtism\data\storage\xml\filesystem;
+
+use Exception;
+
+class FilesystemException extends Exception
+{
+
+}

--- a/src/qtism/data/storage/xml/filesystem/FilesystemFactory.php
+++ b/src/qtism/data/storage/xml/filesystem/FilesystemFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace qtism\data\storage\xml\filesystem;
+
+use RuntimeException;
+
+class FilesystemFactory
+{
+    public static function local(string $path = '/'): FilesystemInterface
+    {
+        // Check for Flysystem v1
+        if (self::isFlysystemV1Installed()) {
+            return FlysystemV1Filesystem::local($path);
+        }
+
+        if (self::isFlysystemV2Installed()) {
+            return FlysystemV2Filesystem::local($path);
+        }
+
+        throw new RuntimeException('Local filesystem could not be initialized.  Please install Flysystem or provide your own FilesystemInterface');
+    }
+
+    public static function isFlysystemV1Installed(): bool
+    {
+        return class_exists('League\\Flysystem\\Filesystem') && class_exists('League\\Flysystem\\Adapter\\Local');
+    }
+
+    public static function isFlysystemV2Installed(): bool
+    {
+        return class_exists('League\\Flysystem\\Filesystem') && class_exists('League\\Flysystem\\Local\\LocalFilesystemAdapter');
+    }
+}

--- a/src/qtism/data/storage/xml/filesystem/FilesystemFactory.php
+++ b/src/qtism/data/storage/xml/filesystem/FilesystemFactory.php
@@ -8,13 +8,14 @@ class FilesystemFactory
 {
     public static function local(string $path = '/'): FilesystemInterface
     {
-        // Check for Flysystem v1
-        if (self::isFlysystemV1Installed()) {
-            return FlysystemV1Filesystem::local($path);
+        try {
+            return FlysystemV2Filesystem::local($path);
+        } catch(\Error $e) {
         }
 
-        if (self::isFlysystemV2Installed()) {
-            return FlysystemV2Filesystem::local($path);
+        try {
+            return FlysystemV1Filesystem::local($path);
+        } catch(\Error $e) {
         }
 
         throw new RuntimeException('Local filesystem could not be initialized.  Please install Flysystem or provide your own FilesystemInterface');
@@ -23,10 +24,5 @@ class FilesystemFactory
     public static function isFlysystemV1Installed(): bool
     {
         return class_exists('League\\Flysystem\\Filesystem') && class_exists('League\\Flysystem\\Adapter\\Local');
-    }
-
-    public static function isFlysystemV2Installed(): bool
-    {
-        return class_exists('League\\Flysystem\\Filesystem') && class_exists('League\\Flysystem\\Local\\LocalFilesystemAdapter');
     }
 }

--- a/src/qtism/data/storage/xml/filesystem/FilesystemInterface.php
+++ b/src/qtism/data/storage/xml/filesystem/FilesystemInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace qtism\data\storage\xml\filesystem;
+
+interface FilesystemInterface
+{
+    /**
+     * Read file from filesystem
+     *
+     * @param string $url
+     * @return string|mixed|false
+     * @throws FilesystemException
+     */
+    public function read(string $url);
+
+    /**
+     * Write content to filesystem
+     *
+     * @param string $url
+     * @param string $content
+     * @return bool
+     * @throws FilesystemException
+     */
+    public function write(string $url, string $content): bool;
+}

--- a/src/qtism/data/storage/xml/filesystem/FlysystemV1Filesystem.php
+++ b/src/qtism/data/storage/xml/filesystem/FlysystemV1Filesystem.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace qtism\data\storage\xml\filesystem;
+
+use Exception;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\FileNotFoundException;
+use League\Flysystem\Filesystem;
+
+class FlysystemV1Filesystem implements FilesystemInterface
+{
+    protected Filesystem $filesystem;
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    public static function local(string $path = '/'): self
+    {
+        return new self(new Filesystem(new Local($path)));
+    }
+
+    public function write(string $url, string $content): bool
+    {
+        try {
+            return $this->filesystem->put($url, $content);
+        } catch (Exception $e) {
+            throw new FilesystemException("Could not write to file '${url}'", $e->getCode(), $e);
+        }
+    }
+
+    public function read(string $url)
+    {
+        try {
+            return $this->filesystem->read($url);
+        } catch (FileNotFoundException $e) {
+            throw new FilesystemException("Could not read file '${url}'", $e->getCode(), $e);
+        }
+    }
+}

--- a/src/qtism/data/storage/xml/filesystem/FlysystemV2Filesystem.php
+++ b/src/qtism/data/storage/xml/filesystem/FlysystemV2Filesystem.php
@@ -27,7 +27,7 @@ class FlysystemV2Filesystem implements FilesystemInterface
                     null,
                     LOCK_EX,
                     LocalFilesystemAdapter::DISALLOW_LINKS,
-                    new FallbackMimeTypeDetector(new ExtensionMimeTypeDetector()), // Serializable
+                    new ExtensionMimeTypeDetector() // Serializable
                 )
             )
         );

--- a/src/qtism/data/storage/xml/filesystem/FlysystemV2Filesystem.php
+++ b/src/qtism/data/storage/xml/filesystem/FlysystemV2Filesystem.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace qtism\data\storage\xml\filesystem;
+
+use Exception;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemException as FlysystemException;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+
+class FlysystemV2Filesystem implements FilesystemInterface
+{
+    protected Filesystem $filesystem;
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    public static function local(string $path = '/'): self
+    {
+        return new self(new Filesystem(new LocalFilesystemAdapter($path)));
+    }
+
+    public function write(string $url, string $content): bool
+    {
+        try {
+            $this->filesystem->write($url, $content);
+            return true;
+        } catch (Exception $e) {
+            throw new FilesystemException("Could not write to file '${url}'", $e->getCode(), $e);
+        }
+    }
+
+    public function read(string $url)
+    {
+        try {
+            return $this->filesystem->read($url);
+        } catch (FlysystemException $e) {
+            throw new FilesystemException("Could not read file '${url}'", $e->getCode(), $e);
+        }
+    }
+}

--- a/src/qtism/data/storage/xml/filesystem/FlysystemV2Filesystem.php
+++ b/src/qtism/data/storage/xml/filesystem/FlysystemV2Filesystem.php
@@ -5,7 +5,9 @@ namespace qtism\data\storage\xml\filesystem;
 use Exception;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemException as FlysystemException;
+use League\Flysystem\Local\FallbackMimeTypeDetector;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\MimeTypeDetection\ExtensionMimeTypeDetector;
 
 class FlysystemV2Filesystem implements FilesystemInterface
 {
@@ -18,7 +20,17 @@ class FlysystemV2Filesystem implements FilesystemInterface
 
     public static function local(string $path = '/'): self
     {
-        return new self(new Filesystem(new LocalFilesystemAdapter($path)));
+        return new self(
+            new Filesystem(
+                new LocalFilesystemAdapter(
+                    $path,
+                    null,
+                    LOCK_EX,
+                    LocalFilesystemAdapter::DISALLOW_LINKS,
+                    new FallbackMimeTypeDetector(new ExtensionMimeTypeDetector()), // Serializable
+                )
+            )
+        );
     }
 
     public function write(string $url, string $content): bool

--- a/test/qtismtest/QtiSmTestCase.php
+++ b/test/qtismtest/QtiSmTestCase.php
@@ -6,11 +6,11 @@ use DateTime;
 use DateTimeZone;
 use DOMDocument;
 use DOMElement;
-use League\Flysystem\Adapter\Local;
-use League\Flysystem\Filesystem;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use qtism\data\QtiComponent;
+use qtism\data\storage\xml\filesystem\FilesystemFactory;
+use qtism\data\storage\xml\filesystem\FilesystemInterface;
 use qtism\data\storage\xml\marshalling\MarshallerFactory;
 use qtism\data\storage\xml\marshalling\MarshallerNotFoundException;
 use qtism\data\storage\xml\versions\QtiVersion;
@@ -23,12 +23,12 @@ use SebastianBergmann\RecursionContext\InvalidArgumentException;
 abstract class QtiSmTestCase extends TestCase
 {
     /**
-     * @var Filesystem
+     * @var FilesystemInterface
      */
     private $fileSystem = null;
 
     /**
-     * @var Filesystem
+     * @var FilesystemInterface
      */
     private $outputFileSystem = null;
 
@@ -37,12 +37,10 @@ abstract class QtiSmTestCase extends TestCase
         parent::setUp();
 
         // Set up File System Local adapter for testing.
-        $adapter = new Local(self::samplesDir());
-        $this->setFileSystem(new Filesystem($adapter));
+        $this->setFileSystem(FilesystemFactory::local(self::samplesDir()));
 
         // Set up File System Local adapter for output.
-        $adapter = new Local(sys_get_temp_dir() . '/qsmout');
-        $this->setOutputFileSystem(new Filesystem($adapter));
+        $this->setOutputFileSystem(FilesystemFactory::local(sys_get_temp_dir() . '/qsmout'));
     }
 
     public function tearDown(): void
@@ -55,7 +53,7 @@ abstract class QtiSmTestCase extends TestCase
      *
      * Setup the FileSystem implementation to be used for testing.
      *
-     * @return Filesystem
+     * @return FilesystemInterface
      */
     protected function getFileSystem()
     {
@@ -67,9 +65,9 @@ abstract class QtiSmTestCase extends TestCase
      *
      * Setup the FileSystem implementation to be used for testing.
      *
-     * @param Filesystem $filesystem
+     * @param FilesystemInterface $filesystem
      */
-    protected function setFileSystem(Filesystem $filesystem)
+    protected function setFileSystem(FilesystemInterface $filesystem)
     {
         $this->fileSystem = $filesystem;
     }
@@ -79,7 +77,7 @@ abstract class QtiSmTestCase extends TestCase
      *
      * Setup the FileSystem implementation to be used for testing.
      *
-     * @return Filesystem
+     * @return FilesystemInterface
      */
     protected function getOutputFileSystem()
     {
@@ -91,9 +89,9 @@ abstract class QtiSmTestCase extends TestCase
      *
      * Setup the FileSystem implementation to be used for testing.
      *
-     * @param Filesystem $filesystem
+     * @param FilesystemInterface $filesystem
      */
-    protected function setOutputFileSystem(Filesystem $filesystem)
+    protected function setOutputFileSystem(FilesystemInterface $filesystem)
     {
         $this->outputFileSystem = $filesystem;
     }


### PR DESCRIPTION
This PR adds support for abstracted filesystems instead of relying on Flysystem v1 exclusively.  This started as a need to support Flysystem v2+, but it was just as easy to move the Filesystem implementation in XmlDocument to interfaces in the event anybody else needs to provide their own read/write implementation.

There's an implementation of the new FilesystemInterface for Flysystemv1 and Flysystemv2+, and I've added backwards compatibility to assure XmlDocument::setFilesystem() still accepts v1 Filesystem classes directly.

