### PR TITLE
[Fix] Deprecation notices

### DIFF
--- a/bin/qtisdk
+++ b/bin/qtisdk
@@ -38,6 +38,6 @@ switch ($module) {
         Render::main();
         break;
     default:
-        CliTools\err("%RUnknown module '${requestedModuleName}'. Available modules are: " . implode(',', $availableModules) . '.%n');
+        CliTools\err("%RUnknown module '{$requestedModuleName}'. Available modules are: " . implode(',', $availableModules) . '.%n');
         exit(Cli::EXIT_FAILURE);
 }

--- a/src/qtism/cli/Cli.php
+++ b/src/qtism/cli/Cli.php
@@ -165,7 +165,7 @@ abstract class Cli
      */
     protected function error($message): void
     {
-        $this->out("%r${message}%n", true);
+        $this->out("%r{$message}%n", true);
     }
 
     /**
@@ -179,7 +179,7 @@ abstract class Cli
     protected function success($message): void
     {
         if ($this->isVerbose() === true) {
-            $this->out("%g${message}%n", true);
+            $this->out("%g{$message}%n", true);
         }
 
         exit(self::EXIT_SUCCESS);
@@ -209,7 +209,7 @@ abstract class Cli
         $msg = 'Missing argument';
 
         if (array_key_exists($longName, $options)) {
-            $msg .= " '${longName}'";
+            $msg .= " '{$longName}'";
         }
 
         $msg .= '.';
@@ -228,7 +228,7 @@ abstract class Cli
     protected function info($message): void
     {
         if ($this->isVerbose() === true) {
-            $this->out("%w${message}%n", true);
+            $this->out("%w{$message}%n", true);
         }
     }
 

--- a/src/qtism/cli/Render.php
+++ b/src/qtism/cli/Render.php
@@ -113,9 +113,9 @@ class Render extends Cli
             $this->missingArgument('source');
         } elseif (is_readable($source) === false) {
             if (file_exists($source) === false) {
-                $msg = "The QTI file '${source}' does not exist.";
+                $msg = "The QTI file '{$source}' does not exist.";
             } else {
-                $msg = "The QTI file '${source}' cannot be read. Check permissions.";
+                $msg = "The QTI file '{$source}' cannot be read. Check permissions.";
             }
 
             $this->fail($msg);
@@ -195,24 +195,24 @@ class Render extends Cli
         } catch (XmlStorageException $e) {
             switch ($e->getCode()) {
                 case XmlStorageException::READ:
-                    $msg = "An error occurred while reading QTI file '${source}'.\nThe system returned the following error:\n";
+                    $msg = "An error occurred while reading QTI file '{$source}'.\nThe system returned the following error:\n";
                     $msg .= ExceptionUtils::formatMessage($e);
                     $this->fail($msg);
                     break;
 
                 case XmlStorageException::XSD_VALIDATION:
-                    $msg = "The QTI file '${source}' is invalid against XML Schema.\nThe system returned the following error:\n";
+                    $msg = "The QTI file '{$source}' is invalid against XML Schema.\nThe system returned the following error:\n";
                     $msg .= ExceptionUtils::formatMessage($e);
                     $this->fail($msg);
                     break;
 
                 case XmlStorageException::VERSION:
-                    $msg = "The QTI version of file '${source}' could not be detected.";
+                    $msg = "The QTI version of file '{$source}' could not be detected.";
                     $this->fail($msg);
                     break;
 
                 default:
-                    $msg = "An fatal error occurred while reading QTI file '${source}'.";
+                    $msg = "An fatal error occurred while reading QTI file '{$source}'.";
                     $this->fail($msg);
                     break;
             }
@@ -266,28 +266,28 @@ class Render extends Cli
                 $assessmentItemElts->item(0)->removeAttribute($attributes->item(0)->name);
             }
 
-            $header .= '<html ' . implode(' ', $htmlAttributes) . ">${nl}";
-            $header .= "${indent}<head>${nl}";
-            $header .= "${indent}${indent}<meta charset=\"utf-8\">${nl}";
-            $header .= "${indent}${indent}<title>" . XmlUtils::escapeXmlSpecialChars($rootComponent->getTitle()) . "</title>${nl}";
-            $header .= "${indent}${indent}" . $renderer->getStylesheets()->ownerDocument->saveXML($renderer->getStylesheets());
-            $header .= "${indent}</head>${nl}";
+            $header .= '<html ' . implode(' ', $htmlAttributes) . ">{$nl}";
+            $header .= "{$indent}<head>{$nl}";
+            $header .= "{$indent}{$indent}<meta charset=\"utf-8\">{$nl}";
+            $header .= "{$indent}{$indent}<title>" . XmlUtils::escapeXmlSpecialChars($rootComponent->getTitle()) . "</title>{$nl}";
+            $header .= "{$indent}{$indent}" . $renderer->getStylesheets()->ownerDocument->saveXML($renderer->getStylesheets());
+            $header .= "{$indent}</head>{$nl}";
 
             $itemBodyElts = $xpath->query("//div[contains(@class, 'qti-itemBody')]");
             if ($itemBodyElts->length > 0) {
                 $body = $xml->saveXml($itemBodyElts->item(0));
                 $body = substr($body, strlen('<div>'));
                 $body = substr($body, 0, strlen('</div>') * -1);
-                $body = "<body ${body}</body>${nl}";
+                $body = "<body {$body}</body>{$nl}";
             } else {
-                $body = $xml->saveXml($xml->documentElement) . ${nl};
+                $body = $xml->saveXml($xml->documentElement) . {$nl};
             }
 
             if ($arguments['document'] === true) {
                 $footer = "</html>\n";
             }
         } else {
-            $body = $xml->saveXml($xml->documentElement) . ${nl};
+            $body = $xml->saveXml($xml->documentElement) . {$nl};
         }
 
         // Indent body...
@@ -299,7 +299,7 @@ class Render extends Cli
 
         foreach (preg_split('/\n|\r/u', $body, -1, PREG_SPLIT_NO_EMPTY) as $bodyLine) {
             // do stuff with $line
-            $indentBody .= "${indent}${bodyLine}${nl}";
+            $indentBody .= "{$indent}{$bodyLine}{$nl}";
         }
 
         $body = $indentBody;
@@ -342,23 +342,23 @@ class Render extends Cli
             }
 
             $header .= "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n";
-            $header .= "<html>${nl}";
-            $header .= "${indent}<head>${nl}";
-            $header .= "${indent}${indent}<meta charset=\"utf-8\">${nl}";
+            $header .= "<html>{$nl}";
+            $header .= "{$indent}<head>{$nl}";
+            $header .= "{$indent}{$indent}<meta charset=\"utf-8\">{$nl}";
 
             if (!empty($title)) {
-                $header .= "${indent}${indent}<title>" . $title . "</title>${nl}";
+                $header .= "{$indent}{$indent}<title>" . $title . "</title>{$nl}";
             }
 
-            $header .= "${indent}${indent}" . $renderer->getStylesheets()->ownerDocument->saveXML($renderer->getStylesheets());
-            $header .= "${indent}</head>${nl}";
-            $header .= "${indent}<body>${nl}";
+            $header .= "{$indent}{$indent}" . $renderer->getStylesheets()->ownerDocument->saveXML($renderer->getStylesheets());
+            $header .= "{$indent}</head>{$nl}";
+            $header .= "{$indent}<body>{$nl}";
 
-            $footer = "${indent}</body>${nl}";
+            $footer = "{$indent}</body>{$nl}";
             $footer .= "</html>\n";
         }
 
-        $body = $xml->saveXml($xml->documentElement) . ${nl};
+        $body = $xml->saveXml($xml->documentElement) . {$nl};
 
         // Indent body...
         $indentBody = '';
@@ -369,7 +369,7 @@ class Render extends Cli
 
         foreach (preg_split('/\n|\r/u', $body, -1, PREG_SPLIT_NO_EMPTY) as $bodyLine) {
             // do stuff with $line
-            $indentBody .= "${indent}${indent}${bodyLine}${nl}";
+            $indentBody .= "{$indent}{$indent}{$bodyLine}{$nl}";
         }
 
         $body = $indentBody;

--- a/src/qtism/common/beans/Bean.php
+++ b/src/qtism/common/beans/Bean.php
@@ -121,12 +121,12 @@ class Bean
         }
 
         if ($this->hasProperty($propertyName) === false) {
-            $msg = "The bean has no '${propertyName}' property.";
+            $msg = "The bean has no '{$propertyName}' property.";
             throw new BeanException($msg, BeanException::NO_METHOD);
         }
 
         if (($getterName = $this->hasGetter($propertyName)) === false) {
-            $msg = "The bean has no public getter for a '${propertyName}' property.";
+            $msg = "The bean has no public getter for a '{$propertyName}' property.";
             throw new BeanException($msg, BeanException::NO_METHOD);
         }
 
@@ -214,12 +214,12 @@ class Bean
         }
 
         if ($this->hasProperty($propertyName) === false) {
-            $msg = "The bean has no '${propertyName}' property.";
+            $msg = "The bean has no '{$propertyName}' property.";
             throw new BeanException($msg, BeanException::NO_METHOD);
         }
 
         if ($this->hasSetter($propertyName) === false) {
-            $msg = "The bean has no public setter for a '${propertyName}' property.";
+            $msg = "The bean has no public setter for a '{$propertyName}' property.";
             throw new BeanException($msg, BeanException::NO_METHOD);
         }
 
@@ -314,11 +314,11 @@ class Bean
             try {
                 return new BeanProperty($className, $propertyName);
             } catch (BeanException $e) {
-                $msg = "The bean property with name '${propertyName}' in class '${className}' could not be retrieved.";
+                $msg = "The bean property with name '{$propertyName}' in class '{$className}' could not be retrieved.";
                 throw new BeanException($msg, BeanException::NO_PROPERTY, $e);
             }
         } else {
-            $msg = "No bean property with name '${propertyName}' in class '${className}'.";
+            $msg = "No bean property with name '{$propertyName}' in class '{$className}'.";
             throw new BeanException($msg, BeanException::NO_PROPERTY);
         }
     }
@@ -490,13 +490,13 @@ class Bean
                 $name = $param->getName();
 
                 if ($this->hasProperty($name) === false) {
-                    $msg = "The constructor parameter '${name}' of class '${class}' has no related bean property.";
+                    $msg = "The constructor parameter '{$name}' of class '{$class}' has no related bean property.";
                     throw new BeanException($msg, BeanException::NO_PROPERTY);
                 } elseif ($this->hasGetter($name) === false) {
-                    $msg = "The constructor parameter '${name}' of class '${class}' has no related bean getter.";
+                    $msg = "The constructor parameter '{$name}' of class '{$class}' has no related bean getter.";
                     throw new BeanException($msg, BeanException::NO_METHOD);
                 } elseif ($this->hasSetter($name) === false) {
-                    $msg = "The construct parameter '${name}' of class '${class}' has no related bean setter.";
+                    $msg = "The construct parameter '{$name}' of class '{$class}' has no related bean setter.";
                     throw new BeanException($msg, BeanException::NO_METHOD);
                 }
             }
@@ -512,10 +512,10 @@ class Bean
             if ($this->hasProperty($name) === true) {
                 // Annotated property found.
                 if ($this->hasGetter($name) === false) {
-                    $msg = "The bean property '${name}' has no related bean getter.";
+                    $msg = "The bean property '{$name}' has no related bean getter.";
                     throw new BeanException($msg, BeanException::NO_METHOD);
                 } elseif ($this->hasSetter($name) === false) {
-                    $msg = "The bean property '${name}' has no related bean setter.";
+                    $msg = "The bean property '{$name}' has no related bean setter.";
                     throw new BeanException($msg, BeanException::NO_METHOD);
                 }
             }

--- a/src/qtism/common/beans/BeanMethod.php
+++ b/src/qtism/common/beans/BeanMethod.php
@@ -50,7 +50,7 @@ class BeanMethod
         try {
             $this->setMethod(new ReflectionMethod($class, $name));
         } catch (ReflectionException $e) {
-            $msg = "The method '${name}' does not exist.";
+            $msg = "The method '{$name}' does not exist.";
             throw new BeanException($msg, BeanException::NO_METHOD, $e);
         }
     }

--- a/src/qtism/common/beans/BeanParameter.php
+++ b/src/qtism/common/beans/BeanParameter.php
@@ -51,7 +51,7 @@ class BeanParameter
         try {
             $this->setParameter(new ReflectionParameter([$class, $method], $name));
         } catch (ReflectionException $e) {
-            $msg = "No such parameter '${name}' for method '${method}' of class '${class}'.";
+            $msg = "No such parameter '{$name}' for method '{$method}' of class '{$class}'.";
             throw new BeanException($msg, BeanException::NO_PARAMETER, $e);
         }
     }

--- a/src/qtism/common/beans/BeanProperty.php
+++ b/src/qtism/common/beans/BeanProperty.php
@@ -51,10 +51,10 @@ class BeanProperty
         try {
             $this->setProperty(new ReflectionProperty($class, $name));
         } catch (ReflectionException $e) {
-            $msg = "The class property with name '${name}' does not exist in class '${class}'.";
+            $msg = "The class property with name '{$name}' does not exist in class '{$class}'.";
             throw new BeanException($msg, BeanException::NO_PROPERTY, $e);
         } catch (BeanException $e) {
-            $msg = "The property with name '${name}' for class '${class}' is not annotated.";
+            $msg = "The property with name '{$name}' for class '{$class}' is not annotated.";
             throw new BeanException($msg, BeanException::NO_PROPERTY, $e);
         }
     }

--- a/src/qtism/common/collections/IdentifierCollection.php
+++ b/src/qtism/common/collections/IdentifierCollection.php
@@ -43,7 +43,7 @@ class IdentifierCollection extends StringCollection
             $msg = "IdentifierCollection class only accept string values, '" . gettype($value) . "' given.";
             throw new InvalidArgumentException($msg);
         } elseif (!Format::isIdentifier($value)) {
-            $msg = "IdentifierCollection class only accept valid QTI Identifiers, '${value}' given.";
+            $msg = "IdentifierCollection class only accept valid QTI Identifiers, '{$value}' given.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/common/datatypes/QtiPair.php
+++ b/src/qtism/common/datatypes/QtiPair.php
@@ -76,7 +76,7 @@ class QtiPair implements QtiDatatype
         if (Format::isIdentifier($first)) {
             $this->first = $first;
         } else {
-            $msg = "'${first}' is an invalid QTI identifier.";
+            $msg = "'{$first}' is an invalid QTI identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -102,7 +102,7 @@ class QtiPair implements QtiDatatype
         if (Format::isIdentifier($second)) {
             $this->second = $second;
         } else {
-            $msg = "'${second}' is an invalid QTI identifier.";
+            $msg = "'{$second}' is an invalid QTI identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/common/datatypes/files/FileSystemFile.php
+++ b/src/qtism/common/datatypes/files/FileSystemFile.php
@@ -222,7 +222,7 @@ class FileSystemFile implements QtiFile
                 // Should we build the path to $destination?
                 $pathinfo = pathinfo($destination);
                 if (isset($pathinfo['dirname']) === false) {
-                    $msg = "The destination argument '${destination}' is a malformed path.";
+                    $msg = "The destination argument '{$destination}' is a malformed path.";
                     throw new RuntimeException($msg);
                 }
 
@@ -251,12 +251,12 @@ class FileSystemFile implements QtiFile
 
                 $sourceFp = @fopen($source, 'r');
                 if ($sourceFp === false) {
-                    throw new RuntimeException("Source file '${source}' could not be open.");
+                    throw new RuntimeException("Source file '{$source}' could not be open.");
                 }
 
                 $destinationFp = @fopen($destination, 'w');
                 if ($destinationFp === false) {
-                    throw new RuntimeException("Destination file '${destination}' could not be open.");
+                    throw new RuntimeException("Destination file '{$destination}' could not be open.");
                 }
 
                 fwrite($destinationFp, $packedFilename . $packedMimeType);
@@ -273,12 +273,12 @@ class FileSystemFile implements QtiFile
                 return new static($destination);
             } else {
                 // Source file not readable.
-                $msg = "File '${source}' found but not readable.";
+                $msg = "File '{$source}' found but not readable.";
                 throw new RuntimeException($msg);
             }
         } else {
             // Source file not found.
-            $msg = "Unable to find source file at '${source}'.";
+            $msg = "Unable to find source file at '{$source}'.";
             throw new RuntimeException($msg);
         }
     }

--- a/src/qtism/common/storage/BinaryStreamAccess.php
+++ b/src/qtism/common/storage/BinaryStreamAccess.php
@@ -372,15 +372,15 @@ class BinaryStreamAccess extends AbstractStreamAccess
         switch ($e->getCode()) {
             case StreamException::NOT_OPEN:
                 $strAction = ucfirst($strAction);
-                $msg = "${strAction} a ${strType} from a closed binary stream is not permitted.";
+                $msg = "{$strAction} a {$strType} from a closed binary stream is not permitted.";
                 throw new BinaryStreamAccessException($msg, $this, BinaryStreamAccessException::NOT_OPEN, $e);
 
             case StreamException::READ:
-                $msg = "An error occurred while ${strAction} a ${strType}.";
+                $msg = "An error occurred while {$strAction} a {$strType}.";
                 throw new BinaryStreamAccessException($msg, $this, $typeError, $e);
 
             default:
-                $msg = "An unknown error occurred while ${strAction} a ${strType}.";
+                $msg = "An unknown error occurred while {$strAction} a {$strType}.";
                 throw new BinaryStreamAccessException($msg, $this, BinaryStreamAccessException::UNKNOWN, $e);
         }
     }

--- a/src/qtism/common/utils/Exception.php
+++ b/src/qtism/common/utils/Exception.php
@@ -53,7 +53,7 @@ class Exception
         do {
             $className = get_class($e);
             $message = $e->getMessage();
-            $returnValue .= ($withClassName === true) ? "[${className}] ${message}" : $message;
+            $returnValue .= ($withClassName === true) ? "[{$className}] {$message}" : $message;
 
             if ($e = $e->getPrevious()) {
                 $returnValue .= "\nCaused by:\n";

--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -371,7 +371,7 @@ class Format
     public static function scale10(float $float, string $x = 'x', $precision = false): string
     {
         // 1. Transform in 'E' notation.
-        $mask = ($precision === false) ? '%e' : "%.${precision}e";
+        $mask = ($precision === false) ? '%e' : "%.{$precision}e";
         $strFloat = sprintf($mask, $float);
 
         // 2. Transform the 'E' notation into 'x 10^n' notation.
@@ -398,7 +398,7 @@ class Format
             }
         }
 
-        return $parts[0] . " ${x} 10" . $newMantissa;
+        return $parts[0] . " {$x} 10" . $newMantissa;
     }
 
     /**

--- a/src/qtism/data/AssessmentTest.php
+++ b/src/qtism/data/AssessmentTest.php
@@ -182,7 +182,7 @@ class AssessmentTest extends QtiComponent implements QtiIdentifiable
             $this->identifier = $identifier;
             $this->notify();
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/QtiComponentCollection.php
+++ b/src/qtism/data/QtiComponentCollection.php
@@ -58,7 +58,7 @@ class QtiComponentCollection extends AbstractCollection
         if (empty($offset)) {
             parent::offsetSet($offset, $value);
         } else {
-            $msg = "QtiComponentCollection must be used as a bag (specific key '${offset}' given).";
+            $msg = "QtiComponentCollection must be used as a bag (specific key '{$offset}' given).";
             throw new RuntimeException($msg);
         }
     }
@@ -71,7 +71,7 @@ class QtiComponentCollection extends AbstractCollection
         if (empty($offset)) {
             parent::offsetUnset($offset);
         } else {
-            $msg = "QtiComponentCollection must be used as a bag (specific key '${offset}' given).";
+            $msg = "QtiComponentCollection must be used as a bag (specific key '{$offset}' given).";
             throw new RuntimeException($msg);
         }
     }

--- a/src/qtism/data/QtiIdentifiableCollection.php
+++ b/src/qtism/data/QtiIdentifiableCollection.php
@@ -121,7 +121,7 @@ class QtiIdentifiableCollection extends QtiComponentCollection implements SplObs
         if ($offset !== null) {
             $msg = 'No specific offset can be set in a QtiIdentifiableCollection. ';
             $msg .= "The offset is always infered from the 'identifier' attribute of ";
-            $msg .= "the given QtiIdentifiable object. Given offset is '${offset}'.";
+            $msg .= "the given QtiIdentifiable object. Given offset is '{$offset}'.";
 
             throw new OutOfRangeException($msg);
         }

--- a/src/qtism/data/SectionPart.php
+++ b/src/qtism/data/SectionPart.php
@@ -158,7 +158,7 @@ class SectionPart extends QtiComponent implements QtiIdentifiable, Shufflable
             $this->identifier = $identifier;
             $this->notify();
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/TestFeedback.php
+++ b/src/qtism/data/TestFeedback.php
@@ -151,7 +151,7 @@ class TestFeedback extends QtiComponent
         if (in_array($access, TestFeedbackAccess::asArray(), true)) {
             $this->access = $access;
         } else {
-            $msg = "'${access}' is not a value from the TestFeedbackAccess enumeration.";
+            $msg = "'{$access}' is not a value from the TestFeedbackAccess enumeration.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -177,7 +177,7 @@ class TestFeedback extends QtiComponent
         if (Format::isIdentifier((string)$outcomeIdentifier)) {
             $this->outcomeIdentifier = $outcomeIdentifier;
         } else {
-            $msg = "'${outcomeIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$outcomeIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -203,7 +203,7 @@ class TestFeedback extends QtiComponent
         if (in_array($showHide, ShowHide::asArray(), true)) {
             $this->showHide = $showHide;
         } else {
-            $msg = "'${showHide}' is not a value from the ShowHide enumeration.";
+            $msg = "'{$showHide}' is not a value from the ShowHide enumeration.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -229,7 +229,7 @@ class TestFeedback extends QtiComponent
         if (Format::isIdentifier((string)$identifier, false)) {
             $this->identifier = $identifier;
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/TestFeedbackRef.php
+++ b/src/qtism/data/TestFeedbackRef.php
@@ -131,7 +131,7 @@ class TestFeedbackRef extends QtiComponent
         if (in_array($access, TestFeedbackAccess::asArray(), true)) {
             $this->access = $access;
         } else {
-            $msg = "'${access}' is not a value from the TestFeedbackAccess enumeration.";
+            $msg = "'{$access}' is not a value from the TestFeedbackAccess enumeration.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -157,7 +157,7 @@ class TestFeedbackRef extends QtiComponent
         if (Format::isIdentifier((string)$outcomeIdentifier)) {
             $this->outcomeIdentifier = $outcomeIdentifier;
         } else {
-            $msg = "'${outcomeIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$outcomeIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -183,7 +183,7 @@ class TestFeedbackRef extends QtiComponent
         if (Format::isIdentifier((string)$identifier, false)) {
             $this->identifier = $identifier;
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -209,7 +209,7 @@ class TestFeedbackRef extends QtiComponent
         if (in_array($showHide, ShowHide::asArray(), true)) {
             $this->showHide = $showHide;
         } else {
-            $msg = "'${showHide}' is not a value from the ShowHide enumeration.";
+            $msg = "'{$showHide}' is not a value from the ShowHide enumeration.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -234,7 +234,7 @@ class TestFeedbackRef extends QtiComponent
         if (Format::isUri($href) === true) {
             $this->href = $href;
         } else {
-            $msg = "'${href}' is not a valid URI.";
+            $msg = "'{$href}' is not a valid URI.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/TestPart.php
+++ b/src/qtism/data/TestPart.php
@@ -170,7 +170,7 @@ class TestPart extends QtiComponent implements QtiIdentifiable
             $this->identifier = $identifier;
             $this->notify();
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -196,7 +196,7 @@ class TestPart extends QtiComponent implements QtiIdentifiable
         if (in_array($navigationMode, NavigationMode::asArray())) {
             $this->navigationMode = $navigationMode;
         } else {
-            $msg = "'${navigationMode}' is not a valid value for NavigationMode.";
+            $msg = "'{$navigationMode}' is not a valid value for NavigationMode.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -222,7 +222,7 @@ class TestPart extends QtiComponent implements QtiIdentifiable
         if (in_array($submissionMode, SubmissionMode::asArray())) {
             $this->submissionMode = $submissionMode;
         } else {
-            $msg = "'${submissionMode}' is not a valid value for SubmissionMode.";
+            $msg = "'{$submissionMode}' is not a valid value for SubmissionMode.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/ViewCollection.php
+++ b/src/qtism/data/ViewCollection.php
@@ -40,7 +40,7 @@ class ViewCollection extends IntegerCollection
     protected function checkType($value): void
     {
         if (!in_array($value, View::asArray())) {
-            $msg = "The ViewsCollection class only accept View enumeration values, '${value}' given.";
+            $msg = "The ViewsCollection class only accept View enumeration values, '{$value}' given.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/content/BodyElement.php
+++ b/src/qtism/data/content/BodyElement.php
@@ -348,7 +348,7 @@ abstract class BodyElement extends QtiComponent
     public function setAriaControls(string $ariaControls): void
     {
         if ($ariaControls !== '' && !Format::isAriaIdRefs($ariaControls)) {
-            $msg = "'${ariaControls}' is not a valid value for attribute 'aria-controls'.";
+            $msg = "'{$ariaControls}' is not a valid value for attribute 'aria-controls'.";
             throw new InvalidArgumentException($msg);
         }
 
@@ -378,7 +378,7 @@ abstract class BodyElement extends QtiComponent
     public function setAriaDescribedBy(string $ariaDescribedBy): void
     {
         if ($ariaDescribedBy !== '' && !Format::isAriaIdRefs($ariaDescribedBy)) {
-            $msg = "'${ariaDescribedBy}' is not a valid value for attribute 'aria-describedby'.";
+            $msg = "'{$ariaDescribedBy}' is not a valid value for attribute 'aria-describedby'.";
             throw new InvalidArgumentException($msg);
         }
 
@@ -408,7 +408,7 @@ abstract class BodyElement extends QtiComponent
     public function setAriaFlowTo(string $ariaFlowTo): void
     {
         if ($ariaFlowTo !== '' && !Format::isAriaIdRefs($ariaFlowTo)) {
-            $msg = "'${ariaFlowTo}' is not a valid value for attribute 'aria-flowto'.";
+            $msg = "'{$ariaFlowTo}' is not a valid value for attribute 'aria-flowto'.";
             throw new InvalidArgumentException($msg);
         }
 
@@ -438,7 +438,7 @@ abstract class BodyElement extends QtiComponent
     public function setAriaLabelledBy(string $ariaLabelledBy): void
     {
         if ($ariaLabelledBy !== '' && !Format::isAriaIdRefs($ariaLabelledBy)) {
-            $msg = "'${ariaLabelledBy}' is not a valid value for attribute 'aria-labelledby'.";
+            $msg = "'{$ariaLabelledBy}' is not a valid value for attribute 'aria-labelledby'.";
             throw new InvalidArgumentException($msg);
         }
 
@@ -468,7 +468,7 @@ abstract class BodyElement extends QtiComponent
     public function setAriaOwns(string $ariaOwns): void
     {
         if ($ariaOwns !== '' && !Format::isAriaIdRefs($ariaOwns)) {
-            $msg = "'${ariaOwns}' is not a valid value for attribute 'aria-owns'.";
+            $msg = "'{$ariaOwns}' is not a valid value for attribute 'aria-owns'.";
             throw new InvalidArgumentException($msg);
         }
 
@@ -498,7 +498,7 @@ abstract class BodyElement extends QtiComponent
     public function setAriaLevel(string $ariaLevel): void
     {
         if ($ariaLevel !== '' && !Format::isAriaLevel($ariaLevel)) {
-            $msg = "'${ariaLevel}' is not a valid value for attribute 'aria-level'.";
+            $msg = "'{$ariaLevel}' is not a valid value for attribute 'aria-level'.";
             throw new InvalidArgumentException($msg);
         }
 
@@ -528,7 +528,7 @@ abstract class BodyElement extends QtiComponent
     public function setAriaLive(int $ariaLive): void
     {
         if ($ariaLive !== false && !in_array($ariaLive, AriaLive::asArray(), true)) {
-            $msg = "'${ariaLive}' is not a valid value for attribute 'aria-live'.";
+            $msg = "'{$ariaLive}' is not a valid value for attribute 'aria-live'.";
             throw new InvalidArgumentException($msg);
         }
 
@@ -562,7 +562,7 @@ abstract class BodyElement extends QtiComponent
             $this->ariaOrientation = $ariaOrientation;
         } else {
             $val = (is_object($ariaOrientation)) ? ('instance of ' . get_class($ariaOrientation)) : $ariaOrientation;
-            $msg = "'${val}' is not a valid value for attribute 'aria-orientation'.";
+            $msg = "'{$val}' is not a valid value for attribute 'aria-orientation'.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -592,7 +592,7 @@ abstract class BodyElement extends QtiComponent
         if (!is_string($ariaLabel)) {
             $val = (is_object($ariaLabel)) ? ('instance of ' . get_class($ariaLabel)) : $ariaLabel;
 
-            $msg = "'${val}' is not a valid value for attribute 'aria-label'.";
+            $msg = "'{$val}' is not a valid value for attribute 'aria-label'.";
             throw new InvalidArgumentException($msg);
         }
 
@@ -624,7 +624,7 @@ abstract class BodyElement extends QtiComponent
         if (!is_bool($ariaHidden)) {
             $val = (is_object($ariaHidden)) ? ('instance of ' . get_class($ariaHidden)) : $ariaHidden;
 
-            $msg = "'${val}' is not a valid value for attribute 'aria-hidden'.";
+            $msg = "'{$val}' is not a valid value for attribute 'aria-hidden'.";
             throw new InvalidArgumentException($msg);
         }
 

--- a/src/qtism/data/expressions/Correct.php
+++ b/src/qtism/data/expressions/Correct.php
@@ -66,7 +66,7 @@ class Correct extends Expression
         if (Format::isIdentifier($identifier, false)) {
             $this->identifier = $identifier;
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/expressions/ItemSubset.php
+++ b/src/qtism/data/expressions/ItemSubset.php
@@ -88,7 +88,7 @@ class ItemSubset extends Expression
         if (Format::isIdentifier($sectionIdentifier) || empty($sectionIdentifier)) {
             $this->sectionIdentifier = $sectionIdentifier;
         } else {
-            $msg = "'${sectionIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$sectionIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/expressions/MapResponse.php
+++ b/src/qtism/data/expressions/MapResponse.php
@@ -75,7 +75,7 @@ class MapResponse extends Expression
         if (Format::isIdentifier($identifier, false)) {
             $this->identifier = $identifier;
         } else {
-            $msg = "${identifier} is not a valid QTI Identifier.";
+            $msg = "{$identifier} is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/expressions/MapResponsePoint.php
+++ b/src/qtism/data/expressions/MapResponsePoint.php
@@ -69,7 +69,7 @@ class MapResponsePoint extends Expression
         if (Format::isIdentifier($identifier, false)) {
             $this->identifier = $identifier;
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/expressions/MathConstant.php
+++ b/src/qtism/data/expressions/MathConstant.php
@@ -71,7 +71,7 @@ class MathConstant extends Expression
         if (in_array($name, MathEnumeration::asArray())) {
             $this->name = $name;
         } else {
-            $msg = "${name} is not a valid QTI Math constant.";
+            $msg = "{$name} is not a valid QTI Math constant.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/expressions/OutcomeMaximum.php
+++ b/src/qtism/data/expressions/OutcomeMaximum.php
@@ -82,7 +82,7 @@ class OutcomeMaximum extends ItemSubset
         if (Format::isIdentifier($outcomeIdentifier)) {
             $this->outcomeIdentifier = $outcomeIdentifier;
         } else {
-            $msg = "'${outcomeIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$outcomeIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -108,7 +108,7 @@ class OutcomeMaximum extends ItemSubset
         if (Format::isIdentifier($weightIdentifier) || $weightIdentifier == '') {
             $this->weightIdentifier = $weightIdentifier;
         } else {
-            $msg = "'${weightIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$weightIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/expressions/OutcomeMinimum.php
+++ b/src/qtism/data/expressions/OutcomeMinimum.php
@@ -82,7 +82,7 @@ class OutcomeMinimum extends ItemSubset
         if (Format::isIdentifier($outcomeIdentifier)) {
             $this->outcomeIdentifier = $outcomeIdentifier;
         } else {
-            $msg = "'${outcomeIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$outcomeIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -108,7 +108,7 @@ class OutcomeMinimum extends ItemSubset
         if (Format::isIdentifier($weightIdentifier) || $weightIdentifier == '') {
             $this->weightIdentifier = $weightIdentifier;
         } else {
-            $msg = "'${weightIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$weightIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/expressions/TestVariables.php
+++ b/src/qtism/data/expressions/TestVariables.php
@@ -111,7 +111,7 @@ class TestVariables extends ItemSubset
         if (Format::isIdentifier($variableIdentifier)) {
             $this->variableIdentifier = $variableIdentifier;
         } else {
-            $msg = "'${variableIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$variableIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -163,7 +163,7 @@ class TestVariables extends ItemSubset
         if (Format::isIdentifier($weightIdentifier) || empty($weightIdentifier)) {
             $this->weightIdentifier = $weightIdentifier;
         } else {
-            $msg = "'${weightIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$weightIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/expressions/Variable.php
+++ b/src/qtism/data/expressions/Variable.php
@@ -112,7 +112,7 @@ class Variable extends Expression
         if (Format::isIdentifier($identifier, false)) {
             $this->identifier = $identifier;
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -139,7 +139,7 @@ class Variable extends Expression
         if (empty($weightIdentifier) || Format::isIdentifier($weightIdentifier)) {
             $this->weightIdentifier = $weightIdentifier;
         } else {
-            $msg = "'${weightIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$weightIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/expressions/operators/FieldValue.php
+++ b/src/qtism/data/expressions/operators/FieldValue.php
@@ -65,7 +65,7 @@ class FieldValue extends Operator
         if (Format::isIdentifier($fieldIdentifier)) {
             $this->fieldIdentifier = $fieldIdentifier;
         } else {
-            $msg = "'${fieldIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$fieldIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/processing/ResponseProcessing.php
+++ b/src/qtism/data/processing/ResponseProcessing.php
@@ -145,7 +145,7 @@ class ResponseProcessing extends QtiComponent
         if (Format::isUri($template) === true || (is_string($template) && empty($template))) {
             $this->template = $template;
         } else {
-            $msg = "The given template '${template}' is not a valid URI.";
+            $msg = "The given template '{$template}' is not a valid URI.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -183,7 +183,7 @@ class ResponseProcessing extends QtiComponent
         if (Format::isUri($templateLocation) === true || (is_string($templateLocation) && empty($templateLocation))) {
             $this->templateLocation = $templateLocation;
         } else {
-            $msg = "The given templateLocation '${templateLocation}' is not a valid URI.";
+            $msg = "The given templateLocation '{$templateLocation}' is not a valid URI.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/state/Shuffling.php
+++ b/src/qtism/data/state/Shuffling.php
@@ -100,7 +100,7 @@ class Shuffling extends QtiComponent
             $msg = 'A Shuffling object must be composed of at least 1 ShufflingGroup object. None given';
             throw new InvalidArgumentException($msg);
         } elseif (($c = count($shufflingGroups)) > 2) {
-            $msg = "A Shuffling object must be composed of at most 2 ShufflingGroup objects. ${c} given.";
+            $msg = "A Shuffling object must be composed of at most 2 ShufflingGroup objects. {$c} given.";
             throw new InvalidArgumentException($msg);
         } else {
             $this->shufflingGroups = $shufflingGroups;
@@ -183,7 +183,7 @@ class Shuffling extends QtiComponent
             }
         }
 
-        throw new OutOfBoundsException("No identifier at index ${index}.");
+        throw new OutOfBoundsException("No identifier at index {$index}.");
     }
 
     /**

--- a/src/qtism/data/state/TemplateDefault.php
+++ b/src/qtism/data/state/TemplateDefault.php
@@ -91,7 +91,7 @@ class TemplateDefault extends QtiComponent
         if (Format::isIdentifier($templateIdentifier)) {
             $this->templateIdentifier = $templateIdentifier;
         } else {
-            $msg = "'${templateIdentifier}' is not a valid QTI Identifier.";
+            $msg = "'{$templateIdentifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/state/Value.php
+++ b/src/qtism/data/state/Value.php
@@ -146,7 +146,7 @@ class Value extends QtiComponent
         if ($fieldIdentifier == '' || Format::isIdentifier($fieldIdentifier)) {
             $this->fieldIdentifier = $fieldIdentifier;
         } else {
-            $msg = "'${fieldIdentifier}' is not a valid QTI identifier.";
+            $msg = "'{$fieldIdentifier}' is not a valid QTI identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -182,7 +182,7 @@ class Value extends QtiComponent
         if (in_array($baseType, BaseType::asArray()) || $baseType === -1) {
             $this->baseType = $baseType;
         } else {
-            $msg = "'${baseType}' is not a value from the BaseType enumeration.";
+            $msg = "'{$baseType}' is not a value from the BaseType enumeration.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/state/VariableDeclaration.php
+++ b/src/qtism/data/state/VariableDeclaration.php
@@ -139,7 +139,7 @@ class VariableDeclaration extends QtiComponent implements QtiIdentifiable
             $this->identifier = $identifier;
             $this->notify();
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/state/VariableMapping.php
+++ b/src/qtism/data/state/VariableMapping.php
@@ -88,7 +88,7 @@ class VariableMapping extends QtiComponent
         if (Format::isIdentifier($source)) {
             $this->source = $source;
         } else {
-            $msg = "'${source}' is not a valid QTI identifier.";
+            $msg = "'{$source}' is not a valid QTI identifier.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -114,7 +114,7 @@ class VariableMapping extends QtiComponent
         if (Format::isIdentifier($target)) {
             $this->target = $target;
         } else {
-            $msg = "'${target}' is not a valid QTI identifier.";
+            $msg = "'{$target}' is not a valid QTI identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/state/Weight.php
+++ b/src/qtism/data/state/Weight.php
@@ -96,7 +96,7 @@ class Weight extends QtiComponent implements QtiIdentifiable
             $this->identifier = $identifier;
             $this->notify();
         } else {
-            $msg = "'${identifier}' is not a valid QTI Identifier.";
+            $msg = "'{$identifier}' is not a valid QTI Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/storage/LocalFileResolver.php
+++ b/src/qtism/data/storage/LocalFileResolver.php
@@ -57,7 +57,7 @@ class LocalFileResolver extends FileResolver
         $baseDir = pathinfo($baseUrl, PATHINFO_DIRNAME);
 
         if (empty($baseDir)) {
-            $msg = "The base directory of the document ('${baseDir}') could not be resolved.";
+            $msg = "The base directory of the document ('{$baseDir}') could not be resolved.";
             throw new ResolutionException($msg);
         }
 

--- a/src/qtism/data/storage/Utils.php
+++ b/src/qtism/data/storage/Utils.php
@@ -53,7 +53,7 @@ class Utils
     public static function stringToDatatype(?string $string, int $baseType)
     {
         $string = $string ?? '';
-        
+
         if (!in_array($baseType, BaseType::asArray(), true)) {
             $msg = 'BaseType must be a value from the BaseType enumeration.';
             throw new InvalidArgumentException($msg);
@@ -62,7 +62,7 @@ class Utils
         switch ($baseType) {
             case BaseType::BOOLEAN:
                 if (!Format::isBoolean($string)) {
-                    $msg = "'${string}' cannot be transformed into boolean.";
+                    $msg = "'{$string}' cannot be transformed into boolean.";
                     throw new UnexpectedValueException($msg);
                 }
 
@@ -70,7 +70,7 @@ class Utils
 
             case BaseType::INTEGER:
                 if (!Format::isInteger($string)) {
-                    $msg = "'${string}' cannot be transformed into integer.";
+                    $msg = "'{$string}' cannot be transformed into integer.";
                     throw new UnexpectedValueException($msg);
                 }
 
@@ -78,7 +78,7 @@ class Utils
 
             case BaseType::FLOAT:
                 if (!Format::isFloat($string)) {
-                    $msg = "'${string}' cannot be transformed into float.";
+                    $msg = "'{$string}' cannot be transformed into float.";
                     throw new UnexpectedValueException($msg);
                 }
 
@@ -86,7 +86,7 @@ class Utils
 
             case BaseType::URI:
                 if (!Format::isUri($string)) {
-                    $msg = "'${string}' is not a valid URI.";
+                    $msg = "'{$string}' is not a valid URI.";
                     throw new UnexpectedValueException($msg);
                 }
 
@@ -94,7 +94,7 @@ class Utils
 
             case BaseType::IDENTIFIER:
                 if (!Format::isIdentifier($string)) {
-                    $msg = "'${string}' is not a valid QTI Identifier.";
+                    $msg = "'{$string}' is not a valid QTI Identifier.";
                     throw new UnexpectedValueException($msg);
                 }
 
@@ -109,12 +109,12 @@ class Utils
                     return (int)$string;
                 }
 
-                $msg = "'${string}' is not a valid QTI Identifier nor a valid integer.";
+                $msg = "'{$string}' is not a valid QTI Identifier nor a valid integer.";
                 throw new UnexpectedValueException($msg);
 
             case BaseType::PAIR:
                 if (!Format::isPair($string)) {
-                    $msg = "'${string}' is not a valid pair.";
+                    $msg = "'{$string}' is not a valid pair.";
                     throw new UnexpectedValueException($msg);
                 }
 
@@ -123,7 +123,7 @@ class Utils
 
             case BaseType::DIRECTED_PAIR:
                 if (!Format::isDirectedPair($string)) {
-                    $msg = "'${string}' is not a valid directed pair.";
+                    $msg = "'{$string}' is not a valid directed pair.";
                     throw new UnexpectedValueException($msg);
                 }
 
@@ -132,7 +132,7 @@ class Utils
 
             case BaseType::DURATION:
                 if (!Format::isDuration($string)) {
-                    $msg = "'${string}' is not a valid duration.";
+                    $msg = "'{$string}' is not a valid duration.";
                     throw new UnexpectedValueException($msg);
                 }
 
@@ -146,7 +146,7 @@ class Utils
 
             case BaseType::POINT:
                 if (!Format::isPoint($string)) {
-                    $msg = "'${string}' is not valid point.";
+                    $msg = "'{$string}' is not valid point.";
                     throw new UnexpectedValueException($msg);
                 }
 
@@ -166,7 +166,7 @@ class Utils
     public static function stringToBoolean(string $string): bool
     {
         if (!Format::isBoolean($string)) {
-            throw new UnexpectedValueException("'${string}' cannot be transformed into boolean.");
+            throw new UnexpectedValueException("'{$string}' cannot be transformed into boolean.");
         }
 
         return strtolower(trim($string)) === 'true';
@@ -195,7 +195,7 @@ class Utils
             // the given shape?
             return new QtiCoords($shape, $intCoords);
         } else {
-            throw new UnexpectedValueException("'${string}' cannot be converted to Coords.");
+            throw new UnexpectedValueException("'{$string}' cannot be converted to Coords.");
         }
     }
 

--- a/src/qtism/data/storage/php/PhpDocument.php
+++ b/src/qtism/data/storage/php/PhpDocument.php
@@ -76,7 +76,7 @@ class PhpDocument extends QtiDocument
         $written = @file_put_contents($url, $stream->getBinary());
 
         if ($written === false) {
-            throw new PhpStorageException("File located at '${url}' could not be written.");
+            throw new PhpStorageException("File located at '{$url}' could not be written.");
         }
 
         if ($written !== false && $exists === true && function_exists('opcache_invalidate') === true) {
@@ -189,7 +189,7 @@ class PhpDocument extends QtiDocument
     public function load(string $url): void
     {
         if (is_readable($url) === false) {
-            $msg = "The PHP document located at '${url}' is not readable or does not exist.";
+            $msg = "The PHP document located at '{$url}' is not readable or does not exist.";
             throw new PhpStorageException($msg, PhpStorageException::READ);
         }
 
@@ -199,7 +199,7 @@ class PhpDocument extends QtiDocument
             $this->setDocumentComponent($rootcomponent);
             $this->setUrl($url);
         } catch (Exception $e) {
-            $msg = "A PHP Runtime Error occurred while executing the PHP source code representing the document to be loaded at '${url}'.";
+            $msg = "A PHP Runtime Error occurred while executing the PHP source code representing the document to be loaded at '{$url}'.";
             throw new PhpStorageException($msg, PhpStorageException::UNKNOWN, $e);
         }
     }

--- a/src/qtism/data/storage/php/PhpStreamAccess.php
+++ b/src/qtism/data/storage/php/PhpStreamAccess.php
@@ -81,7 +81,7 @@ class PhpStreamAccess extends AbstractStreamAccess
                 $this->getStream()->write('null');
             }
         } catch (StreamException $e) {
-            $msg = "An error occurred while writing the scalar value '${scalar}'.";
+            $msg = "An error occurred while writing the scalar value '{$scalar}'.";
             throw new StreamAccessException($msg, $this, 0, $e);
         }
     }
@@ -466,7 +466,7 @@ class PhpStreamAccess extends AbstractStreamAccess
                 $this->writeScalar($value);
             }
         } catch (StreamException $e) {
-            $msg = "An error occurred while writing an argument with value '${value}'.";
+            $msg = "An error occurred while writing an argument with value '{$value}'.";
             throw new StreamAccessException($msg, $this, 0, $e);
         }
     }

--- a/src/qtism/data/storage/php/marshalling/PhpMarshallingContext.php
+++ b/src/qtism/data/storage/php/marshalling/PhpMarshallingContext.php
@@ -224,7 +224,7 @@ class PhpMarshallingContext
     {
         $quantity = (int)$quantity;
         if ($quantity < 1) {
-            $msg = "The 'quantity' argument must be >= 1, '${quantity}' given.";
+            $msg = "The 'quantity' argument must be >= 1, '{$quantity}' given.";
             throw new InvalidArgumentException($msg);
         }
 
@@ -232,7 +232,7 @@ class PhpMarshallingContext
         $stackCount = count($stack);
 
         if ($stackCount < $quantity) {
-            $msg = "The number of elements in the variable names stack (${stackCount}) is lower than the requested quantity (${quantity}).";
+            $msg = "The number of elements in the variable names stack ({$stackCount}) is lower than the requested quantity ({$quantity}).";
             throw new RuntimeException($msg);
         }
 

--- a/src/qtism/data/storage/php/marshalling/PhpQtiDatatypeMarshaller.php
+++ b/src/qtism/data/storage/php/marshalling/PhpQtiDatatypeMarshaller.php
@@ -76,7 +76,7 @@ class PhpQtiDatatypeMarshaller extends PhpMarshaller
         }
 
         $className = get_class($toMarshall);
-        $msg = "Cannot deal with QtiDatatype '${className}'.";
+        $msg = "Cannot deal with QtiDatatype '{$className}'.";
         throw new PhpMarshallingException($msg, PhpMarshallingException::RUNTIME);
     }
 

--- a/src/qtism/data/storage/php/marshalling/PhpScalarMarshaller.php
+++ b/src/qtism/data/storage/php/marshalling/PhpScalarMarshaller.php
@@ -77,7 +77,7 @@ class PhpScalarMarshaller extends PhpMarshaller
 
             $ctx->pushOnVariableStack($varName);
         } catch (StreamAccessException $e) {
-            $msg = "An error occurred while marshalling the scalar value '${scalar}'.";
+            $msg = "An error occurred while marshalling the scalar value '{$scalar}'.";
             throw new PhpMarshallingException($msg, PhpMarshallingException::STREAM, $e);
         }
     }

--- a/src/qtism/data/storage/php/marshalling/Utils.php
+++ b/src/qtism/data/storage/php/marshalling/Utils.php
@@ -68,7 +68,7 @@ class Utils
             $object = new ReflectionObject($value);
             $className = mb_strtolower($object->getShortName(), 'UTF-8');
 
-            return "${className}_${occurence}";
+            return "{$className}_{$occurence}";
         } elseif (is_scalar($value)) {
             return gettype($value) . '_' . $occurence;
         } elseif (is_array($value)) {

--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -312,7 +312,7 @@ class Utils
             return $attr;
         }
 
-        throw new InvalidArgumentException("Unknown datatype '${datatype}'.");
+        throw new InvalidArgumentException("Unknown datatype '{$datatype}'.");
     }
 
     /**
@@ -483,7 +483,7 @@ class Utils
             $formattedErrors = self::formatLibXmlErrors($libXmlErrors);
             if ($formattedErrors !== '') {
                 throw new XmlStorageException(
-                    "${exceptionMessage}:\n${formattedErrors}",
+                    "{$exceptionMessage}:\n{$formattedErrors}",
                     $exceptionCode,
                     null,
                     new LibXmlErrorCollection($libXmlErrors)

--- a/src/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/src/qtism/data/storage/xml/XmlCompactDocument.php
@@ -437,7 +437,7 @@ class XmlCompactDocument extends XmlDocument
                 }
 
                 $parentId = $parent->getIdentifier();
-                $href = "./testFeedback_TF_${parentId}_${occurence}.xml";
+                $href = "./testFeedback_TF_{$parentId}_{$occurence}.xml";
 
                 // Generate the document.
                 $doc = new XmlDocument();

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -242,7 +242,7 @@ class XmlDocument extends QtiDocument
             return $factory->createMarshaller($element)->unmarshall($element);
         } catch (UnmarshallingException $e) {
             $line = $e->getDOMElement()->getLineNo();
-            $msg = "An error occurred while processing QTI-XML at line ${line}.";
+            $msg = "An error occurred while processing QTI-XML at line {$line}.";
             throw new XmlStorageException($msg, XmlStorageException::READ, $e);
         } catch (MarshallerNotFoundException $e) {
             throw XmlStorageException::unsupportedComponentInVersion($e, $this->getVersion());
@@ -420,7 +420,7 @@ class XmlDocument extends QtiDocument
             return $this->getFilesystem()->read($url);
         } catch (FilesystemException $e) {
             throw new XmlStorageException(
-                "Cannot load QTI file at path '${url}'. It does not exist or is not readable.",
+                "Cannot load QTI file at path '{$url}'. It does not exist or is not readable.",
                 XmlStorageException::RESOLUTION,
                 $e
             );
@@ -439,7 +439,7 @@ class XmlDocument extends QtiDocument
             return $this->getFilesystem()->write($url, $content);
         } catch (Exception $e) {
             throw new XmlStorageException(
-                "An error occurred while saving QTI-XML file at '${url}'. Maybe the save location is not reachable?",
+                "An error occurred while saving QTI-XML file at '{$url}'. Maybe the save location is not reachable?",
                 XmlStorageException::WRITE
             );
         }

--- a/src/qtism/data/storage/xml/XmlStorageException.php
+++ b/src/qtism/data/storage/xml/XmlStorageException.php
@@ -96,7 +96,7 @@ class XmlStorageException extends StorageException
         MarshallerNotFoundException $e,
         string $version
     ): self {
-        $msg = "'" . $e->getQtiClassName() . "' components are not supported in QTI version '${version}'.";
+        $msg = "'" . $e->getQtiClassName() . "' components are not supported in QTI version '{$version}'.";
         return new self($msg, self::VERSION, $e);
     }
 

--- a/src/qtism/data/storage/xml/filesystem/FlysystemV1Filesystem.php
+++ b/src/qtism/data/storage/xml/filesystem/FlysystemV1Filesystem.php
@@ -26,7 +26,7 @@ class FlysystemV1Filesystem implements FilesystemInterface
         try {
             return $this->filesystem->put($url, $content);
         } catch (Exception $e) {
-            throw new FilesystemException("Could not write to file '${url}'", $e->getCode(), $e);
+            throw new FilesystemException("Could not write to file '{$url}'", $e->getCode(), $e);
         }
     }
 
@@ -35,7 +35,7 @@ class FlysystemV1Filesystem implements FilesystemInterface
         try {
             return $this->filesystem->read($url);
         } catch (FileNotFoundException $e) {
-            throw new FilesystemException("Could not read file '${url}'", $e->getCode(), $e);
+            throw new FilesystemException("Could not read file '{$url}'", $e->getCode(), $e);
         }
     }
 }

--- a/src/qtism/data/storage/xml/filesystem/FlysystemV2Filesystem.php
+++ b/src/qtism/data/storage/xml/filesystem/FlysystemV2Filesystem.php
@@ -39,7 +39,7 @@ class FlysystemV2Filesystem implements FilesystemInterface
             $this->filesystem->write($url, $content);
             return true;
         } catch (Exception $e) {
-            throw new FilesystemException("Could not write to file '${url}'", $e->getCode(), $e);
+            throw new FilesystemException("Could not write to file '{$url}'", $e->getCode(), $e);
         }
     }
 
@@ -48,7 +48,7 @@ class FlysystemV2Filesystem implements FilesystemInterface
         try {
             return $this->filesystem->read($url);
         } catch (FlysystemException $e) {
-            throw new FilesystemException("Could not read file '${url}'", $e->getCode(), $e);
+            throw new FilesystemException("Could not read file '{$url}'", $e->getCode(), $e);
         }
     }
 }

--- a/src/qtism/data/storage/xml/marshalling/AreaMapEntryMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/AreaMapEntryMarshaller.php
@@ -77,7 +77,7 @@ class AreaMapEntryMarshaller extends Marshaller
                         }
                     } catch (Exception $e) {
                         if (!$e instanceof UnmarshallingException) {
-                            $msg = "The attribute 'coords' with value '${coords}' has an invalid value.";
+                            $msg = "The attribute 'coords' with value '{$coords}' has an invalid value.";
                             throw new UnmarshallingException($msg, $element, $e);
                         } else {
                             throw $e;
@@ -88,7 +88,7 @@ class AreaMapEntryMarshaller extends Marshaller
                     throw new UnmarshallingException($msg, $element);
                 }
             } else {
-                $msg = "The 'shape' attribute value '${shape}' is not a valid value to represent QTI shapes.";
+                $msg = "The 'shape' attribute value '{$shape}' is not a valid value to represent QTI shapes.";
                 throw new UnmarshallingException($msg, $element);
             }
         } else {

--- a/src/qtism/data/storage/xml/marshalling/FeedbackElementMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/FeedbackElementMarshaller.php
@@ -55,7 +55,7 @@ class FeedbackElementMarshaller extends ContentMarshaller
                     try {
                         $component->setShowHide(ShowHide::getConstantByName($showHide));
                     } catch (InvalidArgumentException $e) {
-                        $msg = "'${showHide}' is not a valid value for the 'showHide' attribute of element '" . $element->localName . "'.";
+                        $msg = "'{$showHide}' is not a valid value for the 'showHide' attribute of element '" . $element->localName . "'.";
                         throw new UnmarshallingException($msg, $element, $e);
                     }
 
@@ -65,11 +65,11 @@ class FeedbackElementMarshaller extends ContentMarshaller
                     foreach ($children as $child) {
                         $qtiClassName = $child->getQtiClassName();
                         if ($inline === false && !$child instanceof Flow) {
-                            $msg = "A '${qtiClassName}' cannot be contained by a 'feedbackBlock'.";
+                            $msg = "A '{$qtiClassName}' cannot be contained by a 'feedbackBlock'.";
                             throw new UnmarshallingException($msg, $element);
                         }
                         if ($inline === false && in_array($child->getQtiClassName(), $blockExclusion)) {
-                            $msg = "A '${qtiClassName}' cannot be contained by a 'feedbackBlock'.";
+                            $msg = "A '{$qtiClassName}' cannot be contained by a 'feedbackBlock'.";
                             throw new UnmarshallingException($msg, $element);
                         }
 

--- a/src/qtism/data/storage/xml/marshalling/HottextInteractionMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/HottextInteractionMarshaller.php
@@ -58,7 +58,7 @@ class HottextInteractionMarshaller extends ContentMarshaller
             try {
                 $component = new $fqClass($responseIdentifier, $content);
             } catch (InvalidArgumentException $e) {
-                $msg = "The value '${responseIdentifier}' for the attribute 'responseIdentifier' for element 'hottextInteraction' is not a valid QTI identifier.";
+                $msg = "The value '{$responseIdentifier}' for the attribute 'responseIdentifier' for element 'hottextInteraction' is not a valid QTI identifier.";
                 throw new UnmarshallingException($msg, $element, $e);
             }
 

--- a/src/qtism/data/storage/xml/marshalling/InlineChoiceMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/InlineChoiceMarshaller.php
@@ -52,7 +52,7 @@ class InlineChoiceMarshaller extends ContentMarshaller
             try {
                 $component = new $fqClass($identifier);
             } catch (InvalidArgumentException $e) {
-                $msg = "'${identifier}' is not a valid identifier for an 'inlineChoice' element.";
+                $msg = "'{$identifier}' is not a valid identifier for an 'inlineChoice' element.";
                 throw new UnmarshallingException($msg, $element, $e);
             }
 

--- a/src/qtism/data/storage/xml/marshalling/InterpolationTableMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/InterpolationTableMarshaller.php
@@ -136,7 +136,7 @@ class InterpolationTableMarshaller extends Marshaller
                 try {
                     $object->setDefaultValue(Utils::stringToDatatype($defaultValue, $this->getBaseType()));
                 } catch (UnexpectedValueException $e) {
-                    $msg = "Unable to transform '${defaultValue}' into float.";
+                    $msg = "Unable to transform '{$defaultValue}' into float.";
                     throw new UnmarshallingException($msg, $element, $e);
                 }
             }

--- a/src/qtism/data/storage/xml/marshalling/MapEntryMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/MapEntryMarshaller.php
@@ -132,7 +132,7 @@ class MapEntryMarshaller extends Marshaller
                 throw new UnmarshallingException($msg, $element);
             }
         } catch (UnexpectedValueException $e) {
-            $msg = "The value '${mapKey}' of the 'mapKey' attribute could not be converted to a '" . BaseType::getNameByConstant($this->getBaseType()) . "' value.";
+            $msg = "The value '{$mapKey}' of the 'mapKey' attribute could not be converted to a '" . BaseType::getNameByConstant($this->getBaseType()) . "' value.";
             throw new UnmarshallingException($msg, $element, $e);
         }
     }

--- a/src/qtism/data/storage/xml/marshalling/Marshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/Marshaller.php
@@ -321,7 +321,7 @@ abstract class Marshaller
     public function __call($method, $args)
     {
         if (count($args) < 1) {
-            throw new RuntimeException("Method '${method}' only accepts a single argument.");
+            throw new RuntimeException("Method '{$method}' only accepts a single argument.");
         }
 
         switch ($method) {
@@ -335,7 +335,7 @@ abstract class Marshaller
                 return $this->unmarshall(...$args);
 
             default:
-                throw new RuntimeException("Unknown method Marshaller::'${method}'.");
+                throw new RuntimeException("Unknown method Marshaller::'{$method}'.");
         }
     }
 
@@ -343,7 +343,7 @@ abstract class Marshaller
     {
         if (!$component instanceof QtiComponent || ($this->getExpectedQtiClassName() !== '' && $component->getQtiClassName() !== $this->getExpectedQtiClassName())) {
             $componentName = $this->getComponentName($component);
-            throw new RuntimeException("No marshaller implementation found while marshalling component '${componentName}'.");
+            throw new RuntimeException("No marshaller implementation found while marshalling component '{$componentName}'.");
         }
     }
 
@@ -351,7 +351,7 @@ abstract class Marshaller
     {
         if (!$element instanceof DOMElement || ($this->getExpectedQtiClassName() !== '' && $element->localName !== $this->getExpectedQtiClassName())) {
             $nodeName = $this->getElementName($element);
-            throw new RuntimeException("No Marshaller implementation found while unmarshalling element '${nodeName}'.");
+            throw new RuntimeException("No Marshaller implementation found while unmarshalling element '{$nodeName}'.");
         }
     }
 

--- a/src/qtism/data/storage/xml/marshalling/MarshallerFactory.php
+++ b/src/qtism/data/storage/xml/marshalling/MarshallerFactory.php
@@ -405,11 +405,11 @@ abstract class MarshallerFactory
                     $class = new ReflectionClass($this->getMappingEntry($qtiClassName));
                 } else {
                     // No qtiClassName/mapping entry found.
-                    $msg = "No mapping entry found for QTI class name '${qtiClassName}'.";
+                    $msg = "No mapping entry found for QTI class name '{$qtiClassName}'.";
                     throw new MarshallerNotFoundException($msg, $qtiClassName);
                 }
             } catch (ReflectionException $e) {
-                $msg = "No marshaller implementation could be found for component '${qtiClassName}'.";
+                $msg = "No marshaller implementation could be found for component '{$qtiClassName}'.";
                 throw new MarshallerNotFoundException($msg, $qtiClassName, $e);
             }
 

--- a/src/qtism/data/storage/xml/marshalling/MatchTableMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/MatchTableMarshaller.php
@@ -136,7 +136,7 @@ class MatchTableMarshaller extends Marshaller
                     $object->setDefaultValue($defaultValue);
                 } catch (InvalidArgumentException $e) {
                     $strType = BaseType::getNameByConstant($this->getBaseType());
-                    $msg = "Unable to transform '$defaultValue' in a ${strType}.";
+                    $msg = "Unable to transform '$defaultValue' in a {$strType}.";
                     throw new UnmarshallingException($msg, $element, $e);
                 }
             }

--- a/src/qtism/data/storage/xml/marshalling/MathConstantMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/MathConstantMarshaller.php
@@ -61,7 +61,7 @@ class MathConstantMarshaller extends Marshaller
             if (($cst = MathEnumeration::getConstantByName($name)) !== false) {
                 return new MathConstant($cst);
             } else {
-                $msg = "'${name}' is not a valid value for the attribute 'name' from element '" . $element->localName . "'.";
+                $msg = "'{$name}' is not a valid value for the attribute 'name' from element '" . $element->localName . "'.";
                 throw new UnmarshallingException($msg, $element);
             }
         } else {

--- a/src/qtism/data/storage/xml/marshalling/ModalFeedbackMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ModalFeedbackMarshaller.php
@@ -53,7 +53,7 @@ class ModalFeedbackMarshaller extends ContentMarshaller
                     try {
                         $component->setShowHide(ShowHide::getConstantByName($showHide));
                     } catch (InvalidArgumentException $e) {
-                        $msg = "'${showHide}' is not a valid value for the 'showHide' attribute of element 'modalFeedback'.";
+                        $msg = "'{$showHide}' is not a valid value for the 'showHide' attribute of element 'modalFeedback'.";
                         throw new UnmarshallingException($msg, $element, $e);
                     }
 

--- a/src/qtism/data/storage/xml/marshalling/PositionObjectInteractionMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/PositionObjectInteractionMarshaller.php
@@ -110,7 +110,7 @@ class PositionObjectInteractionMarshaller extends Marshaller
                             throw new UnmarshallingException($msg, $element);
                         }
                     } else {
-                        $msg = "The value of the 'centePoint' attribute of a 'positionObjectInteraction' element must be composed of exactly 2 integer values, ${pointsCount} given.";
+                        $msg = "The value of the 'centePoint' attribute of a 'positionObjectInteraction' element must be composed of exactly 2 integer values, {$pointsCount} given.";
                         throw new UnmarshallingException($msg, $element);
                     }
                 }

--- a/src/qtism/data/storage/xml/marshalling/PromptMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/PromptMarshaller.php
@@ -70,7 +70,7 @@ class PromptMarshaller extends ContentMarshaller
 
         if ($error === true) {
             $qtiClass = $c->getQtiClassName();
-            $msg = "A 'prompt' cannot contain '${qtiClass}' elements.";
+            $msg = "A 'prompt' cannot contain '{$qtiClass}' elements.";
             throw new UnmarshallingException($msg, $element);
         }
 

--- a/src/qtism/data/storage/xml/marshalling/ShufflingMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/ShufflingMarshaller.php
@@ -71,7 +71,7 @@ class ShufflingMarshaller extends Marshaller
                 $msg = "A 'shuffling' element must contain at least 1 'shufflingGroup' element. None given.";
                 throw new UnmarshallingException($msg, $element);
             } elseif ($c > 2) {
-                $msg = "A 'shuffling' element must contain at most 2 'shufflingGroup' elements. ${c} given.";
+                $msg = "A 'shuffling' element must contain at most 2 'shufflingGroup' elements. {$c} given.";
                 throw new UnmarshallingException($msg, $element);
             } else {
                 $shufflingGroups = new ShufflingGroupCollection();

--- a/src/qtism/data/storage/xml/marshalling/TemplateElementMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/TemplateElementMarshaller.php
@@ -55,7 +55,7 @@ class TemplateElementMarshaller extends ContentMarshaller
                     try {
                         $component->setShowHide(ShowHide::getConstantByName($showHide));
                     } catch (InvalidArgumentException $e) {
-                        $msg = "'${showHide}' is not a valid value for the 'showHide' attribute of element '" . $element->localName . "'.";
+                        $msg = "'{$showHide}' is not a valid value for the 'showHide' attribute of element '" . $element->localName . "'.";
                         throw new UnmarshallingException($msg, $element, $e);
                     }
 
@@ -73,7 +73,7 @@ class TemplateElementMarshaller extends ContentMarshaller
                         $component->setContent($content);
                     } catch (InvalidArgumentException $e) {
                         $mustContain = ($element->localName === 'feedbackInline') ? 'inline' : 'block';
-                        $msg = "The content of the '" . $element->localName . "' is invalid. It must only contain '${mustContain}' elements.";
+                        $msg = "The content of the '" . $element->localName . "' is invalid. It must only contain '{$mustContain}' elements.";
                         throw new UnmarshallingException($msg, $element, $e);
                     }
 

--- a/src/qtism/data/storage/xml/marshalling/TextInteractionMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/TextInteractionMarshaller.php
@@ -120,7 +120,7 @@ class TextInteractionMarshaller extends Marshaller
                 $class = 'qtism\\data\\content\\interactions\\' . $name;
                 $component = new $class($responseIdentifier);
             } catch (InvalidArgumentException $e) {
-                $msg = "The value '${responseIdentifier}' of the 'responseIdentifier' attribute of the '" . $element->localName . "' element is not a valid identifier.";
+                $msg = "The value '{$responseIdentifier}' of the 'responseIdentifier' attribute of the '" . $element->localName . "' element is not a valid identifier.";
                 throw new UnmarshallingException($msg, $element, $e);
             }
 

--- a/src/qtism/data/storage/xml/marshalling/TimeLimitsMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/TimeLimitsMarshaller.php
@@ -68,11 +68,11 @@ class TimeLimitsMarshaller extends Marshaller
         $object = new TimeLimits();
 
         if (($value = $this->getDOMElementAttributeAs($element, 'minTime', 'string')) !== null) {
-            $object->setMinTime(StorageUtils::stringToDatatype("PT${value}S", BaseType::DURATION));
+            $object->setMinTime(StorageUtils::stringToDatatype("PT{$value}S", BaseType::DURATION));
         }
 
         if (($value = $this->getDOMElementAttributeAs($element, 'maxTime', 'string')) !== null) {
-            $object->setMaxTime(StorageUtils::stringToDatatype("PT${value}S", BaseType::DURATION));
+            $object->setMaxTime(StorageUtils::stringToDatatype("PT{$value}S", BaseType::DURATION));
         }
 
         if (($value = $this->getDOMElementAttributeAs($element, 'allowLateSubmission', 'boolean')) !== null) {

--- a/src/qtism/runtime/common/Container.php
+++ b/src/qtism/runtime/common/Container.php
@@ -229,7 +229,7 @@ class Container extends AbstractCollection implements Comparable
             if ($d === null) {
                 $strings[] = 'NULL';
             } elseif ($d instanceof QtiString) {
-                $strings[] = "'${d}'";
+                $strings[] = "'{$d}'";
             } elseif ($d instanceof QtiBoolean) {
                 // PHP boolean primitive type.
                 $strings[] = ($d->getValue() === true) ? 'true' : 'false';

--- a/src/qtism/runtime/common/State.php
+++ b/src/qtism/runtime/common/State.php
@@ -114,7 +114,7 @@ class State extends AbstractCollection
         if (isset($data[$variableIdentifier])) {
             unset($data[$variableIdentifier]);
         } else {
-            $msg = "No Variable object with identifier '${variableIdentifier}' found in the current State object.";
+            $msg = "No Variable object with identifier '{$variableIdentifier}' found in the current State object.";
             throw new OutOfBoundsException($msg);
         }
     }
@@ -131,7 +131,7 @@ class State extends AbstractCollection
             if (isset($placeholder[$offset])) {
                 $placeholder[$offset]->setValue($value);
             } else {
-                $msg = "No Variable object with identifier '${offset}' found in the current State object.";
+                $msg = "No Variable object with identifier '{$offset}' found in the current State object.";
                 throw new OutOfBoundsException($msg);
             }
         } else {

--- a/src/qtism/runtime/common/Utils.php
+++ b/src/qtism/runtime/common/Utils.php
@@ -130,7 +130,7 @@ class Utils
     {
         $givenValue = (is_object($value)) ? get_class($value) : gettype($value) . ':' . $value;
         $acceptedTypes = BaseType::getNameByConstant($baseType);
-        $msg = "The value '${givenValue}' is not compliant with the '${acceptedTypes}' baseType.";
+        $msg = "The value '{$givenValue}' is not compliant with the '{$acceptedTypes}' baseType.";
         throw new InvalidArgumentException($msg);
     }
 

--- a/src/qtism/runtime/common/VariableCollection.php
+++ b/src/qtism/runtime/common/VariableCollection.php
@@ -40,7 +40,7 @@ class VariableCollection extends AbstractCollection
     protected function checkType($value): void
     {
         if (!$value instanceof Variable) {
-            $msg = "The VariableCollection class only accept Variable objects, '${value}' given.";
+            $msg = "The VariableCollection class only accept Variable objects, '{$value}' given.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/runtime/common/VariableIdentifier.php
+++ b/src/qtism/runtime/common/VariableIdentifier.php
@@ -122,7 +122,7 @@ class VariableIdentifier
         if (Utils::isValidVariableIdentifier($identifier)) {
             $this->identifier = $identifier;
         } else {
-            $msg = "The identifier '${identifier}' is not a valid QTI Variable Name Identifier.";
+            $msg = "The identifier '{$identifier}' is not a valid QTI Variable Name Identifier.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/runtime/expressions/CorrectProcessor.php
+++ b/src/qtism/runtime/expressions/CorrectProcessor.php
@@ -66,7 +66,7 @@ class CorrectProcessor extends ExpressionProcessor
         } elseif ($var instanceof ResponseVariable) {
             return $var->getCorrectResponse();
         } else {
-            $msg = "The variable with identifier '${identifier}' is not a ResponseVariable object.";
+            $msg = "The variable with identifier '{$identifier}' is not a ResponseVariable object.";
             throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::WRONG_VARIABLE_TYPE);
         }
     }

--- a/src/qtism/runtime/expressions/ExpressionEngine.php
+++ b/src/qtism/runtime/expressions/ExpressionEngine.php
@@ -234,7 +234,7 @@ class ExpressionEngine extends AbstractEngine
 
                 // trace the processing of the operator.
                 $qtiName = $expression->getQtiClassName();
-                $trace = "Operator '${qtiName}' processed.";
+                $trace = "Operator '{$qtiName}' processed.";
                 $this->traceOperator($processor, $result);
 
                 if ($expression !== $this->getComponent()) {
@@ -250,7 +250,7 @@ class ExpressionEngine extends AbstractEngine
 
                 // trace the processing of the expression.
                 $qtiName = $expression->getQtiClassName();
-                $trace = "Expression '${qtiName}' processed.";
+                $trace = "Expression '{$qtiName}' processed.";
                 $this->traceExpression($processor, $result);
             }
         }
@@ -267,7 +267,7 @@ class ExpressionEngine extends AbstractEngine
     protected function traceExpression(ExpressionProcessor $processor, $result): void
     {
         $qtiClassName = $processor->getExpression()->getQtiClassName();
-        $this->trace("${qtiClassName} [${result}]");
+        $this->trace("{$qtiClassName} [{$result}]");
     }
 
     /**
@@ -285,7 +285,7 @@ class ExpressionEngine extends AbstractEngine
         }
 
         $qtiClassName = $processor->getExpression()->getQtiClassName();
-        $msg = "${qtiClassName}(" . implode(', ', $stringOperands) . ") [${result}]";
+        $msg = "{$qtiClassName}(" . implode(', ', $stringOperands) . ") [{$result}]";
         $this->trace($msg);
     }
 }

--- a/src/qtism/runtime/expressions/ExpressionProcessorFactory.php
+++ b/src/qtism/runtime/expressions/ExpressionProcessorFactory.php
@@ -61,7 +61,7 @@ class ExpressionProcessorFactory implements ProcessorFactory
             return new $className($expression);
         }
 
-        $msg = "The QTI expression class '${qtiClassName}' has no dedicated ExpressionProcessor class.";
+        $msg = "The QTI expression class '{$qtiClassName}' has no dedicated ExpressionProcessor class.";
         throw new RuntimeException($msg);
     }
 }

--- a/src/qtism/runtime/expressions/MapResponsePointProcessor.php
+++ b/src/qtism/runtime/expressions/MapResponsePointProcessor.php
@@ -117,15 +117,15 @@ class MapResponsePointProcessor extends ExpressionProcessor
                     throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::WRONG_VARIABLE_CARDINALITY);
                 } else {
                     $strBaseType = BaseType::getNameByConstant($var->getBaseType());
-                    $msg = "The MapResponsePoint expression applies only on variables with baseType 'point', baseType '${strBaseType}' given.";
+                    $msg = "The MapResponsePoint expression applies only on variables with baseType 'point', baseType '{$strBaseType}' given.";
                     throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::WRONG_VARIABLE_BASETYPE);
                 }
             } else {
-                $msg = "The variable with identifier '${identifier}' is not a ResponseVariable.";
+                $msg = "The variable with identifier '{$identifier}' is not a ResponseVariable.";
                 throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::WRONG_VARIABLE_TYPE);
             }
         } else {
-            $msg = "No variable with identifier '${identifier}' could be found in the current State object.";
+            $msg = "No variable with identifier '{$identifier}' could be found in the current State object.";
             throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::NONEXISTENT_VARIABLE);
         }
     }

--- a/src/qtism/runtime/expressions/MapResponseProcessor.php
+++ b/src/qtism/runtime/expressions/MapResponseProcessor.php
@@ -161,7 +161,7 @@ class MapResponseProcessor extends ExpressionProcessor
                 throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::WRONG_VARIABLE_TYPE);
             }
         } else {
-            $msg = "No variable with identifier '${identifier}' could be found while processing MapResponse.";
+            $msg = "No variable with identifier '{$identifier}' could be found while processing MapResponse.";
             throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::NONEXISTENT_VARIABLE);
         }
     }

--- a/src/qtism/runtime/expressions/OutcomeMaximumProcessor.php
+++ b/src/qtism/runtime/expressions/OutcomeMaximumProcessor.php
@@ -76,7 +76,7 @@ class OutcomeMaximumProcessor extends ItemSubsetProcessor
                 if (isset($itemSession[$id]) && $itemSession->getVariable($id) instanceof OutcomeVariable) {
                     $var = $itemSession->getVariable($id);
                     $itemRefIdentifier = $itemSession->getAssessmentItem()->getIdentifier();
-                    $weight = (empty($weightIdentifier)) ? false : $testSession->getWeight("${itemRefIdentifier}.${weightIdentifier}");
+                    $weight = (empty($weightIdentifier)) ? false : $testSession->getWeight("{$itemRefIdentifier}.{$weightIdentifier}");
 
                     // Does this OutcomeVariable contain a value for normalMaximum?
                     if (($normalMaximum = $var->getNormalMaximum()) !== false) {

--- a/src/qtism/runtime/expressions/OutcomeMinimumProcessor.php
+++ b/src/qtism/runtime/expressions/OutcomeMinimumProcessor.php
@@ -71,7 +71,7 @@ class OutcomeMinimumProcessor extends ItemSubsetProcessor
                 if (isset($itemSession[$id]) && $itemSession->getVariable($id) instanceof OutcomeVariable) {
                     $var = $itemSession->getVariable($id);
                     $itemRefIdentifier = $itemSession->getAssessmentItem()->getIdentifier();
-                    $weight = (empty($weightIdentifier)) ? false : $testSession->getWeight("${itemRefIdentifier}.${weightIdentifier}");
+                    $weight = (empty($weightIdentifier)) ? false : $testSession->getWeight("{$itemRefIdentifier}.{$weightIdentifier}");
 
                     // Does this OutcomeVariable contain a value for normalMaximum?
                     if (($normalMinimum = $var->getNormalMinimum()) !== false) {

--- a/src/qtism/runtime/expressions/RandomFloatProcessor.php
+++ b/src/qtism/runtime/expressions/RandomFloatProcessor.php
@@ -58,7 +58,7 @@ class RandomFloatProcessor extends ExpressionProcessor
             if ($min <= $max) {
                 return new QtiFloat(($min + lcg_value() * (abs($max - $min))));
             } else {
-                $msg = "'min':'${min}' is greater than 'max':'${max}'.";
+                $msg = "'min':'{$min}' is greater than 'max':'{$max}'.";
                 throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::LOGIC_ERROR);
             }
         } else {

--- a/src/qtism/runtime/expressions/RandomIntegerProcessor.php
+++ b/src/qtism/runtime/expressions/RandomIntegerProcessor.php
@@ -60,7 +60,7 @@ class RandomIntegerProcessor extends ExpressionProcessor
 
         if (is_int($min) && is_int($max) && is_int($step)) {
             if ($min > $max) {
-                $msg = "'min':'${min}' is greater than 'max':'${max}'.";
+                $msg = "'min':'{$min}' is greater than 'max':'{$max}'.";
                 throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::LOGIC_ERROR);
             }
 

--- a/src/qtism/runtime/expressions/TestVariablesProcessor.php
+++ b/src/qtism/runtime/expressions/TestVariablesProcessor.php
@@ -104,7 +104,7 @@ class TestVariablesProcessor extends ItemSubsetProcessor
 
                         if ($identifier === $id) {
                             $var = $itemSession->getVariable($id);
-                            $weight = (empty($weightIdentifier)) ? false : $testSession->getWeight("${itemRefIdentifier}.${weightIdentifier}");
+                            $weight = (empty($weightIdentifier)) ? false : $testSession->getWeight("{$itemRefIdentifier}.{$weightIdentifier}");
 
                             // Single cardinality? Does it match the baseType?
                             if ($var->getCardinality() === Cardinality::SINGLE && in_array($var->getBaseType(), $baseTypes) && $var->getValue() !== null) {

--- a/src/qtism/runtime/expressions/Utils.php
+++ b/src/qtism/runtime/expressions/Utils.php
@@ -61,6 +61,6 @@ class Utils
     {
         $shortClassName = Reflection::shortClassName($expression);
 
-        return "[${shortClassName}] ${message}";
+        return "[{$shortClassName}] {$message}";
     }
 }

--- a/src/qtism/runtime/expressions/VariableProcessor.php
+++ b/src/qtism/runtime/expressions/VariableProcessor.php
@@ -134,7 +134,7 @@ class VariableProcessor extends ExpressionProcessor
                 }
             } catch (InvalidArgumentException $e) {
                 // Invalid $variableIdentifier.
-                $msg = "Invalid identifier '${variableIdentifier}' given for variable identifier.";
+                $msg = "Invalid identifier '{$variableIdentifier}' given for variable identifier.";
                 throw new ExpressionProcessingException($msg, $this, ExpressionProcessingException::NONEXISTENT_VARIABLE, $e);
             }
         } else {

--- a/src/qtism/runtime/expressions/operators/AnyNProcessor.php
+++ b/src/qtism/runtime/expressions/operators/AnyNProcessor.php
@@ -71,10 +71,10 @@ class AnyNProcessor extends OperatorProcessor
             $varValue = $state[$varName];
 
             if ($varValue === null) {
-                $msg = "The variable with name '${varName}' could not be resolved or is null.";
+                $msg = "The variable with name '{$varName}' could not be resolved or is null.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NONEXISTENT_VARIABLE);
             } elseif (!$varValue instanceof QtiInteger) {
-                $msg = "The variable with name '${varName}' is not an integer.";
+                $msg = "The variable with name '{$varName}' is not an integer.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::WRONG_BASETYPE);
             } else {
                 $min = $varValue->getValue();
@@ -88,10 +88,10 @@ class AnyNProcessor extends OperatorProcessor
             $varValue = $state[$varName];
 
             if ($varValue === null) {
-                $msg = "The variable with name '${varName}' could not be resolved or is null.";
+                $msg = "The variable with name '{$varName}' could not be resolved or is null.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NONEXISTENT_VARIABLE);
             } elseif (!$varValue instanceof QtiInteger) {
-                $msg = "The variable with name '${varName}' is not an integer.";
+                $msg = "The variable with name '{$varName}' is not an integer.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::WRONG_VARIABLE_BASETYPE);
             } else {
                 $max = $varValue->getValue();

--- a/src/qtism/runtime/expressions/operators/EqualProcessor.php
+++ b/src/qtism/runtime/expressions/operators/EqualProcessor.php
@@ -104,10 +104,10 @@ class EqualProcessor extends OperatorProcessor
                 $varValue = $state[$tolerance0Name];
 
                 if ($varValue === null) {
-                    $msg = "The variable with name '${tolerance0Name}' could not be resolved.";
+                    $msg = "The variable with name '{$tolerance0Name}' could not be resolved.";
                     throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NONEXISTENT_VARIABLE);
                 } elseif (!$varValue instanceof QtiFloat) {
-                    $msg = "The variable with name '${tolerance0Name}' is not a float.";
+                    $msg = "The variable with name '{$tolerance0Name}' is not a float.";
                     throw new OperatorProcessingException($msg, $this, OperatorProcessingException::WRONG_VARIABLE_BASETYPE);
                 }
 

--- a/src/qtism/runtime/expressions/operators/EqualRoundedProcessor.php
+++ b/src/qtism/runtime/expressions/operators/EqualRoundedProcessor.php
@@ -92,10 +92,10 @@ class EqualRoundedProcessor extends OperatorProcessor
             $varValue = $state[$varName];
 
             if ($varValue === null) {
-                $msg = "The variable with name '${varName}' could not be resolved.";
+                $msg = "The variable with name '{$varName}' could not be resolved.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NONEXISTENT_VARIABLE);
             } elseif (!$varValue instanceof QtiInteger) {
-                $msg = "The variable with name '${varName}' is not an integer.";
+                $msg = "The variable with name '{$varName}' is not an integer.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::WRONG_VARIABLE_BASETYPE);
             }
 
@@ -113,7 +113,7 @@ class EqualRoundedProcessor extends OperatorProcessor
             try {
                 $rounded[] = $roundToProcessor->process();
             } catch (OperatorProcessingException $e) {
-                $msg = "An error occurred while rounding '${operand}'.";
+                $msg = "An error occurred while rounding '{$operand}'.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::LOGIC_ERROR, $e);
             }
         }

--- a/src/qtism/runtime/expressions/operators/IndexProcessor.php
+++ b/src/qtism/runtime/expressions/operators/IndexProcessor.php
@@ -70,17 +70,17 @@ class IndexProcessor extends OperatorProcessor
                 if ($index instanceof QtiInteger) {
                     $n = $index->getValue();
                 } else {
-                    $msg = "The value '${index}' is not an integer. Ordered containers can be only accessed by integers.";
+                    $msg = "The value '{$index}' is not an integer. Ordered containers can be only accessed by integers.";
                     throw new OperatorProcessingException($msg, $this, OperatorProcessingException::WRONG_VARIABLE_BASETYPE);
                 }
             } else {
-                $msg = "Unknown variable reference '${n}'.";
+                $msg = "Unknown variable reference '{$n}'.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NONEXISTENT_VARIABLE);
             }
         }
 
         if ($n < 1) {
-            $msg = "The value of 'n' must be a non-zero postive integer, '${n}' given.";
+            $msg = "The value of 'n' must be a non-zero postive integer, '{$n}' given.";
             throw new OperatorProcessingException($msg, $this, OperatorProcessingException::LOGIC_ERROR);
         }
 

--- a/src/qtism/runtime/expressions/operators/OperatorProcessor.php
+++ b/src/qtism/runtime/expressions/operators/OperatorProcessor.php
@@ -66,8 +66,8 @@ abstract class OperatorProcessor extends ExpressionProcessor
         $given = count($operands);
 
         if ($given < $min) {
-            $msg = "The Operator to be processed '" . get_class($this) . "' requires at least ${min} operand(s). ";
-            $msg .= "${given} operand(s) given.";
+            $msg = "The Operator to be processed '" . get_class($this) . "' requires at least {$min} operand(s). ";
+            $msg .= "{$given} operand(s) given.";
             throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NOT_ENOUGH_OPERANDS);
         }
 
@@ -76,8 +76,8 @@ abstract class OperatorProcessor extends ExpressionProcessor
         $given = count($operands);
 
         if ($max !== -1 && $given > $max) {
-            $msg = "The Operator to be processed '" . get_class($this) . "' requires at most ${max} operand(s). ";
-            $msg .= "${given} operand(s) given.";
+            $msg = "The Operator to be processed '" . get_class($this) . "' requires at most {$max} operand(s). ";
+            $msg .= "{$given} operand(s) given.";
             throw new OperatorProcessingException($msg, $this, OperatorProcessingException::TOO_MUCH_OPERANDS);
         }
 

--- a/src/qtism/runtime/expressions/operators/OperatorProcessorFactory.php
+++ b/src/qtism/runtime/expressions/operators/OperatorProcessorFactory.php
@@ -82,7 +82,7 @@ class OperatorProcessorFactory extends ExpressionProcessorFactory
             $className = $nsPackage . $qtiClassName . 'Processor';
 
             if (!class_exists($className)) {
-                $msg = "No dedicated OperatorProcessor class found for QTI operator '${qtiClassName}'.";
+                $msg = "No dedicated OperatorProcessor class found for QTI operator '{$qtiClassName}'.";
                 throw new RuntimeException($msg);
             }
         }

--- a/src/qtism/runtime/expressions/operators/PatternMatchProcessor.php
+++ b/src/qtism/runtime/expressions/operators/PatternMatchProcessor.php
@@ -84,7 +84,7 @@ class PatternMatchProcessor extends OperatorProcessor
             return new QtiBoolean(false);
         } else {
             $errorType = OperatorUtils::lastPregErrorMessage();
-            $msg = "An internal error occurred while processing the regular expression '${rawPattern}': ${errorType}.";
+            $msg = "An internal error occurred while processing the regular expression '{$rawPattern}': {$errorType}.";
             throw new OperatorProcessingException($msg, $this, OperatorProcessingException::RUNTIME_ERROR);
         }
     }

--- a/src/qtism/runtime/expressions/operators/RepeatProcessor.php
+++ b/src/qtism/runtime/expressions/operators/RepeatProcessor.php
@@ -75,10 +75,10 @@ class RepeatProcessor extends OperatorProcessor
             $varValue = $state[$varName];
 
             if ($varValue === null) {
-                $msg = "The variable with name '${varName}' could not be resolved.";
+                $msg = "The variable with name '{$varName}' could not be resolved.";
                 throw new OperatorProcessingException($msg, $this);
             } elseif (!$varValue instanceof QtiInteger) {
-                $msg = "The variable with name '${varName}' is not an integer value.";
+                $msg = "The variable with name '{$varName}' is not an integer value.";
                 throw new OperatorProcessingException($msg, $this);
             }
 

--- a/src/qtism/runtime/expressions/operators/RoundToProcessor.php
+++ b/src/qtism/runtime/expressions/operators/RoundToProcessor.php
@@ -106,10 +106,10 @@ class RoundToProcessor extends OperatorProcessor
             $figures = $state[$figuresIdentifier];
 
             if ($figures === null) {
-                $msg = "The variable '${figuresIdentifier}' used to set up the 'figures' attribute is null or nonexisting.";
+                $msg = "The variable '{$figuresIdentifier}' used to set up the 'figures' attribute is null or nonexisting.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NONEXISTENT_VARIABLE);
             } elseif (!$figures instanceof QtiInteger) {
-                $msg = "The variable '${figuresIdentifier}' used to set up the 'figures' attribute is not an integer.";
+                $msg = "The variable '{$figuresIdentifier}' used to set up the 'figures' attribute is not an integer.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::WRONG_VARIABLE_BASETYPE);
             }
             $figures = $figures->getValue();
@@ -118,7 +118,7 @@ class RoundToProcessor extends OperatorProcessor
         if ($roundingMode === RoundingMode::SIGNIFICANT_FIGURES) {
             if ($figures <= 0) {
                 // As per QTI 2.1 spec.
-                $msg = "The 'figures' attribute must be a non-zero positive integer when mode 'significantFigures' is used, '${figures}' given.";
+                $msg = "The 'figures' attribute must be a non-zero positive integer when mode 'significantFigures' is used, '{$figures}' given.";
                 throw new OperatorProcessingException($msg, $this, OperatorProcessingException::LOGIC_ERROR);
             }
 
@@ -136,7 +136,7 @@ class RoundToProcessor extends OperatorProcessor
         } else {
             // As per QTI 2.1 spec.
             if ($figures < 0) {
-                $msg = "The 'figures' attribute must be a integer greater than or equal to zero when mode 'decimalPlaces' is used, '${figures}' given.";
+                $msg = "The 'figures' attribute must be a integer greater than or equal to zero when mode 'decimalPlaces' is used, '{$figures}' given.";
                 throw new OperatorProcessingException($msg, $this);
             }
 

--- a/src/qtism/runtime/expressions/operators/custom/Explode.php
+++ b/src/qtism/runtime/expressions/operators/custom/Explode.php
@@ -59,7 +59,7 @@ class Explode extends CustomOperatorProcessor
         $operands = $this->getOperands();
 
         if (($c = count($operands)) < 2) {
-            $msg = "The 'qtism.runtime.expressions.operators.custom.Explode' custom operator takes 2 sub-expressions as parameters, ${c} given.";
+            $msg = "The 'qtism.runtime.expressions.operators.custom.Explode' custom operator takes 2 sub-expressions as parameters, {$c} given.";
             throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NOT_ENOUGH_OPERANDS);
         } elseif ($operands->containsNull() === true) {
             return null;

--- a/src/qtism/runtime/expressions/operators/custom/Implode.php
+++ b/src/qtism/runtime/expressions/operators/custom/Implode.php
@@ -52,7 +52,7 @@ class Implode extends CustomOperatorProcessor
         $operands = $this->getOperands();
 
         if (($c = count($operands)) < 2) {
-            $msg = "The 'qtism.runtime.expressions.operators.custom.Implode' custom operator takes 2 sub-expressions as parameters, ${c} given.";
+            $msg = "The 'qtism.runtime.expressions.operators.custom.Implode' custom operator takes 2 sub-expressions as parameters, {$c} given.";
             throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NOT_ENOUGH_OPERANDS);
         } elseif ($operands->containsNull() === true) {
             return null;

--- a/src/qtism/runtime/pci/json/Marshaller.php
+++ b/src/qtism/runtime/pci/json/Marshaller.php
@@ -99,7 +99,7 @@ class Marshaller
             $json = $this->marshallUnit($data);
         } else {
             $className = get_class($this);
-            $msg = "The '${className}::marshall' method only takes State, QtiDatatype and null values as arguments, '";
+            $msg = "The '{$className}::marshall' method only takes State, QtiDatatype and null values as arguments, '";
 
             if (is_object($data)) {
                 $msg .= get_class($data);

--- a/src/qtism/runtime/pci/json/Unmarshaller.php
+++ b/src/qtism/runtime/pci/json/Unmarshaller.php
@@ -482,7 +482,7 @@ class Unmarshaller
                 }
             } catch (InvalidArgumentException $e) {
                 $strBaseType = BaseType::getNameByConstant($baseType);
-                $msg = "A value is not compliant with the '${strBaseType}' baseType.";
+                $msg = "A value is not compliant with the '{$strBaseType}' baseType.";
                 $code = UnmarshallingException::NOT_PCI;
                 throw new UnmarshallingException($msg, $code);
             }

--- a/src/qtism/runtime/processing/PrintedVariableEngine.php
+++ b/src/qtism/runtime/processing/PrintedVariableEngine.php
@@ -199,7 +199,7 @@ class PrintedVariableEngine extends AbstractEngine
         $mappingIndicator = $this->getComponent()->getMappingIndicator();
 
         foreach ($variable->getValue() as $k => $v) {
-            $processedValues[] = "${k}${mappingIndicator}" . $this->processValue(Utils::inferBaseType($v), $v);
+            $processedValues[] = "{$k}{$mappingIndicator}" . $this->processValue(Utils::inferBaseType($v), $v);
         }
 
         return implode($this->getComponent()->getDelimiter(), $processedValues);

--- a/src/qtism/runtime/processing/ResponseProcessingEngine.php
+++ b/src/qtism/runtime/processing/ResponseProcessingEngine.php
@@ -222,12 +222,12 @@ class ResponseProcessingEngine extends AbstractEngine
             }
 
             if (empty($finalTemplateFile)) {
-                $msg = "The template file could not be found: template='${template}', templateLocation='${templateLocation}'.";
+                $msg = "The template file could not be found: template='{$template}', templateLocation='{$templateLocation}'.";
                 throw new ResponseProcessingException($msg, $this, ResponseProcessingException::TEMPLATE_NOT_FOUND);
             }
 
             // Open the file and retrieve the rules.
-            $this->trace("loading response processing template '${finalTemplateFile}'");
+            $this->trace("loading response processing template '{$finalTemplateFile}'");
             $php = new PhpDocument();
             $php->load($finalTemplateFile);
             $rules = $php->getDocumentComponent()->getResponseRules();

--- a/src/qtism/runtime/rendering/css/CssScoper.php
+++ b/src/qtism/runtime/rendering/css/CssScoper.php
@@ -466,7 +466,7 @@ class CssScoper implements Renderable
                 $this->afterCharReading($char);
             } catch (MemoryStreamException $e) {
                 $stream->close();
-                $msg = "An unexpected error occurred while reading the CSS file '${file}'.";
+                $msg = "An unexpected error occurred while reading the CSS file '{$file}'.";
                 throw new RenderingException($msg, RenderingException::RUNTIME, $e);
             }
         }
@@ -498,7 +498,7 @@ class CssScoper implements Renderable
             $stream->open();
             $this->setStream($stream);
         } else {
-            throw new RenderingException("The CSS file '${file}' could not be open.", RenderingException::RUNTIME);
+            throw new RenderingException("The CSS file '{$file}' could not be open.", RenderingException::RUNTIME);
         }
     }
 

--- a/src/qtism/runtime/rendering/css/Utils.php
+++ b/src/qtism/runtime/rendering/css/Utils.php
@@ -47,7 +47,7 @@ class Utils
     public static function mapSelector($selector, array $map): string
     {
         foreach ($map as $k => $v) {
-            $pattern = "/(?:(^|\s|\+|,|~|>)(${k})(\$|\s|,|\+|\.|\~|>|:|\[))/u";
+            $pattern = "/(?:(^|\s|\+|,|~|>)({$k})(\$|\s|,|\+|\.|\~|>|:|\[))/u";
             $count = 1;
             while ($count > 0) {
                 $selector = preg_replace($pattern, '$1.' . $v . '$3', $selector, -1, $count);
@@ -65,7 +65,7 @@ class Utils
     public static function mapPseudoClasses($selector, array $map)
     {
         foreach ($map as $k => $v) {
-            $selector = str_replace(":-${k}", ".${v}", $selector);
+            $selector = str_replace(":-{$k}", ".{$v}", $selector);
         }
 
         return $selector;

--- a/src/qtism/runtime/rendering/markup/AbstractMarkupRenderingEngine.php
+++ b/src/qtism/runtime/rendering/markup/AbstractMarkupRenderingEngine.php
@@ -580,7 +580,7 @@ abstract class AbstractMarkupRenderingEngine implements Renderable
 
                         foreach ($maths as $math) {
                             // Find <mi> and <ci> elements.
-                            foreach ($xpath->query(".//m:mi[text() = '${templateIdentifier}']|.//m:ci[text() = '${templateIdentifier}']|.//mi[text() = '${templateIdentifier}']|.//ci[text() = '${templateIdentifier}']", $math) as $mathElement) {
+                            foreach ($xpath->query(".//m:mi[text() = '{$templateIdentifier}']|.//m:ci[text() = '{$templateIdentifier}']|.//mi[text() = '{$templateIdentifier}']|.//ci[text() = '{$templateIdentifier}']", $math) as $mathElement) {
                                 $localElementName = ($mathElement->localName === 'mi') ? 'mn' : 'cn';
                                 $newMathElement = $mathElement->ownerDocument->createElement($localElementName);
                                 $printedVariable = new PrintedVariable($templateIdentifier);
@@ -796,7 +796,7 @@ abstract class AbstractMarkupRenderingEngine implements Renderable
         } elseif (isset($renderers['qtism'][$className])) {
             return $renderers['qtism'][$className];
         } else {
-            $msg = "No AbstractRenderer implementation registered for QTI class name '${className}'.";
+            $msg = "No AbstractRenderer implementation registered for QTI class name '{$className}'.";
             throw new RenderingException($msg, RenderingException::NO_RENDERER);
         }
     }
@@ -1074,11 +1074,11 @@ abstract class AbstractMarkupRenderingEngine implements Renderable
         $identifierType = QtiIdentifier::class;
         $scalarType = QtiScalar::class;
         $containerType = Container::class;
-        $scalarCheck = "${val} instanceof ${identifierType} && ${val}->equals(new ${identifierType}('${identifier}'))";
-        $containerCheck = "${val} instanceof ${containerType} && ${val}->contains(new ${identifierType}('${identifier}'))";
-        $valCheck = "(${scalarCheck} || ${containerCheck})";
+        $scalarCheck = "{$val} instanceof {$identifierType} && {$val}->equals(new {$identifierType}('{$identifier}'))";
+        $containerCheck = "{$val} instanceof {$containerType} && {$val}->contains(new {$identifierType}('{$identifier}'))";
+        $valCheck = "({$scalarCheck} || {$containerCheck})";
 
-        $ifStmt = " qtism-if (${operator}(${val} !== null && ${valCheck})): ";
+        $ifStmt = " qtism-if ({$operator}({$val} !== null && {$valCheck})): ";
         $endifStmt = ' qtism-endif ';
 
         $ifStmtCmt = $rendering->ownerDocument->createComment($ifStmt);
@@ -1107,11 +1107,11 @@ abstract class AbstractMarkupRenderingEngine implements Renderable
         $conds = [];
 
         foreach ($component->getViews() as $v) {
-            $conds[] = "in_array(${v}, ${viewsName})";
+            $conds[] = "in_array({$v}, {$viewsName})";
         }
 
         $conds = (count($views) > 1) ? implode(' || ', $conds) : $conds[0];
-        $ifStmt = " qtism-if (${conds}): ";
+        $ifStmt = " qtism-if ({$conds}): ";
         $endifStmt = ' qtism-endif ';
 
         $ifStmtCmt = $rendering->ownerDocument->createComment($ifStmt);
@@ -1141,11 +1141,11 @@ abstract class AbstractMarkupRenderingEngine implements Renderable
         $identifierType = QtiIdentifier::class;
         $scalarType = QtiScalar::class;
         $containerType = Container::class;
-        $scalarCheck = "${val} instanceof ${identifierType} && ${val}->equals(new ${identifierType}('${identifier}'))";
-        $containerCheck = "${val} instanceof ${containerType} && ${val}->contains(new ${identifierType}('${identifier}'))";
-        $valCheck = "(${scalarCheck} || ${containerCheck})";
+        $scalarCheck = "{$val} instanceof {$identifierType} && {$val}->equals(new {$identifierType}('{$identifier}'))";
+        $containerCheck = "{$val} instanceof {$containerType} && {$val}->contains(new {$identifierType}('{$identifier}'))";
+        $valCheck = "({$scalarCheck} || {$containerCheck})";
 
-        $ifStmt = " qtism-if (${operator}(${val} !== null && ${valCheck})): ";
+        $ifStmt = " qtism-if ({$operator}({$val} !== null && {$valCheck})): ";
         $endifStmt = ' qtism-endif ';
 
         $ifStmtCmt = $rendering->ownerDocument->createComment($ifStmt);
@@ -1166,7 +1166,7 @@ abstract class AbstractMarkupRenderingEngine implements Renderable
         $interactionIndex = $this->interactionCounter;
         $stateName = $this->getStateName();
 
-        $includeStmtCmt = $rendering->ownerDocument->createComment(' qtism-include($' . "${stateName}, ${interactionIndex}, ${choiceIdentifier}, ${choiceIndex}): ");
+        $includeStmtCmt = $rendering->ownerDocument->createComment(' qtism-include($' . "{$stateName}, {$interactionIndex}, {$choiceIdentifier}, {$choiceIndex}): ");
         $endIncludeStmtCmt = $rendering->ownerDocument->createComment(' qtism-endinclude ');
         $rendering->insertBefore($includeStmtCmt, $rendering->firstChild);
         $rendering->appendChild($endIncludeStmtCmt);

--- a/src/qtism/runtime/rendering/markup/MarkupPostRenderer.php
+++ b/src/qtism/runtime/rendering/markup/MarkupPostRenderer.php
@@ -226,7 +226,7 @@ class MarkupPostRenderer implements Renderable
             $output = preg_replace('/<!--\s+qtism-endif\s+-->/iu', '<?php endif; ?>', $output);
 
             $className = Utils::class;
-            $call = "<?php echo ${className}::printVariable(\\1); ?>";
+            $call = "<?php echo {$className}::printVariable(\\1); ?>";
             $output = preg_replace('/<!--\s+qtism-printVariable\((.+?)\)\s+-->/iu', $call, $output);
 
             $matches = [];

--- a/src/qtism/runtime/rendering/markup/xhtml/ChoiceInteractionRenderer.php
+++ b/src/qtism/runtime/rendering/markup/xhtml/ChoiceInteractionRenderer.php
@@ -68,7 +68,7 @@ class ChoiceInteractionRenderer extends InteractionRenderer
 
         $qtiCount = count($component->getSimpleChoices());
         $qtiCount = ($qtiCount % 2 === 1) ? $qtiCount + 1 : $qtiCount;
-        $this->additionalUserClass("qti-count-${qtiCount}");
+        $this->additionalUserClass("qti-count-{$qtiCount}");
 
         $fragment->firstChild->setAttribute('data-shuffle', ($component->mustShuffle() === true) ? 'true' : 'false');
         $fragment->firstChild->setAttribute('data-max-choices', (string)$component->getMaxChoices());

--- a/src/qtism/runtime/rules/AbstractConditionProcessor.php
+++ b/src/qtism/runtime/rules/AbstractConditionProcessor.php
@@ -155,8 +155,8 @@ abstract class AbstractConditionProcessor extends RuleProcessor
 
         $className = ucfirst($this->getQtiNature());
         $nsClass = 'qtism\\data\\rules\\' . $className . 'Condition';
-        $ruleGetter = "get${className}Rules";
-        $statementGetter = "get${className}"; // + 'If'|'ElseIf'|'Else'
+        $ruleGetter = "get{$className}Rules";
+        $statementGetter = "get{$className}"; // + 'If'|'ElseIf'|'Else'
 
         while (count($this->getTrail()) > 0) {
             $rule = $this->popTrail();

--- a/src/qtism/runtime/rules/LookupOutcomeValueProcessor.php
+++ b/src/qtism/runtime/rules/LookupOutcomeValueProcessor.php
@@ -67,10 +67,10 @@ class LookupOutcomeValueProcessor extends RuleProcessor
         $var = $state->getVariable($identifier);
 
         if ($var === null) {
-            $msg = "The variable to set '${identifier}' does not exist in the current state.";
+            $msg = "The variable to set '{$identifier}' does not exist in the current state.";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::NONEXISTENT_VARIABLE);
         } elseif (!$var instanceof OutcomeVariable) {
-            $msg = "The variable to set '${identifier}' is not an OutcomeVariable.";
+            $msg = "The variable to set '{$identifier}' is not an OutcomeVariable.";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::WRONG_VARIABLE_TYPE);
         }
 
@@ -83,7 +83,7 @@ class LookupOutcomeValueProcessor extends RuleProcessor
             // Let's lookup the associated table.
             $table = $var->getLookupTable();
             if ($table === null) {
-                $msg = "No lookupTable in declaration of variable '${identifier}'.";
+                $msg = "No lookupTable in declaration of variable '{$identifier}'.";
                 throw new RuleProcessingException($msg, $this, RuleProcessingException::LOGIC_ERROR);
             }
 
@@ -97,7 +97,7 @@ class LookupOutcomeValueProcessor extends RuleProcessor
 
             if ($table instanceof InterpolationTable) {
                 if (!$val instanceof QtiFloat && !$val instanceof QtiInteger && !$val instanceof QtiDuration) {
-                    $msg = "The value of variable '${identifier}' must be integer, float or duration when used with an interpolationTable";
+                    $msg = "The value of variable '{$identifier}' must be integer, float or duration when used with an interpolationTable";
                     throw new RuleProcessingException($msg, $this, RuleProcessingException::LOGIC_ERROR);
                 }
 
@@ -116,7 +116,7 @@ class LookupOutcomeValueProcessor extends RuleProcessor
             } else {
                 // $table instanceof MatchTable
                 if (!$val instanceof QtiInteger) {
-                    $msg = "The value of the variable '${identifier}' must be integer when used with a matchTable.";
+                    $msg = "The value of the variable '{$identifier}' must be integer when used with a matchTable.";
                     throw new RuleProcessingException($msg, $this, RuleProcessingException::LOGIC_ERROR);
                 }
 
@@ -134,7 +134,7 @@ class LookupOutcomeValueProcessor extends RuleProcessor
                 $state[$identifier] = $finalVal;
             } catch (InvalidArgumentException $e) {
                 // $targetVal's baseType not compliant with target variable's baseType.
-                $msg = "The looked up value's baseType is not compliant with the baseType of variable '${identifier}'.";
+                $msg = "The looked up value's baseType is not compliant with the baseType of variable '{$identifier}'.";
                 throw new RuleProcessingException($msg, $this, RuleProcessingException::RUNTIME_ERROR);
             }
         } catch (ExpressionProcessingException $e) {

--- a/src/qtism/runtime/rules/RuleProcessorFactory.php
+++ b/src/qtism/runtime/rules/RuleProcessorFactory.php
@@ -59,7 +59,7 @@ class RuleProcessorFactory implements ProcessorFactory
             return new $className($rule);
         }
 
-        $msg = "The QTI rule class '${qtiClassName}' has no dedicated RuleProcessor class.";
+        $msg = "The QTI rule class '{$qtiClassName}' has no dedicated RuleProcessor class.";
         throw new RuntimeException($msg);
     }
 }

--- a/src/qtism/runtime/rules/SetCorrectResponseProcessor.php
+++ b/src/qtism/runtime/rules/SetCorrectResponseProcessor.php
@@ -59,10 +59,10 @@ class SetCorrectResponseProcessor extends RuleProcessor
         $var = $state->getVariable($variableIdentifier);
 
         if ($var === null) {
-            $msg = "No variable with identifier '${variableIdentifier}' to be set in the current state.";
+            $msg = "No variable with identifier '{$variableIdentifier}' to be set in the current state.";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::NONEXISTENT_VARIABLE);
         } elseif (!$var instanceof ResponseVariable) {
-            $msg = "The variable to set '${variableIdentifier}' is not an instance of 'ResponseVariable'.";
+            $msg = "The variable to set '{$variableIdentifier}' is not an instance of 'ResponseVariable'.";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::WRONG_VARIABLE_TYPE);
         }
 
@@ -74,7 +74,7 @@ class SetCorrectResponseProcessor extends RuleProcessor
             $varBaseType = (BaseType::getNameByConstant($var->getBaseType()) === false) ? 'noBaseType' : BaseType::getNameByConstant($var->getBaseType());
             $varCardinality = (Cardinality::getNameByConstant($var->getCardinality()));
             // The affected value does not match the baseType of the variable $var.
-            $msg = "Unable to set value ${val} to variable '${variableIdentifier}' (cardinality = ${varCardinality}, baseType = ${varBaseType}).";
+            $msg = "Unable to set value {$val} to variable '{$variableIdentifier}' (cardinality = {$varCardinality}, baseType = {$varBaseType}).";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::WRONG_VARIABLE_BASETYPE, $e);
         } catch (ExpressionProcessingException $e) {
             $msg = "An error occurred while processing the expression bound with the 'SetCorrectResponse' rule.";

--- a/src/qtism/runtime/rules/SetDefaultValueProcessor.php
+++ b/src/qtism/runtime/rules/SetDefaultValueProcessor.php
@@ -60,10 +60,10 @@ class SetDefaultValueProcessor extends RuleProcessor
         $var = $state->getVariable($variableIdentifier);
 
         if ($var === null) {
-            $msg = "No variable with identifier '${variableIdentifier}' to be set in the current state.";
+            $msg = "No variable with identifier '{$variableIdentifier}' to be set in the current state.";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::NONEXISTENT_VARIABLE);
         } elseif (!$var instanceof ResponseVariable && !$var instanceof OutcomeVariable) {
-            $msg = "The variable to set '${variableIdentifier}' is not an instance of 'ResponseVariable' nor an instance of 'OutcomeVariable'.";
+            $msg = "The variable to set '{$variableIdentifier}' is not an instance of 'ResponseVariable' nor an instance of 'OutcomeVariable'.";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::WRONG_VARIABLE_TYPE);
         }
 
@@ -75,7 +75,7 @@ class SetDefaultValueProcessor extends RuleProcessor
             $varBaseType = (BaseType::getNameByConstant($var->getBaseType()) === false) ? 'noBaseType' : BaseType::getNameByConstant($var->getBaseType());
             $varCardinality = (Cardinality::getNameByConstant($var->getCardinality()));
             // The affected value does not match the baseType of the variable $var.
-            $msg = "Unable to set value ${val} to variable '${variableIdentifier}' (cardinality = ${varCardinality}, baseType = ${varBaseType}).";
+            $msg = "Unable to set value {$val} to variable '{$variableIdentifier}' (cardinality = {$varCardinality}, baseType = {$varBaseType}).";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::WRONG_VARIABLE_BASETYPE, $e);
         } catch (ExpressionProcessingException $e) {
             $msg = "An error occurred while processing the expression bound with the 'SetCorrectResponse' rule.";

--- a/src/qtism/runtime/rules/SetValueProcessor.php
+++ b/src/qtism/runtime/rules/SetValueProcessor.php
@@ -57,10 +57,10 @@ abstract class SetValueProcessor extends RuleProcessor
         $var = $state->getVariable($identifier);
 
         if ($var === null) {
-            $msg = "No variable with identifier '${identifier}' to be set in the current state.";
+            $msg = "No variable with identifier '{$identifier}' to be set in the current state.";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::NONEXISTENT_VARIABLE);
         } elseif (Reflection::isInstanceOf($var, $this->getVariableType()) === false) {
-            $msg = "The variable to set '${identifier}' is not an instance of '" . $this->getVariableType() . "'.";
+            $msg = "The variable to set '{$identifier}' is not an instance of '" . $this->getVariableType() . "'.";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::WRONG_VARIABLE_TYPE);
         }
 
@@ -97,7 +97,7 @@ abstract class SetValueProcessor extends RuleProcessor
             $varBaseType = (BaseType::getNameByConstant($var->getBaseType()) === false) ? 'noBaseType' : BaseType::getNameByConstant($var->getBaseType());
             $varCardinality = (Cardinality::getNameByConstant($var->getCardinality()));
             // The affected value does not match the baseType of the variable $var.
-            $msg = "Unable to set value ${val} to variable '${identifier}' (cardinality = ${varCardinality}, baseType = ${varBaseType}).";
+            $msg = "Unable to set value {$val} to variable '{$identifier}' (cardinality = {$varCardinality}, baseType = {$varBaseType}).";
             throw new RuleProcessingException($msg, $this, RuleProcessingException::WRONG_VARIABLE_BASETYPE, $e);
         }
     }

--- a/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
+++ b/src/qtism/runtime/storage/binary/AbstractQtiBinaryStorage.php
@@ -233,7 +233,7 @@ abstract class AbstractQtiBinaryStorage extends AbstractStorage
             $stream->close();
         } catch (Exception $e) {
             $sessionId = $assessmentTestSession->getSessionId();
-            $msg = "An error occurred while persisting AssessmentTestSession with ID '${sessionId}': " . $e->getMessage();
+            $msg = "An error occurred while persisting AssessmentTestSession with ID '{$sessionId}': " . $e->getMessage();
             throw new StorageException($msg, StorageException::PERSISTENCE, $e);
         }
     }

--- a/src/qtism/runtime/storage/binary/LocalQtiBinaryStorage.php
+++ b/src/qtism/runtime/storage/binary/LocalQtiBinaryStorage.php
@@ -101,7 +101,7 @@ class LocalQtiBinaryStorage extends AbstractQtiBinaryStorage
         $written = @file_put_contents($path, $stream->getBinary());
 
         if ($written === false || $written === 0) {
-            $msg = "An error occurred while persisting the binary stream at '${path}'.";
+            $msg = "An error occurred while persisting the binary stream at '{$path}'.";
             throw new RuntimeException($msg);
         }
     }
@@ -121,7 +121,7 @@ class LocalQtiBinaryStorage extends AbstractQtiBinaryStorage
         $read = @file_get_contents($path);
 
         if ($read === false || strlen($read) === 0) {
-            $msg = "An error occurred while retrieving the binary stream at '${path}'. Nothing could be read. The file is empty or missing.";
+            $msg = "An error occurred while retrieving the binary stream at '{$path}'. Nothing could be read. The file is empty or missing.";
             throw new RuntimeException($msg);
         }
 

--- a/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
+++ b/src/qtism/runtime/storage/binary/QtiBinaryStreamAccess.php
@@ -770,7 +770,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                     /** @var VariableDeclaration $variableDeclaration */
                     $variableDeclaration = $seeker->seekComponent($variableType, $varPosition);
                 } catch (OutOfBoundsException $e) {
-                    $msg = "No variable found at position ${varPosition} in the assessmentTest tree structure.";
+                    $msg = "No variable found at position {$varPosition} in the assessmentTest tree structure.";
                     throw new QtiBinaryStreamAccessException(
                         $msg,
                         $this,
@@ -819,7 +819,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
             $msg = 'An error occurred while reading an assessment item session.';
             throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::ITEM_SESSION, $e);
         } catch (OutOfBoundsException $e) {
-            $msg = "No assessmentItemRef found at position ${itemRefPosition} in the assessmentTest tree structure.";
+            $msg = "No assessmentItemRef found at position {$itemRefPosition} in the assessmentTest tree structure.";
             throw new QtiBinaryStreamAccessException($msg, $this, QtiBinaryStreamAccessException::ITEM_SESSION, $e);
         }
     }
