### PR TITLE
Legacy: Allow ruby tag be possible to add on InlineColletions

### DIFF
--- a/qtism/data/content/xhtml/html5/Figcaption.php
+++ b/qtism/data/content/xhtml/html5/Figcaption.php
@@ -22,9 +22,7 @@ declare(strict_types=1);
 
 namespace qtism\data\content\xhtml\html5;
 
-use qtism\data\content\FlowStatic;
-
-class Figcaption extends Html5LayoutElement implements FlowStatic
+class Figcaption extends Html5LayoutElement
 {
     public const QTI_CLASS_NAME_FIGCAPTION = 'figcaption';
 

--- a/qtism/data/content/xhtml/html5/Figure.php
+++ b/qtism/data/content/xhtml/html5/Figure.php
@@ -20,12 +20,12 @@
 
 namespace qtism\data\content\xhtml\html5;
 
-use qtism\data\content\FlowStatic;
+use qtism\data\content\Inline;
 
 /**
  * The XHTML figure class.
  */
-class Figure extends Html5LayoutElement implements FlowStatic
+class Figure extends Html5LayoutElement implements Inline
 {
     public const QTI_CLASS_NAME_FIGURE = 'figure';
 

--- a/qtism/data/content/xhtml/html5/Figure.php
+++ b/qtism/data/content/xhtml/html5/Figure.php
@@ -21,11 +21,12 @@
 namespace qtism\data\content\xhtml\html5;
 
 use qtism\data\content\Inline;
+use qtism\data\content\TextOrVariable;
 
 /**
  * The XHTML figure class.
  */
-class Figure extends Html5LayoutElement implements Inline
+class Figure extends Html5LayoutElement implements Inline, TextOrVariable
 {
     public const QTI_CLASS_NAME_FIGURE = 'figure';
 

--- a/qtism/data/content/xhtml/html5/Rb.php
+++ b/qtism/data/content/xhtml/html5/Rb.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace qtism\data\content\xhtml\html5;
 
-use qtism\data\content\FlowStatic;
+use qtism\data\content\Inline;
 
-class Rb extends Html5LayoutElement implements FlowStatic
+class Rb extends Html5LayoutElement implements Inline
 {
     public const QTI_CLASS_NAME = 'rb';
 

--- a/qtism/data/content/xhtml/html5/Rb.php
+++ b/qtism/data/content/xhtml/html5/Rb.php
@@ -22,9 +22,7 @@ declare(strict_types=1);
 
 namespace qtism\data\content\xhtml\html5;
 
-use qtism\data\content\Inline;
-
-class Rb extends Html5LayoutElement implements Inline
+class Rb extends Html5LayoutElement
 {
     public const QTI_CLASS_NAME = 'rb';
 

--- a/qtism/data/content/xhtml/html5/Rp.php
+++ b/qtism/data/content/xhtml/html5/Rp.php
@@ -22,9 +22,7 @@ declare(strict_types=1);
 
 namespace qtism\data\content\xhtml\html5;
 
-use qtism\data\content\Inline;
-
-class Rp extends Html5LayoutElement implements Inline
+class Rp extends Html5LayoutElement
 {
     public const QTI_CLASS_NAME = 'rp';
 

--- a/qtism/data/content/xhtml/html5/Rp.php
+++ b/qtism/data/content/xhtml/html5/Rp.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace qtism\data\content\xhtml\html5;
 
-use qtism\data\content\FlowStatic;
+use qtism\data\content\Inline;
 
-class Rp extends Html5LayoutElement implements FlowStatic
+class Rp extends Html5LayoutElement implements Inline
 {
     public const QTI_CLASS_NAME = 'rp';
 

--- a/qtism/data/content/xhtml/html5/Rt.php
+++ b/qtism/data/content/xhtml/html5/Rt.php
@@ -22,9 +22,7 @@ declare(strict_types=1);
 
 namespace qtism\data\content\xhtml\html5;
 
-use qtism\data\content\Inline;
-
-class Rt extends Html5LayoutElement implements Inline
+class Rt extends Html5LayoutElement
 {
     public const QTI_CLASS_NAME = 'rt';
 

--- a/qtism/data/content/xhtml/html5/Rt.php
+++ b/qtism/data/content/xhtml/html5/Rt.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace qtism\data\content\xhtml\html5;
 
-use qtism\data\content\FlowStatic;
+use qtism\data\content\Inline;
 
-class Rt extends Html5LayoutElement implements FlowStatic
+class Rt extends Html5LayoutElement implements Inline
 {
     public const QTI_CLASS_NAME = 'rt';
 

--- a/qtism/data/content/xhtml/html5/Ruby.php
+++ b/qtism/data/content/xhtml/html5/Ruby.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace qtism\data\content\xhtml\html5;
 
-use qtism\data\content\FlowStatic;
+use qtism\data\content\Inline;
 
-class Ruby extends Html5LayoutElement implements FlowStatic
+class Ruby extends Html5LayoutElement implements Inline
 {
     public const QTI_CLASS_NAME = 'ruby';
 

--- a/qtism/data/content/xhtml/html5/Ruby.php
+++ b/qtism/data/content/xhtml/html5/Ruby.php
@@ -23,8 +23,9 @@ declare(strict_types=1);
 namespace qtism\data\content\xhtml\html5;
 
 use qtism\data\content\Inline;
+use qtism\data\content\TextOrVariable;
 
-class Ruby extends Html5LayoutElement implements Inline
+class Ruby extends Html5LayoutElement implements Inline, TextOrVariable
 {
     public const QTI_CLASS_NAME = 'ruby';
 

--- a/qtism/data/content/xhtml/html5/Ruby.php
+++ b/qtism/data/content/xhtml/html5/Ruby.php
@@ -23,9 +23,10 @@ declare(strict_types=1);
 namespace qtism\data\content\xhtml\html5;
 
 use qtism\data\content\Inline;
+use qtism\data\content\InlineStatic;
 use qtism\data\content\TextOrVariable;
 
-class Ruby extends Html5LayoutElement implements Inline, TextOrVariable
+class Ruby extends Html5LayoutElement implements Inline, TextOrVariable, InlineStatic
 {
     public const QTI_CLASS_NAME = 'ruby';
 
@@ -34,3 +35,5 @@ class Ruby extends Html5LayoutElement implements Inline, TextOrVariable
         return self::QTI_CLASS_NAME;
     }
 }
+
+

--- a/qtism/data/storage/xml/marshalling/GapChoiceMarshaller.php
+++ b/qtism/data/storage/xml/marshalling/GapChoiceMarshaller.php
@@ -26,6 +26,7 @@ namespace qtism\data\storage\xml\marshalling;
 use DOMElement;
 use InvalidArgumentException;
 use qtism\data\content\FlowStaticCollection;
+use qtism\data\content\xhtml\html5\Ruby;
 use qtism\data\QtiComponent;
 use qtism\data\QtiComponentCollection;
 use qtism\data\ShowHide;
@@ -65,6 +66,7 @@ class GapChoiceMarshaller extends ContentMarshaller
         'textRun',
         'tt',
         'var',
+        Ruby::QTI_CLASS_NAME
     ];
 
     /**


### PR DESCRIPTION
# [TR-4839](https://oat-sa.atlassian.net/browse/TR-4839)

## Description 
When we configure Ruby in Asset tab and add it to passage , we got error `InlineCollection objects only accept to store Inline objects` 

## Development Impact
Include Ruby tags to Inline interfaces, also Include to that Group `Figure` because it should be same with `Img`

## Demo
https://user-images.githubusercontent.com/2750628/200549592-b057cb06-97f7-4d68-9801-61e5bef1984e.mov

