### PR TITLE
fix: add missing bean property

### DIFF
--- a/src/qtism/data/expressions/RandomFloat.php
+++ b/src/qtism/data/expressions/RandomFloat.php
@@ -37,6 +37,7 @@ class RandomFloat extends Expression
      * The min attribute value.
      *
      * @var float
+     * @qtism-bean-property
      */
     private $min = 0.0;
 


### PR DESCRIPTION
This PR aims to fix PHP marshalling of `RandomFloat` component