### PR TITLE
Fix support of original file name

### DIFF
--- a/src/qtism/common/datatypes/files/FileManager.php
+++ b/src/qtism/common/datatypes/files/FileManager.php
@@ -57,10 +57,11 @@ interface FileManager
      * @param string $data A binary string representing the data.
      * @param string $mimeType The MIME type of the resulting File object.
      * @param string $filename The filename of the resulting File object.
+     * @param string|null $path A path for file provided externally of the resulting File object
      * @return QtiFile
      * @throws FileManagerException
      */
-    public function createFromData($data, $mimeType, $filename = '');
+    public function createFromData($data, $mimeType, $filename = '', $path = null);
 
     /**
      * Retrieve a previously created instance by $identifier.

--- a/src/qtism/common/datatypes/files/FileManager.php
+++ b/src/qtism/common/datatypes/files/FileManager.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/common/datatypes/files/FileManager.php
+++ b/src/qtism/common/datatypes/files/FileManager.php
@@ -67,9 +67,10 @@ interface FileManager
      * Retrieve a previously created instance by $identifier.
      *
      * @param string $identifier
+     * @param string|null $filename
      * @throws FileManagerException
      */
-    public function retrieve($identifier);
+    public function retrieve($identifier, $filename = null);
 
     /**
      * Delete a given QtiFile from its storage.

--- a/src/qtism/common/datatypes/files/FileSystemFileManager.php
+++ b/src/qtism/common/datatypes/files/FileSystemFileManager.php
@@ -93,12 +93,13 @@ class FileSystemFileManager implements FileManager
      * @param string $data The binary data of the FileSystemFile object to be created.
      * @param string $mimeType A mime-type.
      * @param string $filename A file name e.g. "myfile.txt".
+     * @param string|null $path A path for file provided externally
      * @return FileSystemFile
      * @throws FileManagerException
      */
-    public function createFromData($data, $mimeType, $filename = '')
+    public function createFromData($data, $mimeType, $filename = '', $path = null)
     {
-        $destination = $this->buildDestination();
+        $destination = $path ?: $this->buildDestination();
 
         try {
             return FileSystemFile::createFromData($data, $destination, $mimeType, $filename);

--- a/src/qtism/common/datatypes/files/FileSystemFileManager.php
+++ b/src/qtism/common/datatypes/files/FileSystemFileManager.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/common/datatypes/files/FileSystemFileManager.php
+++ b/src/qtism/common/datatypes/files/FileSystemFileManager.php
@@ -112,11 +112,12 @@ class FileSystemFileManager implements FileManager
     /**
      * Retrieve a FileSystemFile object from its unique identifier.
      *
-     * @param string identifier
+     * @param string $identifier
+     * @param string|null $filename
      * @return FileSystemFile
      * @throws FileManagerException
      */
-    public function retrieve($identifier)
+    public function retrieve($identifier, $filename = null)
     {
         try {
             return FileSystemFile::retrieveFile($identifier);

--- a/src/qtism/runtime/pci/json/Marshaller.php
+++ b/src/qtism/runtime/pci/json/Marshaller.php
@@ -378,6 +378,7 @@ class Marshaller
                 'file' => [
                     'mime' => $file->getMimeType(),
                     'data' => base64_encode($file->getData()),
+                    'path' => $file->getIdentifier()
                 ],
             ],
         ];

--- a/src/qtism/runtime/pci/json/Unmarshaller.php
+++ b/src/qtism/runtime/pci/json/Unmarshaller.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/runtime/pci/json/Unmarshaller.php
+++ b/src/qtism/runtime/pci/json/Unmarshaller.php
@@ -372,7 +372,8 @@ class Unmarshaller
         return $this->getFileManager()->createFromData(
             base64_decode($fileArray['data']),
             $fileArray['mime'],
-            $fileArray['name'] ?? ''
+            $fileArray['name'] ?? '',
+            $fileArray['path'] ?? null
         );
     }
 

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -96,6 +96,8 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
         self::ENCODED_TEMPLATE_DECLARATION => 'templateDeclaration',
     ];
 
+    private const FILE_IDENTIFIER_ENCODING_MASK = '%s : %s';
+
     /** @var FileManager */
     private $fileManager;
 
