### PR TITLE
fix: use patched version for vulnerable league/flysystem repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"ext-libxml": "*",
 		"ext-mbstring": "*",
 		"ext-simplexml": "*",
-		"league/flysystem": "^1.0|^2.0|^3.0",
+		"league/flysystem": "^1.0|2.1.1|^3.0",
 		"league/mime-type-detection": "^1.0",
 		"oat-sa/lib-beeme": "0.2.0",
 		"wp-cli/php-cli-tools": "0.10.3"


### PR DESCRIPTION
FIx Time-of-check Time-of-use (TOCTOU) Race Condition in league/flysystem