@@ -1114,7 +1114,7 @@ class QtiBinaryStreamAccess extends BinaryStreamAccess
                     $this->writeShort($seeker->seekPosition($responseDeclarations[$respId]));
                     $this->writeVariableValue($responseVariable);
                 } else {
-                    $msg = "No response variable with identifier '${respId}' found in related assessmentItemRef.";
+                    $msg = "No response variable with identifier '{$respId}' found in related assessmentItemRef.";
                     throw new QtiBinaryStreamAccessException(
                         $msg,
                         $this,

--- a/src/qtism/runtime/storage/common/AssessmentTestSeeker.php
+++ b/src/qtism/runtime/storage/common/AssessmentTestSeeker.php
@@ -132,7 +132,7 @@ class AssessmentTestSeeker
      */
     protected function &getComponentStore(): array
     {
-        return $this->componentsStore;
+        return $this->componentStore;
     }
 
     /**
@@ -145,12 +145,12 @@ class AssessmentTestSeeker
     {
         $class = $component->getQtiClassName();
 
-        if (isset($this->componentsStore[$class]) === false) {
-            $this->componentsStore[$class] = [];
+        if (isset($this->componentStore[$class]) === false) {
+            $this->componentStore[$class] = [];
         }
 
         $position = $this->getClassCount($class);
-        $this->componentsStore[$class][$position] = $component;
+        $this->componentStore[$class][$position] = $component;
         $this->incrementClassCount($component);
 
         return $position;
@@ -168,8 +168,8 @@ class AssessmentTestSeeker
     {
         $component = false;
 
-        if (isset($this->componentsStore[$class]) === true && isset($this->componentsStore[$class][$position]) === true) {
-            $component = $this->componentsStore[$class][$position];
+        if (isset($this->componentStore[$class]) === true && isset($this->componentStore[$class][$position]) === true) {
+            $component = $this->componentStore[$class][$position];
         }
 
         return $component;
@@ -186,7 +186,7 @@ class AssessmentTestSeeker
         $position = false;
         $class = $component->getQtiClassName();
 
-        if ((isset($this->componentsStore[$class]) === true) && ($search = array_search($component, $this->componentsStore[$class], true)) !== false) {
+        if ((isset($this->componentStore[$class]) === true) && ($search = array_search($component, $this->componentStore[$class], true)) !== false) {
             $position = $search;
         }
 

--- a/src/qtism/runtime/storage/common/AssessmentTestSeeker.php
+++ b/src/qtism/runtime/storage/common/AssessmentTestSeeker.php
@@ -222,7 +222,7 @@ class AssessmentTestSeeker
             }
         }
 
-        $msg = "Unable to find a QtiComponent object with QTI class '${class}' at position '${position}'.";
+        $msg = "Unable to find a QtiComponent object with QTI class '{$class}' at position '{$position}'.";
         throw new OutOfBoundsException($msg);
     }
 
@@ -253,7 +253,7 @@ class AssessmentTestSeeker
         }
 
         $class = $component->getQtiClassName();
-        $msg = "Unable to find the position of a QtiComponent with QTI class '${class}'.";
+        $msg = "Unable to find the position of a QtiComponent with QTI class '{$class}'.";
         throw new OutOfBoundsException($msg);
     }
 

--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -588,7 +588,7 @@ class AssessmentItemSession extends State
                 // The session state is INTERACTING. Thus, we need to update the built-in
                 // duration variable.
                 $diffSeconds = Time::timeDiffSeconds($this->getTimeReference(), $time);
-                $diffDuration = new QtiDuration("PT${diffSeconds}S");
+                $diffDuration = new QtiDuration("PT{$diffSeconds}S");
                 $this['duration']->add($diffDuration);
             }
 
@@ -691,19 +691,19 @@ class AssessmentItemSession extends State
         if ($this->getState() === AssessmentItemSessionState::CLOSED) {
             if ($this->isMaxTimeReached() === true) {
                 $identifier = $this->getAssessmentItem()->getIdentifier();
-                $msg = "A new attempt for item '${identifier}' is not allowed. The maximum time limit in force is reached.";
+                $msg = "A new attempt for item '{$identifier}' is not allowed. The maximum time limit in force is reached.";
                 throw new AssessmentItemSessionException($msg, $this, AssessmentItemSessionException::DURATION_OVERFLOW);
             } elseif ($this->getAssessmentItem()->isAdaptive() === true && $this['completionStatus']->getValue() === self::COMPLETION_STATUS_COMPLETED) {
                 $identifier = $this->getAssessmentItem()->getIdentifier();
-                $msg = "A new attempt for item '${identifier}' is not allowed. It is adaptive and its completion status is 'completed'.";
+                $msg = "A new attempt for item '{$identifier}' is not allowed. It is adaptive and its completion status is 'completed'.";
                 throw new AssessmentItemSessionException($msg, $this, AssessmentItemSessionException::ATTEMPTS_OVERFLOW);
             } elseif ($submissionMode === SubmissionMode::SIMULTANEOUS && $numAttempts > 0) {
                 $identifier = $this->getAssessmentItem()->getIdentifier();
-                $msg = "A new attempt for item '${identifier}' is not allowed. The submissionMode is simultaneous and the only accepted attempt is already begun.";
+                $msg = "A new attempt for item '{$identifier}' is not allowed. The submissionMode is simultaneous and the only accepted attempt is already begun.";
                 throw new AssessmentItemSessionException($msg, $this, AssessmentItemSessionException::ATTEMPTS_OVERFLOW);
             } elseif ($submissionMode === SubmissionMode::INDIVIDUAL && $maxAttempts !== 0 && $numAttempts >= $maxAttempts) {
                 $identifier = $this->getAssessmentItem()->getIdentifier();
-                $msg = "A new attempt for item '${identifier}' is not allowed. The maximum number of attempts (${maxAttempts}) is reached.";
+                $msg = "A new attempt for item '{$identifier}' is not allowed. The maximum number of attempts ({$maxAttempts}) is reached.";
                 throw new AssessmentItemSessionException($msg, $this, AssessmentItemSessionException::ATTEMPTS_OVERFLOW);
             }
         }
@@ -1222,7 +1222,7 @@ class AssessmentItemSession extends State
     {
         $shufflings = $this->getShufflingStates();
         if (isset($shufflings[$shufflingStateIndex]) === false) {
-            $msg = "No Shuffling State at index ${shufflingStateIndex}.";
+            $msg = "No Shuffling State at index {$shufflingStateIndex}.";
             throw new OutOfBoundsException($msg);
         } else {
             return $shufflings[$shufflingStateIndex]->getIdentifierAt($choiceIndex);
@@ -1391,7 +1391,7 @@ class AssessmentItemSession extends State
 
                 if (TestUtils::isResponseValid($value, $constraint) === false) {
                     throw new AssessmentItemSessionException(
-                        "Response '${responseIdentifier}' is invalid against the constraints described in the interaction it is bound to.",
+                        "Response '{$responseIdentifier}' is invalid against the constraints described in the interaction it is bound to.",
                         $this,
                         AssessmentItemSessionException::INVALID_RESPONSE
                     );

--- a/src/qtism/runtime/tests/AssessmentItemSessionStore.php
+++ b/src/qtism/runtime/tests/AssessmentItemSessionStore.php
@@ -106,7 +106,7 @@ class AssessmentItemSessionStore
             return $this->shelves[$assessmentItemRef][$occurence];
         } else {
             $itemId = $assessmentItemRef->getIdentifier();
-            $msg = "No AssessmentItemSession object bound to '${itemId}.${occurence}'.";
+            $msg = "No AssessmentItemSession object bound to '{$itemId}.{$occurence}'.";
             throw new OutOfBoundsException($msg);
         }
     }
@@ -141,7 +141,7 @@ class AssessmentItemSessionStore
             return $this->shelves[$assessmentItemRef];
         } else {
             $itemId = $assessmentItemRef->getIdentifier();
-            $msg = "No AssessmentItemSession objects bound to '${itemId}'.";
+            $msg = "No AssessmentItemSession objects bound to '{$itemId}'.";
             throw new OutOfBoundsException($msg);
         }
     }

--- a/src/qtism/runtime/tests/AssessmentTestSession.php
+++ b/src/qtism/runtime/tests/AssessmentTestSession.php
@@ -265,7 +265,7 @@ class AssessmentTestSession extends State
         if ($this->hasTimeReference() === true) {
             if ($this->getState() === AssessmentTestSessionState::INTERACTING) {
                 $diffSeconds = abs(Time::timeDiffSeconds($this->getTimeReference(), $time));
-                $diffDuration = new QtiDuration("PT${diffSeconds}S");
+                $diffDuration = new QtiDuration("PT{$diffSeconds}S");
 
                 // Update the duration store.
                 $routeItem = $this->getCurrentRouteItem();
@@ -1022,7 +1022,7 @@ class AssessmentTestSession extends State
         $route = $this->getRoute();
 
         if ($position >= $route->count()) {
-            $msg = "Position '${position}' is out of the Route boundaries.";
+            $msg = "Position '{$position}' is out of the Route boundaries.";
             throw new AssessmentTestSessionException($msg, AssessmentTestSessionException::FORBIDDEN_JUMP);
         }
 
@@ -1206,7 +1206,7 @@ class AssessmentTestSession extends State
             $v = new VariableIdentifier($identifier);
 
             if ($v->hasPrefix() === true || $v->hasSequenceNumber() === true) {
-                $msg = "'${identifier}' is not a valid item reference identifier.";
+                $msg = "'{$identifier}' is not a valid item reference identifier.";
                 throw new InvalidArgumentException($msg, 0);
             }
 
@@ -1221,7 +1221,7 @@ class AssessmentTestSession extends State
                 return false;
             }
         } catch (InvalidArgumentException $e) {
-            $msg = "'${identifier}' is not a valid item reference identifier.";
+            $msg = "'{$identifier}' is not a valid item reference identifier.";
             throw new InvalidArgumentException($msg, 0, $e);
         }
     }
@@ -1734,11 +1734,11 @@ class AssessmentTestSession extends State
             try {
                 $identifier = new VariableIdentifier($identifier);
                 if ($identifier->hasSequenceNumber() === true) {
-                    $msg = "The identifier ('${identifier}') cannot contain a sequence number.";
+                    $msg = "The identifier ('{$identifier}') cannot contain a sequence number.";
                     throw new InvalidArgumentException($msg);
                 }
             } catch (InvalidArgumentException $e) {
-                $msg = "'${identifier}' is not a valid variable identifier.";
+                $msg = "'{$identifier}' is not a valid variable identifier.";
                 throw new InvalidArgumentException($msg, 0, $e);
             }
         } elseif (!$identifier instanceof VariableIdentifier) {
@@ -1794,7 +1794,7 @@ class AssessmentTestSession extends State
             }
         } catch (InvalidArgumentException $e) {
             $variableIdentifier = $variable->getIdentifier();
-            $msg = "The identifier '${variableIdentifier}' of the variable to set is invalid.";
+            $msg = "The identifier '{$variableIdentifier}' of the variable to set is invalid.";
             throw new OutOfRangeException($msg, 0, $e);
         }
 
@@ -1916,7 +1916,7 @@ class AssessmentTestSession extends State
                 return null;
             }
         } catch (InvalidArgumentException $e) {
-            $msg = "AssessmentTestSession object addressed with an invalid identifier '${offset}'.";
+            $msg = "AssessmentTestSession object addressed with an invalid identifier '{$offset}'.";
             throw new OutOfRangeException($msg, 0, $e);
         }
     }
@@ -1944,7 +1944,7 @@ class AssessmentTestSession extends State
                 $data = &$this->getDataPlaceHolder();
                 $varName = $v->getVariableName();
                 if (isset($data[$varName]) === false) {
-                    $msg = "The variable '${varName}' to be set does not exist in the current context.";
+                    $msg = "The variable '{$varName}' to be set does not exist in the current context.";
                     throw new OutOfBoundsException($msg);
                 }
 
@@ -1975,7 +1975,7 @@ class AssessmentTestSession extends State
             }
         } catch (InvalidArgumentException $e) {
             // Invalid variable identifier.
-            $msg = "AssessmentTestSession object addressed with an invalid identifier '${offset}'.";
+            $msg = "AssessmentTestSession object addressed with an invalid identifier '{$offset}'.";
             throw new OutOfRangeException($msg, 0, $e);
         }
     }
@@ -1998,18 +1998,18 @@ class AssessmentTestSession extends State
             $v = new VariableIdentifier($offset);
 
             if ($v->hasPrefix() === true) {
-                $msg = "Only variables in the global scope of an AssessmentTestSession may be unset. '${offset}' is not in the global scope.";
+                $msg = "Only variables in the global scope of an AssessmentTestSession may be unset. '{$offset}' is not in the global scope.";
                 throw new OutOfBoundsException($msg);
             }
 
             if (isset($data[$offset])) {
                 $data[$offset]->setValue(null);
             } else {
-                $msg = "The variable '${offset}' does not exist in the AssessmentTestSession's global scope.";
+                $msg = "The variable '{$offset}' does not exist in the AssessmentTestSession's global scope.";
                 throw new OutOfBoundsException($msg);
             }
         } catch (InvalidArgumentException $e) {
-            $msg = "The variable identifier '${offset}' is not a valid variable identifier.";
+            $msg = "The variable identifier '{$offset}' is not a valid variable identifier.";
             throw new OutOfRangeException($msg, 0, $e);
         }
     }
@@ -2037,7 +2037,7 @@ class AssessmentTestSession extends State
 
             return isset($data[$offset]);
         } catch (InvalidArgumentException $e) {
-            $msg = "'${offset}' is not a valid variable identifier.";
+            $msg = "'{$offset}' is not a valid variable identifier.";
             throw new OutOfRangeException($msg);
         }
     }
@@ -2648,7 +2648,7 @@ class AssessmentTestSession extends State
                 $source = $constraint->getSource();
 
                 if ($minTimeRespected === false) {
-                    $msg = "Minimum duration of ${sourceNature} '${identifier}' not reached.";
+                    $msg = "Minimum duration of {$sourceNature} '{$identifier}' not reached.";
 
                     if ($source instanceof AssessmentTest) {
                         $code = AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_UNDERFLOW;
@@ -2662,7 +2662,7 @@ class AssessmentTestSession extends State
 
                     throw new AssessmentTestSessionException($msg, $code);
                 } elseif ($maxTimeRespected === false) {
-                    $msg = "Maximum duration of ${sourceNature} '${identifier}' not respected.";
+                    $msg = "Maximum duration of {$sourceNature} '{$identifier}' not respected.";
 
                     if ($source instanceof AssessmentTest) {
                         $code = AssessmentTestSessionException::ASSESSMENT_TEST_DURATION_OVERFLOW;
@@ -2752,19 +2752,19 @@ class AssessmentTestSession extends State
 
                 case AssessmentItemSessionException::DURATION_OVERFLOW:
                     $sessionIdentifier = $this->buildCurrentItemSessionIdentifier();
-                    $msg = "Maximum duration of Item Session '${sessionIdentifier}' is reached.";
+                    $msg = "Maximum duration of Item Session '{$sessionIdentifier}' is reached.";
                     $code = AssessmentTestSessionException::ASSESSMENT_ITEM_DURATION_OVERFLOW;
                     break;
 
                 case AssessmentItemSessionException::DURATION_UNDERFLOW:
                     $sessionIdentifier = $this->buildCurrentItemSessionIdentifier();
-                    $msg = "Minimum duration of Item Session '${sessionIdentifier}' not reached.";
+                    $msg = "Minimum duration of Item Session '{$sessionIdentifier}' not reached.";
                     $code = AssessmentTestSessionException::ASSESSMENT_ITEM_DURATION_UNDERFLOW;
                     break;
 
                 case AssessmentItemSessionException::ATTEMPTS_OVERFLOW:
                     $sessionIdentifier = $this->buildCurrentItemSessionIdentifier();
-                    $msg = "Maximum number of attempts of Item Session '${sessionIdentifier}' reached.";
+                    $msg = "Maximum number of attempts of Item Session '{$sessionIdentifier}' reached.";
                     $code = AssessmentTestSessionException::ASSESSMENT_ITEM_ATTEMPTS_OVERFLOW;
                     break;
 
@@ -2776,19 +2776,19 @@ class AssessmentTestSession extends State
 
                 case AssessmentItemSessionException::INVALID_RESPONSE:
                     $sessionIdentifier = $this->buildCurrentItemSessionIdentifier();
-                    $msg = "An invalid response was given for Item Session '${sessionIdentifier}' while 'itemSessionControl->validateResponses' is in force.";
+                    $msg = "An invalid response was given for Item Session '{$sessionIdentifier}' while 'itemSessionControl->validateResponses' is in force.";
                     $code = AssessmentTestSessionException::ASSESSMENT_ITEM_INVALID_RESPONSE;
                     break;
 
                 case AssessmentItemSessionException::SKIPPING_FORBIDDEN:
                     $sessionIdentifier = $this->buildCurrentItemSessionIdentifier();
-                    $msg = "The Item Session '${sessionIdentifier}' is not allowed to be skipped.";
+                    $msg = "The Item Session '{$sessionIdentifier}' is not allowed to be skipped.";
                     $code = AssessmentTestSessionException::ASSESSMENT_ITEM_SKIPPING_FORBIDDEN;
                     break;
 
                 case AssessmentItemSessionException::STATE_VIOLATION:
                     $sessionIdentifier = $this->buildCurrentItemSessionIdentifier();
-                    $msg = "The Item Session '${sessionIdentifier}' entered an invalid state.";
+                    $msg = "The Item Session '{$sessionIdentifier}' entered an invalid state.";
                     $code = AssessmentTestSessionException::STATE_VIOLATION;
                     break;
             }
@@ -2812,7 +2812,7 @@ class AssessmentTestSession extends State
         $itemIdentifier = $this->getCurrentAssessmentItemRef()->getIdentifier();
         $itemOccurence = $this->getCurrentAssessmentItemRefOccurence();
 
-        return "${itemIdentifier}.${itemOccurence}";
+        return "{$itemIdentifier}.{$itemOccurence}";
     }
 
     /**

--- a/src/qtism/runtime/tests/DurationStore.php
+++ b/src/qtism/runtime/tests/DurationStore.php
@@ -50,17 +50,17 @@ class DurationStore extends State
 
         if (!$value instanceof OutcomeVariable) {
             $className = get_class($value);
-            $msg = "The DurationStore only aims at storing OutcomeVariable objects, ${className} object given.";
+            $msg = "The DurationStore only aims at storing OutcomeVariable objects, {$className} object given.";
             throw new InvalidArgumentException($msg);
         }
 
         if (($bt = $value->getBaseType()) !== BaseType::DURATION) {
             $baseTypeName = BaseType::getNameByConstant($bt);
             $msg = "The DurationStore only aims at storing OutcomeVariable objects with a 'duration' baseType, ";
-            $msg .= "'${baseTypeName}' baseType given ";
+            $msg .= "'{$baseTypeName}' baseType given ";
 
             $id = $value->getIdentifier();
-            $msg .= "for variable '${id}'.";
+            $msg .= "for variable '{$id}'.";
 
             throw new InvalidArgumentException($msg);
         }
@@ -68,10 +68,10 @@ class DurationStore extends State
         if (($bt = $value->getCardinality()) !== Cardinality::SINGLE) {
             $cardinalityName = Cardinality::getNameByConstant($bt);
             $msg = "The DurationStore only aims at storing OutcomeVariable objects with a 'single' cardinality, ";
-            $msg .= "'${cardinalityName}' cardinality given ";
+            $msg .= "'{$cardinalityName}' cardinality given ";
 
             $id = $value->getIdentifier();
-            $msg .= "for variable '${id}'.";
+            $msg .= "for variable '{$id}'.";
 
             throw new InvalidArgumentException($msg);
         }

--- a/src/qtism/runtime/tests/Route.php
+++ b/src/qtism/runtime/tests/Route.php
@@ -816,7 +816,7 @@ class Route implements Iterator
         if (isset($routeItems[$position])) {
             return $routeItems[$position];
         } else {
-            $msg = "No RouteItem object found at position '${position}'.";
+            $msg = "No RouteItem object found at position '{$position}'.";
             throw new OutOfBoundsException($msg);
         }
     }
@@ -959,7 +959,7 @@ class Route implements Iterator
             return $routeItem->getTestPart() === $testPart;
         } catch (OutOfBoundsException $e) {
             // The position does not refer to any RouteItem. This is out of the bounds of the route.
-            $msg = "The position '${position}' is out of the bounds of the route.";
+            $msg = "The position '{$position}' is out of the bounds of the route.";
             throw new OutOfBoundsException($msg, 0, $e);
         }
     }
@@ -988,7 +988,7 @@ class Route implements Iterator
             $map = $this->getTestPartIdentifierMap();
 
             if (isset($map[$testPart]) === false) {
-                $msg = "No testPart with identifier '${testPart}' is referenced in the Route.";
+                $msg = "No testPart with identifier '{$testPart}' is referenced in the Route.";
                 throw new OutOfBoundsException($msg);
             }
 
@@ -1022,7 +1022,7 @@ class Route implements Iterator
             $map = $this->getAssessmentSectionIdentifierMap();
 
             if (isset($map[$assessmentSection]) === false) {
-                $msg = "No assessmentSection with identifier '${assessmentSection}' found in the Route.";
+                $msg = "No assessmentSection with identifier '{$assessmentSection}' found in the Route.";
                 throw new OutOfBoundsException($msg);
             }
 
@@ -1057,14 +1057,14 @@ class Route implements Iterator
             if (($ref = $this->assessmentItemRefs[$assessmentItemRef]) !== null) {
                 return $this->assessmentItemRefMap[$ref];
             } else {
-                $msg = "No AssessmentItemRef with identifier '${assessmentItemRef}' found in the Route.";
+                $msg = "No AssessmentItemRef with identifier '{$assessmentItemRef}' found in the Route.";
                 throw new OutOfBoundsException($msg);
             }
         } elseif ($assessmentItemRef instanceof AssessmentItemRef) {
             if (isset($this->assessmentItemRefMap[$assessmentItemRef]) === true) {
                 return $this->assessmentItemRefMap[$assessmentItemRef];
             } else {
-                $msg = "No AssessmentItemRef with 'identifier' ${assessmentItemRef}' found in the Route.";
+                $msg = "No AssessmentItemRef with 'identifier' {$assessmentItemRef}' found in the Route.";
                 throw new OutOfBoundsException($msg);
             }
         } else {
@@ -1105,7 +1105,7 @@ class Route implements Iterator
             $id = ($identifier->hasPrefix() === false) ? $identifier->getVariableName() : $identifier->getPrefix();
             $occurence = ($identifier->hasPrefix() === false) ? 0 : ($identifier->getVariableName() - 1);
         } catch (InvalidArgumentException $e) {
-            $msg = "The given identifier '${identifier}' is an invalid branching target.";
+            $msg = "The given identifier '{$identifier}' is an invalid branching target.";
             throw new OutOfRangeException($msg);
         }
 
@@ -1163,7 +1163,7 @@ class Route implements Iterator
         }
 
         // No such identifier referenced in the route, cannot branch.
-        $msg = "No such identifier '${id}' found in the route for branching.";
+        $msg = "No such identifier '{$id}' found in the route for branching.";
         throw new OutOfBoundsException($msg);
     }
 

--- a/src/qtism/runtime/tests/SelectableRouteCollection.php
+++ b/src/qtism/runtime/tests/SelectableRouteCollection.php
@@ -59,12 +59,12 @@ class SelectableRouteCollection extends AbstractCollection
         $routes = &$this->getDataPlaceHolder();
 
         if (isset($routes[$position1]) === false) {
-            $msg = "No Route object at position '${position1}'.";
+            $msg = "No Route object at position '{$position1}'.";
             throw new OutOfBoundsException($msg);
         }
 
         if (isset($routes[$position2]) === false) {
-            $msg = "No Route object at position '${position2}'.";
+            $msg = "No Route object at position '{$position2}'.";
             throw new OutOfBoundsException($msg);
         }
 

--- a/test/qtismtest/QtiSmRouteTestCase.php
+++ b/test/qtismtest/QtiSmRouteTestCase.php
@@ -56,19 +56,19 @@ abstract class QtiSmRouteTestCase extends QtiSmTestCase
 
             for ($j = 0; $j < $itemCount; $j++) {
                 $itemNum = $j + 1 + ($itemCount * $i);
-                $assessmentItemRefs[] = new AssessmentItemRef("Q${itemNum}", "Q${itemNum}.xml");
+                $assessmentItemRefs[] = new AssessmentItemRef("Q{$itemNum}", "Q{$itemNum}.xml");
             }
 
             $assessmentSections = new AssessmentSectionCollection();
-            $assessmentSections[] = new AssessmentSection("S${partNum}", "Section ${partNum}", true);
-            $assessmentSections["S${partNum}"]->setSectionParts($assessmentItemRefs);
+            $assessmentSections[] = new AssessmentSection("S{$partNum}", "Section {$partNum}", true);
+            $assessmentSections["S{$partNum}"]->setSectionParts($assessmentItemRefs);
 
             $testParts = new TestPartCollection();
-            $testParts[] = new TestPart("T${partNum}", $assessmentSections);
+            $testParts[] = new TestPart("T{$partNum}", $assessmentSections);
 
             for ($j = 0; $j < count($assessmentItemRefs); $j++) {
                 $itemNum = $j + 1 + ($itemCount * $i);
-                $route->addRouteItem($assessmentItemRefs["Q${itemNum}"], $assessmentSections["S${partNum}"], $testParts["T${partNum}"], $assessmentTest);
+                $route->addRouteItem($assessmentItemRefs["Q{$itemNum}"], $assessmentSections["S{$partNum}"], $testParts["T{$partNum}"], $assessmentTest);
             }
         }
 

--- a/test/qtismtest/data/QtiComponentIteratorTest.php
+++ b/test/qtismtest/data/QtiComponentIteratorTest.php
@@ -143,13 +143,13 @@ class QtiComponentIteratorTest extends QtiSmTestCase
         $dir = self::samplesDir();
 
         return [
-            ["${dir}custom/runtime/itemsubset.xml", 7, ['responseProcessing']],
-            ["${dir}custom/runtime/itemsubset.xml", 1, ['testPart']],
-            ["${dir}custom/runtime/itemsubset.xml", 3, ['assessmentSection']],
-            ["${dir}custom/runtime/itemsubset.xml", 11, ['responseProcessing', 'testPart', 'assessmentSection']],
-            ["${dir}custom/runtime/itemsubset.xml", 15, ['outcomeDeclaration']],
-            ["${dir}custom/runtime/itemsubset.xml", 0, ['x']],
-            ["${dir}custom/runtime/itemsubset.xml", 0, ['x', 'y']],
+            ["{$dir}custom/runtime/itemsubset.xml", 7, ['responseProcessing']],
+            ["{$dir}custom/runtime/itemsubset.xml", 1, ['testPart']],
+            ["{$dir}custom/runtime/itemsubset.xml", 3, ['assessmentSection']],
+            ["{$dir}custom/runtime/itemsubset.xml", 11, ['responseProcessing', 'testPart', 'assessmentSection']],
+            ["{$dir}custom/runtime/itemsubset.xml", 15, ['outcomeDeclaration']],
+            ["{$dir}custom/runtime/itemsubset.xml", 0, ['x']],
+            ["{$dir}custom/runtime/itemsubset.xml", 0, ['x', 'y']],
         ];
     }
 }

--- a/test/qtismtest/data/content/BodyElementTest.php
+++ b/test/qtismtest/data/content/BodyElementTest.php
@@ -121,7 +121,7 @@ class BodyElementTest extends QtiSmTestCase
             ['custom-text-box '],
             [''],
             [' '],
-            // todo: check that it's intended to be that permissive. 
+            // todo: check that it's intended to be that permissive.
             ['   e v e n   that kind of things */4231\'"("        -(&é(   '],
         ];
     }
