### PR TITLE
Handle false result of unpack function at test session reading

### DIFF
--- a/src/qtism/common/storage/UnpackingStreamException.php
+++ b/src/qtism/common/storage/UnpackingStreamException.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace qtism\common\storage;
+
+class UnpackingStreamException extends StreamException
+{
+
+}


### PR DESCRIPTION
## Summary
this PR aim to add proper handling false result of `unpack` function and trigger exception, to avoid TypeError
```
2023-05-04T17:53:14+02:00 In BinaryStreamAccess.php line 164:
2023-05-04T17:53:14+02:00                                                                      
2023-05-04T17:53:14+02:00   current(): Argument #1 ($array) must be of type array, bool given  
2023-05-04T17:53:14+02:00 
```