### PR TITLE
fix: use tryUnpack on readInteger

### DIFF
--- a/src/qtism/common/storage/BinaryStreamAccess.php
+++ b/src/qtism/common/storage/BinaryStreamAccess.php
@@ -127,7 +127,7 @@ class BinaryStreamAccess extends AbstractStreamAccess
         try {
             $bin = $this->getStream()->read(4);
 
-            return (int)current(unpack('l', $bin));
+            return (int)current($this->tryUnpack('l', $bin));
         } catch (StreamException $e) {
             $this->handleBinaryStreamException($e, BinaryStreamAccessException::INT);
         }


### PR DESCRIPTION
## Summary
use new exception driven tryUnpack at missed readInteger method