@@ -385,7 +385,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaControlsAttributes($value): void
     {
-        $msg = "'${value}' is not a valid value for attribute 'aria-controls'.";
+        $msg = "'{$value}' is not a valid value for attribute 'aria-controls'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);
@@ -410,7 +410,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaDescribedByAttributes($value): void
     {
-        $msg = "'${value}' is not a valid value for attribute 'aria-describedby'.";
+        $msg = "'{$value}' is not a valid value for attribute 'aria-describedby'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);
@@ -435,7 +435,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaFlowToAttributes($value): void
     {
-        $msg = "'${value}' is not a valid value for attribute 'aria-flowto'.";
+        $msg = "'{$value}' is not a valid value for attribute 'aria-flowto'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);
@@ -460,7 +460,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaLabelledByAttributes($value): void
     {
-        $msg = "'${value}' is not a valid value for attribute 'aria-labelledby'.";
+        $msg = "'{$value}' is not a valid value for attribute 'aria-labelledby'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);
@@ -485,7 +485,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaOwnsAttributes($value): void
     {
-        $msg = "'${value}' is not a valid value for attribute 'aria-owns'.";
+        $msg = "'{$value}' is not a valid value for attribute 'aria-owns'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);
@@ -510,7 +510,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaLevelAttributes(string $value): void
     {
-        $msg = "'${value}' is not a valid value for attribute 'aria-level'.";
+        $msg = "'{$value}' is not a valid value for attribute 'aria-level'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);
@@ -532,7 +532,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaLiveAttributes($value): void
     {
-        $msg = "'${value}' is not a valid value for attribute 'aria-live'.";
+        $msg = "'{$value}' is not a valid value for attribute 'aria-live'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);
@@ -559,7 +559,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaOrientationAttributes($value, $msg = null): void
     {
-        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-orientation'.";
+        $msg = $msg ?? "'{$value}' is not a valid value for attribute 'aria-orientation'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);
@@ -588,7 +588,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaLabelAttributes($value, $msg = null): void
     {
-        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-label'.";
+        $msg = $msg ?? "'{$value}' is not a valid value for attribute 'aria-label'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);
@@ -619,7 +619,7 @@ class BodyElementTest extends QtiSmTestCase
      */
     public function testInvalidAriaHiddenAttributes($value, $msg = null): void
     {
-        $msg = $msg ?? "'${value}' is not a valid value for attribute 'aria-hidden'.";
+        $msg = $msg ?? "'{$value}' is not a valid value for attribute 'aria-hidden'.";
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($msg);

--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -330,7 +330,7 @@ class XmlDocumentTest extends QtiSmTestCase
         // This path does not resolve anything.
         $path = self::samplesDir() . 'invalid/unknown.xml';
 
-        $expectedMsg = "Cannot load QTI file at path '${path}'. It does not exist or is not readable.";
+        $expectedMsg = "Cannot load QTI file at path '{$path}'. It does not exist or is not readable.";
         $this->expectException(XmlStorageException::class);
         $this->expectExceptionMessage($expectedMsg);
         $this->expectExceptionCode(XmlStorageException::RESOLUTION);
@@ -445,7 +445,7 @@ class XmlDocumentTest extends QtiSmTestCase
             <sum>
                 <subtract>
                     <mathConstant name="pi"/>
-                    <mathConstant name="pi"/>            
+                    <mathConstant name="pi"/>
                 </subtract>
             </sum>');
 
@@ -481,7 +481,7 @@ class XmlDocumentTest extends QtiSmTestCase
         $doc = new XmlDocument('2.2.0');
         $doc->loadFromString('
             <div>
-                <bdo dir="rtl">I am reversed!</bdo>            
+                <bdo dir="rtl">I am reversed!</bdo>
             </div>');
 
         // This should fail because in QTI 2.2.0 because <bdo> does not exist.
@@ -504,7 +504,7 @@ class XmlDocumentTest extends QtiSmTestCase
         $doc = new XmlDocument('2.0.0');
         $doc->loadFromString('
             <div>
-                <bdo dir="rtl">I am reversed!</bdo>            
+                <bdo dir="rtl">I am reversed!</bdo>
             </div>');
     }
 
@@ -626,7 +626,7 @@ class XmlDocumentTest extends QtiSmTestCase
         $path = 'invalid/unknown.xml';
 
         $this->expectException(XmlStorageException::class);
-        $this->expectExceptionMessage("Cannot load QTI file at path '${path}'. It does not exist or is not readable.");
+        $this->expectExceptionMessage("Cannot load QTI file at path '{$path}'. It does not exist or is not readable.");
 
         $doc->load($path);
     }

--- a/test/qtismtest/runtime/expressions/operators/custom/org/qtism/test/Explode.php
+++ b/test/qtismtest/runtime/expressions/operators/custom/org/qtism/test/Explode.php
@@ -25,7 +25,7 @@ class Explode extends CustomOperatorProcessor
             $msg = "The 'org.qtism.test.Explode' custom operator implementation requires 1 operand. None given.";
             throw new OperatorProcessingException($msg, $this, OperatorProcessingException::NOT_ENOUGH_OPERANDS);
         } elseif ($count > 1) {
-            $msg = "The 'org.qtism.test.Explode' custom operator implementation requires 1 operand. ${count} given.";
+            $msg = "The 'org.qtism.test.Explode' custom operator implementation requires 1 operand. {$count} given.";
             throw new OperatorProcessingException($msg, $this, OperatorProcessingException::TOO_MUCH_OPERANDS);
         } else {
             parent::setOperands($operands);

--- a/test/qtismtest/runtime/tests/AssessmentItemSessionTimingTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentItemSessionTimingTest.php
@@ -325,7 +325,7 @@ class AssessmentItemSessionTimingTest extends QtiSmAssessmentItemTestCase
 
             // simulate some time... 1 second to answer the item.
             $t = $i + 1;
-            $itemSession->setTime(self::createDate("2014-07-14 13:00:0${t}"));
+            $itemSession->setTime(self::createDate("2014-07-14 13:00:0{$t}"));
 
             $itemSession['RESPONSE'] = $attempts[$i];
             $itemSession->endAttempt();

--- a/test/qtismtest/runtime/tests/AssessmentTestSessionTest.php
+++ b/test/qtismtest/runtime/tests/AssessmentTestSessionTest.php
@@ -108,8 +108,8 @@ class AssessmentTestSessionTest extends QtiSmAssessmentTestSessionTestCase
         $assessmentTestSession->beginTestSession();
         // check Q01.1, Q01.2, Q01.3 item sessions are all initialized.
         for ($i = 1; $i <= 3; $i++) {
-            $score = $assessmentTestSession["Q01.${i}.SCORE"];
-            $response = $assessmentTestSession["Q01.${i}.RESPONSE"];
+            $score = $assessmentTestSession["Q01.{$i}.SCORE"];
+            $response = $assessmentTestSession["Q01.{$i}.RESPONSE"];
             $this::assertNull($response);
             $this::assertInstanceOf(QtiFloat::class, $score);
             $this::assertEquals(0.0, $score->getValue());

--- a/test/samples/custom/php/gen.php
+++ b/test/samples/custom/php/gen.php
@@ -7,10 +7,10 @@ use qtism\data\storage\xml\XmlCompactDocument;
 
 $test = $argv[1];
 
-$xmlFile = __DIR__ . "/../runtime/${test}.xml";
+$xmlFile = __DIR__ . "/../runtime/{$test}.xml";
 $xmlDoc = new XmlCompactDocument();
 $xmlDoc->load($xmlFile);
 
 $phpDoc = new PhpDocument();
 $phpDoc->setDocumentComponent($xmlDoc->getDocumentComponent());
-$phpDoc->save("${test}.php");
+$phpDoc->save("{$test}.php");

--- a/test/scripts/BasicTestSessionSpeed.php
+++ b/test/scripts/BasicTestSessionSpeed.php
@@ -266,4 +266,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed10.php
+++ b/test/scripts/BasicTestSessionSpeed10.php
@@ -369,4 +369,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed15.php
+++ b/test/scripts/BasicTestSessionSpeed15.php
@@ -452,4 +452,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed20.php
+++ b/test/scripts/BasicTestSessionSpeed20.php
@@ -539,4 +539,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed25.php
+++ b/test/scripts/BasicTestSessionSpeed25.php
@@ -624,4 +624,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed30.php
+++ b/test/scripts/BasicTestSessionSpeed30.php
@@ -709,4 +709,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed35.php
+++ b/test/scripts/BasicTestSessionSpeed35.php
@@ -795,4 +795,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed40.php
+++ b/test/scripts/BasicTestSessionSpeed40.php
@@ -879,4 +879,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed5.php
+++ b/test/scripts/BasicTestSessionSpeed5.php
@@ -284,4 +284,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed50.php
+++ b/test/scripts/BasicTestSessionSpeed50.php
@@ -1060,4 +1060,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/BasicTestSessionSpeed60.php
+++ b/test/scripts/BasicTestSessionSpeed60.php
@@ -1240,4 +1240,4 @@ echo 'Persist average time = ' . (array_sum($averagePersist) / count($averagePer
 echo 'MoveNext average time = ' . (array_sum($averageNext) / count($averageNext)) . "\n";
 echo 'Load average time = ' . (array_sum($averageLoad) / count($averageLoad)) . "\n";
 echo 'Neighbourhood average time = ' . (array_sum($averageNeighbourhood) / count($averageNeighbourhood)) . "\n";
-echo "Number correct = ${numberCorrect}\n";
+echo "Number correct = {$numberCorrect}\n";

--- a/test/scripts/SelectionSingleSection.php
+++ b/test/scripts/SelectionSingleSection.php
@@ -17,7 +17,7 @@ $sectionsDistribution = [];
 for ($i = 0; $i < $iterations; $i++) {
     $manager = new SessionManager(new FileSystemFileManager());
 
-    echo "Taking test ${i}...\n";
+    echo "Taking test {$i}...\n";
     $sections = [];
 
     $session = $manager->createAssessmentTestSession($doc->getDocumentComponent());
@@ -46,5 +46,5 @@ ksort($sectionsDistribution);
 echo "\nDistribution:\n";
 
 foreach ($sectionsDistribution as $section => $dist) {
-    echo "${section}: ${dist}\n";
+    echo "{$section}: {$dist}\n";
 }

--- a/test/scripts/XmlLoadSpeed.php
+++ b/test/scripts/XmlLoadSpeed.php
@@ -29,7 +29,7 @@ function testAssessmentItems(array $files, $validate = false): void
         $outcomeDeclarationCount = count($itemDoc->getDocumentComponent()->getComponentsByClassName('outcomeDeclaration'));
         $responseDeclarationCount = count($itemDoc->getDocumentComponent()->getComponentsByClassName('responseDeclaration'));
 
-        outputDescription("${responseDeclarationCount} resonseDeclaration(s), ${outcomeDeclarationCount} outcomeDeclaration(s)");
+        outputDescription("{$responseDeclarationCount} resonseDeclaration(s), {$outcomeDeclarationCount} outcomeDeclaration(s)");
         outputDescription('Memory usage is ' . (memory_get_usage() / 1024 ** 2) . ' MB');
         output('');
 
@@ -64,7 +64,7 @@ function testAssessmentTests(array $files, $validate = false): void
         $sectionCount = count($testDoc->getDocumentComponent()->getComponentsByClassName('assessmentSection'));
         $itemCount = count($testDoc->getDocumentComponent()->getComponentsByClassName('assessmentItemRef'));
 
-        outputDescription("${partCount} testPart(s), ${sectionCount} assessmentSection(s), ${itemCount} assessmentItemRef(s)");
+        outputDescription("{$partCount} testPart(s), {$sectionCount} assessmentSection(s), {$itemCount} assessmentItemRef(s)");
         outputDescription('Memory usage is ' . (memory_get_usage() / 1024 ** 2) . ' MB');
 
         output('');
@@ -99,7 +99,7 @@ function outputAverage($avg): void
  */
 function outputDescription($msg): void
 {
-    output(" + ${msg}");
+    output(" + {$msg}");
 }
 
 /**
@@ -107,7 +107,7 @@ function outputDescription($msg): void
  */
 function output($msg): void
 {
-    echo "${msg}\n";
+    echo "{$msg}\n";
 }
 
 /**

--- a/test/scripts/XmlVsPhpResponseProcessing.php
+++ b/test/scripts/XmlVsPhpResponseProcessing.php
@@ -61,5 +61,5 @@ foreach ($templates as $t) {
     }
     $meanPhp = $meanPhp / $iterations;
 
-    echo "+ ${t} (XML = ${meanXml} - PHP ${meanPhp})\n";
+    echo "+ {$t} (XML = {$meanXml} - PHP {$meanPhp})\n";
 }


### PR DESCRIPTION
# [TR-5755](https://oat-sa.atlassian.net/browse/TR-5755)

## Deprecations
```
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/vendor/qtism/qtism/src/qtism/data/content/BodyElement.php on line 441
Deprecated: Creation of dynamic property qtism\runtime\storage\binary\BinaryAssessmentTestSeeker::$componentsStore is deprecated
```

## Related PRs
* https://github.com/oat-sa/tao-deliver-be/pull/1190

[TR-5755]: https://oat-sa.atlassian.net/browse/TR-5755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