@@ -1156,7 +1158,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
     {
         $toPersist = $file instanceof FileHash
             ? json_encode($file)
-            : $file->getIdentifier();
+            : sprintf(self::FILE_IDENTIFIER_ENCODING_MASK, $file->getIdentifier(), $file->getFilename());
 
         try {
             $this->writeString($toPersist);
@@ -1187,7 +1189,9 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             return FileHash::createFromArray($decoded);
         }
 
-        return $this->getFileManager()->retrieve($id);
+        [$id, $filename] = sscanf($id, self::FILE_IDENTIFIER_ENCODING_MASK);
+
+        return $this->getFileManager()->retrieve($id, $filename);
     }
 
     /**

--- a/test/qtismtest/common/datatypes/files/FileSystemFileManagerTest.php
+++ b/test/qtismtest/common/datatypes/files/FileSystemFileManagerTest.php
@@ -78,7 +78,7 @@ class FileSystemFileManagerTest extends QtiSmTestCase
     {
         $manager = new FileSystemFileManager();
         $mFile = $manager->createFromFile(self::samplesDir() . 'datatypes/file/raw/text.txt', 'text/plain', 'newname.txt');
-        $mFile = $manager->retrieve($mFile->getIdentifier());
+        $mFile = $manager->retrieve($mFile->getIdentifier(), $mFile->getFilename());
         $this::assertEquals('text/plain', $mFile->getMimeType());
         $this::assertEquals('newname.txt', $mFile->getFilename());
         $this::assertEquals('I contain some text...', $mFile->getData());

--- a/test/qtismtest/runtime/pci/json/JsonMarshallerTest.php
+++ b/test/qtismtest/runtime/pci/json/JsonMarshallerTest.php
@@ -168,10 +168,10 @@ class JsonMarshallerTest extends QtiSmTestCase
         $returnValue[] = [new QtiDuration('P3DT4H'), json_encode(['base' => ['duration' => 'P3DT4H']])];
 
         $file = new FileSystemFile($samples . 'datatypes/file/text-plain_text_data.txt');
-        $returnValue[] = [$file, json_encode(['base' => ['file' => ['mime' => $file->getMimeType(), 'data' => base64_encode($file->getData()), 'name' => 'text.txt']]])];
+        $returnValue[] = [$file, json_encode(['base' => ['file' => ['mime' => $file->getMimeType(), 'data' => base64_encode($file->getData()),  'path' => $file->getIdentifier(), 'name' => 'text.txt']]])];
 
         $file = new FileSystemFile($samples . 'datatypes/file/image-png_noname_data.png');
-        $returnValue[] = [$file, json_encode(['base' => ['file' => ['mime' => $file->getMimeType(), 'data' => base64_encode($file->getData())]]])];
+        $returnValue[] = [$file, json_encode(['base' => ['file' => ['mime' => $file->getMimeType(), 'data' => base64_encode($file->getData()), 'path' => $file->getIdentifier()]]])];
 
         $id = 'http://some.cloud.storage/path/to/stored-file.txt';
         $mimeType = 'text/plain';

--- a/test/qtismtest/runtime/pci/json/JsonUnmarshallerTest.php
+++ b/test/qtismtest/runtime/pci/json/JsonUnmarshallerTest.php
@@ -276,6 +276,10 @@ class JsonUnmarshallerTest extends QtiSmTestCase
         $file = $fileManager->retrieve($samples . 'datatypes/file/text-plain_text_data.txt');
         $returnValue[] = [$file, '{ "base" : { "file" : { "mime" : "text\/plain", "data" : ' . json_encode(base64_encode('Some text...')) . ', "name" : "text.txt" } } }'];
 
+        $targetPath = $samples . 'datatypes/file/target_text-plain_text_data.txt';
+        $file = $fileManager->createFromData($file->getData(), $file->getMimeType(), $file->getFilename(), $targetPath);
+        $returnValue[] = [$file, '{ "base" : { "file" : { "mime" : "text\/plain", "data" : ' . json_encode(base64_encode('Some text...')) . ', "name" : "text.txt", "path" : "' . $targetPath . '" } } }'];
+
         $originalfile = $samples . 'datatypes/file/raw/image.png';
         $filepath = $samples . 'datatypes/file/image-png_noname_data.png';
         $file = $fileManager->retrieve($filepath);

--- a/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
+++ b/test/qtismtest/runtime/storage/binary/QtiBinaryStreamAccessTest.php
@@ -5,12 +5,15 @@ namespace qtismtest\runtime\storage\binary;
 use qtism\common\collections\IdentifierCollection;
 use qtism\common\Comparable;
 use qtism\common\datatypes\files\FileHash;
+use qtism\common\datatypes\files\FileManager;
+use qtism\common\datatypes\files\FileManagerException;
 use qtism\common\datatypes\files\FileSystemFile;
 use qtism\common\datatypes\files\FileSystemFileManager;
 use qtism\common\datatypes\QtiBoolean;
 use qtism\common\datatypes\QtiDatatype;
 use qtism\common\datatypes\QtiDirectedPair;
 use qtism\common\datatypes\QtiDuration;
+use qtism\common\datatypes\QtiFile;
 use qtism\common\datatypes\QtiFloat;
 use qtism\common\datatypes\QtiIdentifier;
 use qtism\common\datatypes\QtiInteger;
@@ -22,9 +25,11 @@ use qtism\common\datatypes\QtiUri;
 use qtism\common\enums\BaseType;
 use qtism\common\enums\Cardinality;
 use qtism\common\storage\BinaryStreamAccessException;
+use qtism\common\storage\IStream;
 use qtism\common\storage\MemoryStream;
 use qtism\common\storage\MemoryStreamException;
 use qtism\common\storage\StreamAccessException;
+use qtism\common\storage\StreamException;
 use qtism\data\ItemSessionControl;
 use qtism\data\NavigationMode;
 use qtism\data\state\CorrectResponse;
@@ -45,6 +50,7 @@ use qtism\runtime\common\State;
 use qtism\runtime\common\TemplateVariable;
 use qtism\runtime\common\Variable;
 use qtism\runtime\common\VariableFactory;
+use qtism\runtime\common\VariableFactoryInterface;
 use qtism\runtime\storage\binary\QtiBinaryStreamAccess;
 use qtism\runtime\storage\binary\QtiBinaryStreamAccessException;
 use qtism\runtime\storage\binary\QtiBinaryVersion;
@@ -59,6 +65,8 @@ use ReflectionProperty;
  */
 class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
 {
+    private const EXPECTED_FILE_IDENTIFIER_ENCODING_MASK = '%s : %s';
+
     /**
      * @dataProvider readVariableValueProvider
      *
@@ -1888,6 +1896,235 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $access->writeIntOrIdentifier(new QtiIntOrIdentifier('identifier'));
     }
 
+
+    public function testSuccessfulWriteFileWithFileHash(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $file = new FileHash('id', 'text\css', 'main.css', md5('content'));
+        $jsonFileHash = json_encode($file);
+        $streamMock->expects(self::once())
+            ->method('write')
+            ->with(pack('S', strlen($jsonFileHash)) . $jsonFileHash);
+
+        $subject->writeFile($file);
+    }
+
+    public function testFailedWriteFileWithFileHash(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $file = new FileHash('id', 'text\css', 'main.css', md5('content'));
+        $jsonFileHash = json_encode($file);
+        $streamMock->expects(self::once())
+            ->method('write')
+            ->with(pack('S', strlen($jsonFileHash)) . $jsonFileHash)
+            ->willThrowException($this->createStreamException('message', $streamMock));
+
+        $this->expectException(BinaryStreamAccessException::class);
+        $subject->writeFile($file);
+    }
+
+    public function testSuccessfulReadFileWithFileHash(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $file = new FileHash('id', 'text\css', 'main.css', md5('content'));
+        $jsonFileHash = json_encode($file);
+        $streamMock->expects(self::exactly(2))
+            ->method('read')
+            ->withConsecutive([2], [strlen($jsonFileHash)])
+            ->willReturnOnConsecutiveCalls(
+                pack('S', strlen($jsonFileHash)),
+                $jsonFileHash
+            );
+
+        self::assertInstanceOf(FileHash::class, $subject->readFile());
+    }
+
+    public function testFailedReadFileWithFileHash(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $streamMock->expects(self::once())
+            ->method('read')
+            ->with(2)
+            ->willThrowException($this->createStreamException('message', $streamMock));
+
+        $this->expectException(BinaryStreamAccessException::class);
+        $subject->readFile();
+    }
+
+    public function testSuccessfulWriteFileWithNotFileHash(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $file = $this->createMock(QtiFile::class);
+        $fileIdentifier = 'file/identifier/or/path';
+        $fileName = 'fileName';
+        $file->expects(self::once())->method('getIdentifier')->willReturn($fileIdentifier);
+        $file->expects(self::once())->method('getFilename')->willReturn($fileName);
+        $fileString = sprintf(self::EXPECTED_FILE_IDENTIFIER_ENCODING_MASK, $fileIdentifier, $fileName);
+
+        $streamMock->expects(self::once())
+            ->method('write')
+            ->with(pack('S', strlen($fileString)) . $fileString);
+
+        $subject->writeFile($file);
+    }
+
+    public function testSuccessfulWriteFileWithNotFileHashWithoutFilename(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $file = $this->createMock(QtiFile::class);
+        $fileIdentifier = 'file/identifier/or/path';
+        $fileName = null;
+        $file->expects(self::once())->method('getIdentifier')->willReturn($fileIdentifier);
+        $file->expects(self::once())->method('getFilename')->willReturn($fileName);
+        $fileString = sprintf(self::EXPECTED_FILE_IDENTIFIER_ENCODING_MASK, $fileIdentifier, $fileName);
+
+        $streamMock->expects(self::once())
+            ->method('write')
+            ->with(pack('S', strlen($fileString)) . $fileString);
+
+        $subject->writeFile($file);
+    }
+
+    public function testFailedWriteFileWithNotFileHash(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $file = $this->createMock(QtiFile::class);
+        $fileIdentifier = 'file/identifier/or/path';
+        $fileName = 'fileName';
+        $file->expects(self::once())->method('getIdentifier')->willReturn($fileIdentifier);
+        $file->expects(self::once())->method('getFilename')->willReturn($fileName);
+        $fileString = sprintf(self::EXPECTED_FILE_IDENTIFIER_ENCODING_MASK, $fileIdentifier, $fileName);
+        $streamMock->expects(self::once())
+            ->method('write')
+            ->with(pack('S', strlen($fileString)) . $fileString)
+            ->willThrowException($this->createStreamException('message', $streamMock));
+
+        $this->expectException(BinaryStreamAccessException::class);
+        $subject->writeFile($file);
+    }
+
+    public function testSuccessfulReadFileWithNotFileHash(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $file = $this->createMock(QtiFile::class);
+        $fileIdentifier = 'file/identifier/or/path';
+        $fileName = 'fileName';
+        $fileString = sprintf(self::EXPECTED_FILE_IDENTIFIER_ENCODING_MASK, $fileIdentifier, $fileName);
+
+        $streamMock->expects(self::exactly(2))
+            ->method('read')
+            ->withConsecutive([2], [strlen($fileString)])
+            ->willReturnOnConsecutiveCalls(
+                pack('S', strlen($fileString)),
+                $fileString
+            );
+
+        $fileManagerMock->expects(self::once())
+            ->method('retrieve')
+            ->with($fileIdentifier, $fileName)
+            ->willReturn($file);
+
+        self::assertInstanceOf(get_class($file), $subject->readFile());
+    }
+
+    public function testSuccessfulReadFileWithNotFileHashWithoutFileName(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $file = $this->createMock(QtiFile::class);
+        $fileIdentifier = 'file/identifier/or/path';
+        $fileName = null;
+        $fileString = sprintf(self::EXPECTED_FILE_IDENTIFIER_ENCODING_MASK, $fileIdentifier, $fileName);
+
+        $streamMock->expects(self::exactly(2))
+            ->method('read')
+            ->withConsecutive([2], [strlen($fileString)])
+            ->willReturnOnConsecutiveCalls(
+                pack('S', strlen($fileString)),
+                $fileString
+            );
+
+        $fileManagerMock->expects(self::once())
+            ->method('retrieve')
+            ->with($fileIdentifier, $fileName)
+            ->willReturn($file);
+
+        self::assertInstanceOf(get_class($file), $subject->readFile());
+    }
+
+    public function testFailedRetrieveReadFileWithFileHash(): void
+    {
+        $streamMock = $this->createMock(IStream::class);
+        $fileManagerMock = $this->createMock(FileManager::class);
+        $variableFactoryMock = $this->createMock(VariableFactoryInterface::class);
+
+        $subject = new QtiBinaryStreamAccess($streamMock, $fileManagerMock, $variableFactoryMock);
+
+        $fileIdentifier = 'file/identifier/or/path';
+        $fileName = 'fileName';
+        $fileString = sprintf(self::EXPECTED_FILE_IDENTIFIER_ENCODING_MASK, $fileIdentifier, $fileName);
+
+        $streamMock->expects(self::exactly(2))
+            ->method('read')
+            ->withConsecutive([2], [strlen($fileString)])
+            ->willReturnOnConsecutiveCalls(
+                pack('S', strlen($fileString)),
+                $fileString
+            );
+
+        $fileManagerMock->expects(self::once())
+            ->method('retrieve')
+            ->with($fileIdentifier, $fileName)
+            ->willThrowException(new FileManagerException('message'));
+
+        $this->expectException(FileManagerException::class);
+        $subject->readFile();
+    }
+
     /**
      * @param int $versionNumber
      * @return QtiBinaryVersion
@@ -1901,5 +2138,16 @@ class QtiBinaryStreamAccessTest extends QtiSmAssessmentItemTestCase
         $property->setAccessible(false);
 
         return $version;
+    }
+
+
+    private function createStreamException(string $message, IStream $stream): StreamException
+    {
+        return new class($message, $stream) extends StreamException {
+            public function __construct($message, IStream $source, $code = 0, \Exception $previous = null)
+            {
+                parent::__construct($message, $source, $code, $previous);
+            }
+        };
     }
 }


### PR DESCRIPTION
# [TR-4660](https://oat-sa.atlassian.net/browse/TR-4660)

## Summary
Name of original file lost on different steps of test session
- at persisting by file manager
- at persisting test session in binary stream
I have __doubts__ about implemented way of encoding file id with name in qti binary stream

## Dependencies
required for - https://github.com/oat-sa/bundle-qti/pull/60
required for - https://github.com/oat-sa/tao-deliver-be/pull/1008

## Todo
validate and adjust tests if necessary