### PR TITLE
feat: allow to use dir attr in itemBody element

### DIFF
--- a/src/qtism/data/content/ItemBody.php
+++ b/src/qtism/data/content/ItemBody.php
@@ -47,6 +47,8 @@ use InvalidArgumentException;
  */
 class ItemBody extends BodyElement
 {
+    public const QTI_CLASS_NAME = 'itemBody';
+
     /**
      * The blocks composing the itemBody.
      *

--- a/src/qtism/data/storage/xml/marshalling/Marshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/Marshaller.php
@@ -31,6 +31,7 @@ use qtism\data\content\BodyElement;
 use qtism\data\content\Direction;
 use qtism\data\content\enums\AriaLive;
 use qtism\data\content\enums\AriaOrientation;
+use qtism\data\content\ItemBody;
 use qtism\data\QtiComponent;
 use qtism\data\storage\xml\Utils as XmlUtils;
 use qtism\data\storage\xml\versions\QtiVersion;
@@ -120,6 +121,7 @@ abstract class Marshaller
         'infoControl',
         'inlineChoice',
         'inlineChoiceInteraction',
+        ItemBody::QTI_CLASS_NAME,
         'kbd',
         'label',
         'li',

--- a/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
@@ -162,8 +162,6 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase
         $this::assertEquals('../sections/../sections/../items/question3.xml', $assessmentItemRefs['Q03']->getHref());
     }
 
-
-
     /**
      * @return array
      */
@@ -242,7 +240,6 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase
     {
         $doc = new XmlDocument();
         $doc->load(self::samplesDir() . 'custom/items/item_body_dir_attr.xml', true);
-
 
         /** @var ItemBody $itemBody */
         $itemBody = $doc->getDocumentComponent()->getComponentsByClassName('itemBody')[0];

--- a/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlAssessmentTestDocumentTest.php
@@ -2,6 +2,7 @@
 
 namespace qtismtest\data\storage\xml;
 
+use qtism\data\content\Direction;
 use qtism\data\storage\xml\XmlDocument;
 use qtism\data\storage\xml\XmlStorageException;
 use qtismtest\QtiSmTestCase;
@@ -11,6 +12,7 @@ use qtism\data\AssessmentSectionRef;
 use qtism\data\TestPart;
 use qtism\data\AssessmentTest;
 use qtism\data\storage\xml\LibXmlErrorCollection;
+use qtism\data\content\ItemBody;
 
 /**
  * Class XmlAssessmentTestDocumentTest
@@ -160,6 +162,8 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase
         $this::assertEquals('../sections/../sections/../items/question3.xml', $assessmentItemRefs['Q03']->getHref());
     }
 
+
+
     /**
      * @return array
      */
@@ -232,6 +236,21 @@ class XmlAssessmentTestDocumentTest extends QtiSmTestCase
             ['custom/tests/mixed_assessment_section_refs/test_similar_ids.xml', true],
             ['custom/tests/mixed_assessment_section_refs/test_different_ids.xml', true],
         ];
+    }
+
+    public function testParseItemBodyWithDirAttr(): void
+    {
+        $doc = new XmlDocument();
+        $doc->load(self::samplesDir() . 'custom/items/item_body_dir_attr.xml', true);
+
+
+        /** @var ItemBody $itemBody */
+        $itemBody = $doc->getDocumentComponent()->getComponentsByClassName('itemBody')[0];
+
+        $this::assertTrue(isset($itemBody));
+        $this::assertNotEmpty($itemBody->getDir());
+        $this::assertEquals(Direction::RTL, $itemBody->getDir());
+
     }
 
     /**

--- a/test/samples/custom/items/item_body_dir_attr.xml
+++ b/test/samples/custom/items/item_body_dir_attr.xml
@@ -1,0 +1,26 @@
+<assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p2" xmlns:m="http://www.w3.org/1998/Math/MathML"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p2 http://www.imsglobal.org/xsd/qti/qtiv2p2/imsqti_v2p2.xsd"
+                identifier="item_body_dir_attr" title="RTL Examples 5" label="RTL Hebrew" xml:lang="he-IL"
+                adaptive="false" timeDependent="false" toolName="TAO" toolVersion="2022.11">
+    <responseDeclaration identifier="RESPONSE" cardinality="multiple" baseType="identifier"/>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" normalMaximum="0"/>
+    <outcomeDeclaration identifier="MAXSCORE" cardinality="single" baseType="float">
+        <defaultValue>
+            <value>0</value>
+        </defaultValue>
+    </outcomeDeclaration>
+    <itemBody dir="rtl">
+        <div class="grid-row">
+            <div class="col-12">
+                <choiceInteraction responseIdentifier="RESPONSE" shuffle="false" maxChoices="0" minChoices="0"
+                                   orientation="vertical">
+                    <simpleChoice identifier="choice_1" fixed="false" showHide="show">東北</simpleChoice>
+                    <simpleChoice identifier="choice_2" fixed="false" showHide="show">北陸</simpleChoice>
+                    <simpleChoice identifier="choice_3" fixed="false" showHide="show">甲信越</simpleChoice>
+                </choiceInteraction>
+            </div>
+        </div>
+    </itemBody>
+    <responseProcessing template="http://www.imsglobal.org/question/qti_v2p2/rptemplates/match_correct"/>
+</assessmentItem>


### PR DESCRIPTION
# [PISA25-212](https://oat-sa.atlassian.net/browse/PISA25-212)

## Description 
support for RTL at the block or interaction level was dropped since MCA (who was the original sponsor for this) did not need to change the orientation within an item (what we called bidirectional content back then). So it stayed on the itemBody alone, as part of the dir attribute.

## Development impact
1. Use const for element name 
2. Include itemBody to white list of `dir` arttribute elements 

## see test run