### PR TITLE
fix: not validate maxWords for XHTML extendTextInteractions

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '7.4', '8.0', '8.1']
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3']
 
     steps:
       - uses: actions/checkout@v3

--- a/src/qtism/data/content/interactions/ExtendedTextInteraction.php
+++ b/src/qtism/data/content/interactions/ExtendedTextInteraction.php
@@ -162,6 +162,9 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     private $format = TextFormat::PLAIN;
 
+    // This option disable also validation for patternMask
+    private $isDisabledMaxWordValidation = false;
+
     /**
      * Create a new ExtendedTextInteraction object.
      *
@@ -313,7 +316,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function getPatternMask(): string
     {
-        return $this->patternMask;
+        return !$this->isDisabledMaxWordValidation() ? $this->patternMask : '';
     }
 
     /**
@@ -323,7 +326,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function hasPatternMask(): bool
     {
-        return $this->getPatternMask() !== '';
+        return !$this->isDisabledMaxWordValidation() && $this->getPatternMask() !== '';
     }
 
     /**
@@ -389,7 +392,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function getMaxStrings(): int
     {
-        return $this->maxStrings;
+        return !$this->isDisabledMaxWordValidation() ? $this->maxStrings : -1;
     }
 
     /**
@@ -399,7 +402,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function hasMaxStrings(): bool
     {
-        return $this->getMaxStrings() !== -1;
+        return !$this->isDisabledMaxWordValidation() && $this->getMaxStrings() !== -1;
     }
 
     /**
@@ -505,7 +508,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
             $this->getResponseIdentifier(),
             $this->getMinStrings(),
             ($this->hasMaxStrings() === false) ? 0 : $this->getMaxStrings(),
-            $this->getPatternMask()
+            ($this->isDisabledMaxWordValidation() == false) ? $this->getPatternMask() : '',
         );
     }
 
@@ -523,5 +526,23 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     public function getQtiClassName(): string
     {
         return 'extendedTextInteraction';
+    }
+
+    /**
+     *  This option disable also validation for patternMask
+    */
+    public function isDisabledMaxWordValidation(): bool
+    {
+        return $this->isDisabledMaxWordValidation;
+    }
+
+    public function setIsDisabledMaxWordValidation(bool $isDisabledMaxWordValidation): void
+    {
+        $this->isDisabledMaxWordValidation = $isDisabledMaxWordValidation;
+    }
+
+    public function disabledMaxWordValidation(): void
+    {
+        $this->setIsDisabledMaxWordValidation(true);
     }
 }

--- a/src/qtism/data/content/interactions/ExtendedTextInteraction.php
+++ b/src/qtism/data/content/interactions/ExtendedTextInteraction.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -19,7 +17,7 @@ declare(strict_types=1);
  *
  * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
- * @author  Jérôme Bogaerts <jerome@taotesting.com>
+ * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2
  */
 
@@ -49,7 +47,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * If the string interaction is bound to a numeric response variable then the base attribute
      * must be used to set the number base in which to interpret the value entered by the candidate.
      *
-     * @var                 int
+     * @var int
      * @qtism-bean-property
      */
     private $base = 10;
@@ -61,7 +59,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * entered by the candidate can also be captured by binding the interaction to a second
      * response variable (of base-type string).
      *
-     * @var                 string
+     * @var string
      * @qtism-bean-property
      */
     private $stringIdentifier = '';
@@ -74,7 +72,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * use the value of this attribute to set the size of the response box, where applicable.
      * This is not a validity constraint.
      *
-     * @var                 int|null
+     * @var int|null
      * @qtism-bean-property
      */
     private $expectedLength;
@@ -89,7 +87,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * responses is required for progression through a test. This could be done by providing
      * an illustrative sample response in the prompt, for example.
      *
-     * @var                 string
+     * @var string
      * @qtism-bean-property
      */
     private $patternMask = '';
@@ -104,7 +102,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * default placeholder text when this is required. Implementors should be aware of the
      * issues concerning the use of default values described in the section on Response Variables.
      *
-     * @var                 string
+     * @var string
      * @qtism-bean-property
      */
     private $placeholderText = '';
@@ -117,7 +115,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * to control the maximum number of separate strings accepted from the candidate. When
      * multiple strings are accepted, expectedLength applies to each string.
      *
-     * @var                 int
+     * @var int
      * @qtism-bean-property
      */
     private $maxStrings = -1;
@@ -133,7 +131,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * non-empty string to form a valid response. More complex constraints on the form of
      * the string can be controlled with the patternMask attribute.
      *
-     * @var                 int
+     * @var int
      * @qtism-bean-property
      */
     private $minStrings = 0;
@@ -146,7 +144,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Engine should use the value of this attribute to set the size of the response box,
      * where applicable. This is not a validity constraint.
      *
-     * @var                 int|null
+     * @var int|null
      * @qtism-bean-property
      */
     private $expectedLines;
@@ -159,7 +157,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * interpreted by response processing engines and also controls the way it should be
      * captured in the delivery engine.
      *
-     * @var                 int
+     * @var int
      * @qtism-bean-property
      */
     private $format = TextFormat::PLAIN;
@@ -167,11 +165,11 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     /**
      * Create a new ExtendedTextInteraction object.
      *
-     * @param  string $responseIdentifier The identifier of the associated response variable.
-     * @param  string $id                 The id of the bodyElement.
-     * @param  string $class              The class of the bodyElement.
-     * @param  string $lang               The lang of the bodyElement.
-     * @param  string $label              The label of the bodyElement.
+     * @param string $responseIdentifier The identifier of the associated response variable.
+     * @param string $id The id of the bodyElement.
+     * @param string $class The class of the bodyElement.
+     * @param string $lang The lang of the bodyElement.
+     * @param string $label The label of the bodyElement.
      * @throws InvalidArgumentException If any of the arguments is invalid.
      */
     public function __construct($responseIdentifier, $id = '', $class = '', $lang = '', $label = '')
@@ -183,7 +181,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * If the interaction is bound to a numeric response variable, get the number base in which
      * to interpret the value entered by the candidate.
      *
-     * @param  int $base A positive (>= 0) integer.
+     * @param int $base A positive (>= 0) integer.
      * @throws InvalidArgumentException If $base is not a positive integer.
      */
     public function setBase($base): void
@@ -212,7 +210,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * plain text entered by the candidate will be stored. If $stringIdentifier is an empty string, it means that
      * there is no value for the stringIdentifier attribute.
      *
-     * @param  string $stringIdentifier A QTI Identifier or an empty string.
+     * @param string $stringIdentifier A QTI Identifier or an empty string.
      * @throws InvalidArgumentException If $stringIdentifier is not a valid QTIIdentifier nor an empty string.
      */
     public function setStringIdentifier($stringIdentifier): void
@@ -251,7 +249,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Set the hint to the candidate about the expected overall length of its
      * response. A null value unsets expectedLength.
      *
-     * @param  int|null $expectedLength A non-negative integer (>= 0) or null to unset expectedLength.
+     * @param int|null $expectedLength A non-negative integer (>= 0) or null to unset expectedLength.
      * @throws InvalidArgumentException If $expectedLength is not a non-negative integer nor null.
      */
     public function setExpectedLength($expectedLength): void
@@ -293,7 +291,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Set the pattern mask specifying an XML Schema 2 regular expression that the candidate response must
      * match with. If $patternMask is an empty string, it means that there is no value defined for patternMask.
      *
-     * @param  string $patternMask An XML Schema 2 regular expression or an empty string.
+     * @param string $patternMask An XML Schema 2 regular expression or an empty string.
      * @throws InvalidArgumentException If $patternMask is not a string value.
      */
     public function setPatternMask($patternMask): void
@@ -332,7 +330,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Set a placeholder text. If $placeholderText is an empty string, it means that no value is defined
      * for the placeholderText attribute.
      *
-     * @param  string $placeholderText A placeholder text or an empty string.
+     * @param string $placeholderText A placeholder text or an empty string.
      * @throws InvalidArgumentException If $placeholderText is not a string value.
      */
     public function setPlaceholderText($placeholderText): void
@@ -370,7 +368,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * If the interaction is bound to a numeric response variable, get the number of separate strings
      * accepted from the candidate. If $maxStrings is -1, it means no value is defined for the attribute.
      *
-     * @param  int $maxStrings A strictly positive (> 0) integer or -1.
+     * @param int $maxStrings A strictly positive (> 0) integer or -1.
      * @throws InvalidArgumentException If $maxStrings is not a strictly positive integer nor -1.
      */
     public function setMaxStrings($maxStrings): void
@@ -407,7 +405,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     /**
      * Set the minimum separate (non-empty) strings required from the candidate.
      *
-     * @param  string $minStrings A positive (>= 0) integer.
+     * @param string $minStrings A positive (>= 0) integer.
      * @throws InvalidArgumentException If $minStrings is not a positive integer.
      */
     public function setMinStrings($minStrings): void
@@ -434,7 +432,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Set the hint to the candidate about the expected number of lines of its
      * response. A null value unsets expectedLines.
      *
-     * @param  int|null $expectedLines A non-negative integer (>= 0) or null.
+     * @param int|null $expectedLines A non-negative integer (>= 0) or null.
      * @throws InvalidArgumentException If $expectedLines is not a non-negative integer nor null.
      */
     public function setExpectedLines($expectedLines): void
@@ -475,7 +473,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     /**
      * Set the format of the text entered by the candidate.
      *
-     * @param  int $format A value from the TextFormat enumeration.
+     * @param int $format A value from the TextFormat enumeration.
      * @throws InvalidArgumentException If $format is not a value from the TextFormat enumeration.
      */
     public function setFormat($format): void

--- a/src/qtism/data/content/interactions/ExtendedTextInteraction.php
+++ b/src/qtism/data/content/interactions/ExtendedTextInteraction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -17,7 +19,7 @@
  *
  * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
- * @author Jérôme Bogaerts <jerome@taotesting.com>
+ * @author  Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2
  */
 
@@ -47,7 +49,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * If the string interaction is bound to a numeric response variable then the base attribute
      * must be used to set the number base in which to interpret the value entered by the candidate.
      *
-     * @var int
+     * @var                 int
      * @qtism-bean-property
      */
     private $base = 10;
@@ -59,7 +61,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * entered by the candidate can also be captured by binding the interaction to a second
      * response variable (of base-type string).
      *
-     * @var string
+     * @var                 string
      * @qtism-bean-property
      */
     private $stringIdentifier = '';
@@ -72,7 +74,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * use the value of this attribute to set the size of the response box, where applicable.
      * This is not a validity constraint.
      *
-     * @var int|null
+     * @var                 int|null
      * @qtism-bean-property
      */
     private $expectedLength;
@@ -87,7 +89,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * responses is required for progression through a test. This could be done by providing
      * an illustrative sample response in the prompt, for example.
      *
-     * @var string
+     * @var                 string
      * @qtism-bean-property
      */
     private $patternMask = '';
@@ -102,7 +104,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * default placeholder text when this is required. Implementors should be aware of the
      * issues concerning the use of default values described in the section on Response Variables.
      *
-     * @var string
+     * @var                 string
      * @qtism-bean-property
      */
     private $placeholderText = '';
@@ -115,7 +117,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * to control the maximum number of separate strings accepted from the candidate. When
      * multiple strings are accepted, expectedLength applies to each string.
      *
-     * @var int
+     * @var                 int
      * @qtism-bean-property
      */
     private $maxStrings = -1;
@@ -131,7 +133,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * non-empty string to form a valid response. More complex constraints on the form of
      * the string can be controlled with the patternMask attribute.
      *
-     * @var int
+     * @var                 int
      * @qtism-bean-property
      */
     private $minStrings = 0;
@@ -144,7 +146,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Engine should use the value of this attribute to set the size of the response box,
      * where applicable. This is not a validity constraint.
      *
-     * @var int|null
+     * @var                 int|null
      * @qtism-bean-property
      */
     private $expectedLines;
@@ -157,22 +159,19 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * interpreted by response processing engines and also controls the way it should be
      * captured in the delivery engine.
      *
-     * @var int
+     * @var                 int
      * @qtism-bean-property
      */
     private $format = TextFormat::PLAIN;
 
-    // This option disable also validation for patternMask
-    private $isDisabledMaxWordValidation = false;
-
     /**
      * Create a new ExtendedTextInteraction object.
      *
-     * @param string $responseIdentifier The identifier of the associated response variable.
-     * @param string $id The id of the bodyElement.
-     * @param string $class The class of the bodyElement.
-     * @param string $lang The lang of the bodyElement.
-     * @param string $label The label of the bodyElement.
+     * @param  string $responseIdentifier The identifier of the associated response variable.
+     * @param  string $id                 The id of the bodyElement.
+     * @param  string $class              The class of the bodyElement.
+     * @param  string $lang               The lang of the bodyElement.
+     * @param  string $label              The label of the bodyElement.
      * @throws InvalidArgumentException If any of the arguments is invalid.
      */
     public function __construct($responseIdentifier, $id = '', $class = '', $lang = '', $label = '')
@@ -184,7 +183,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * If the interaction is bound to a numeric response variable, get the number base in which
      * to interpret the value entered by the candidate.
      *
-     * @param int $base A positive (>= 0) integer.
+     * @param  int $base A positive (>= 0) integer.
      * @throws InvalidArgumentException If $base is not a positive integer.
      */
     public function setBase($base): void
@@ -213,7 +212,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * plain text entered by the candidate will be stored. If $stringIdentifier is an empty string, it means that
      * there is no value for the stringIdentifier attribute.
      *
-     * @param string $stringIdentifier A QTI Identifier or an empty string.
+     * @param  string $stringIdentifier A QTI Identifier or an empty string.
      * @throws InvalidArgumentException If $stringIdentifier is not a valid QTIIdentifier nor an empty string.
      */
     public function setStringIdentifier($stringIdentifier): void
@@ -252,7 +251,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Set the hint to the candidate about the expected overall length of its
      * response. A null value unsets expectedLength.
      *
-     * @param int|null $expectedLength A non-negative integer (>= 0) or null to unset expectedLength.
+     * @param  int|null $expectedLength A non-negative integer (>= 0) or null to unset expectedLength.
      * @throws InvalidArgumentException If $expectedLength is not a non-negative integer nor null.
      */
     public function setExpectedLength($expectedLength): void
@@ -294,7 +293,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Set the pattern mask specifying an XML Schema 2 regular expression that the candidate response must
      * match with. If $patternMask is an empty string, it means that there is no value defined for patternMask.
      *
-     * @param string $patternMask An XML Schema 2 regular expression or an empty string.
+     * @param  string $patternMask An XML Schema 2 regular expression or an empty string.
      * @throws InvalidArgumentException If $patternMask is not a string value.
      */
     public function setPatternMask($patternMask): void
@@ -333,7 +332,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Set a placeholder text. If $placeholderText is an empty string, it means that no value is defined
      * for the placeholderText attribute.
      *
-     * @param string $placeholderText A placeholder text or an empty string.
+     * @param  string $placeholderText A placeholder text or an empty string.
      * @throws InvalidArgumentException If $placeholderText is not a string value.
      */
     public function setPlaceholderText($placeholderText): void
@@ -371,7 +370,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * If the interaction is bound to a numeric response variable, get the number of separate strings
      * accepted from the candidate. If $maxStrings is -1, it means no value is defined for the attribute.
      *
-     * @param int $maxStrings A strictly positive (> 0) integer or -1.
+     * @param  int $maxStrings A strictly positive (> 0) integer or -1.
      * @throws InvalidArgumentException If $maxStrings is not a strictly positive integer nor -1.
      */
     public function setMaxStrings($maxStrings): void
@@ -408,7 +407,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     /**
      * Set the minimum separate (non-empty) strings required from the candidate.
      *
-     * @param string $minStrings A positive (>= 0) integer.
+     * @param  string $minStrings A positive (>= 0) integer.
      * @throws InvalidArgumentException If $minStrings is not a positive integer.
      */
     public function setMinStrings($minStrings): void
@@ -435,7 +434,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      * Set the hint to the candidate about the expected number of lines of its
      * response. A null value unsets expectedLines.
      *
-     * @param int|null $expectedLines A non-negative integer (>= 0) or null.
+     * @param  int|null $expectedLines A non-negative integer (>= 0) or null.
      * @throws InvalidArgumentException If $expectedLines is not a non-negative integer nor null.
      */
     public function setExpectedLines($expectedLines): void
@@ -476,7 +475,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     /**
      * Set the format of the text entered by the candidate.
      *
-     * @param int $format A value from the TextFormat enumeration.
+     * @param  int $format A value from the TextFormat enumeration.
      * @throws InvalidArgumentException If $format is not a value from the TextFormat enumeration.
      */
     public function setFormat($format): void

--- a/src/qtism/data/content/interactions/ExtendedTextInteraction.php
+++ b/src/qtism/data/content/interactions/ExtendedTextInteraction.php
@@ -316,7 +316,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function getPatternMask(): string
     {
-        return !$this->isDisabledMaxWordValidation() ? $this->patternMask : '';
+        return $this->patternMask;
     }
 
     /**
@@ -326,7 +326,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function hasPatternMask(): bool
     {
-        return !$this->isDisabledMaxWordValidation() && $this->getPatternMask() !== '';
+        return $this->getPatternMask() !== '';
     }
 
     /**
@@ -392,7 +392,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function getMaxStrings(): int
     {
-        return !$this->isDisabledMaxWordValidation() ? $this->maxStrings : -1;
+        return $this->maxStrings;
     }
 
     /**
@@ -402,7 +402,7 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
      */
     public function hasMaxStrings(): bool
     {
-        return !$this->isDisabledMaxWordValidation() && $this->getMaxStrings() !== -1;
+        return $this->getMaxStrings() !== -1;
     }
 
     /**
@@ -508,7 +508,13 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
             $this->getResponseIdentifier(),
             $this->getMinStrings(),
             ($this->hasMaxStrings() === false) ? 0 : $this->getMaxStrings(),
-            ($this->isDisabledMaxWordValidation() == false) ? $this->getPatternMask() : '',
+            $this->getPatternMask(),
+            [
+                'qtiClassName' => $this->getQtiClassName(),
+                'options' => [
+                    'format' => $this->getFormat(),
+                ],
+            ]
         );
     }
 
@@ -526,23 +532,5 @@ class ExtendedTextInteraction extends BlockInteraction implements StringInteract
     public function getQtiClassName(): string
     {
         return 'extendedTextInteraction';
-    }
-
-    /**
-     *  This option disable also validation for patternMask
-    */
-    public function isDisabledMaxWordValidation(): bool
-    {
-        return $this->isDisabledMaxWordValidation;
-    }
-
-    public function setIsDisabledMaxWordValidation(bool $isDisabledMaxWordValidation): void
-    {
-        $this->isDisabledMaxWordValidation = $isDisabledMaxWordValidation;
-    }
-
-    public function disabledMaxWordValidation(): void
-    {
-        $this->setIsDisabledMaxWordValidation(true);
     }
 }

--- a/src/qtism/data/state/ResponseValidityConstraint.php
+++ b/src/qtism/data/state/ResponseValidityConstraint.php
@@ -70,6 +70,11 @@ class ResponseValidityConstraint extends QtiComponent
     private $associationValidityConstraints;
 
     /**
+     *  Provide additional information about the ResponseValidityConstraint.
+     */
+    private $extraData = [];
+
+    /**
      * Create a new ResponseValidityConstraint object.
      *
      * If the $patternMask attribute is provided, it represent a constraint to be applied on all string
@@ -81,13 +86,14 @@ class ResponseValidityConstraint extends QtiComponent
      * @param string $patternMask (optional) A XML Schema regular expression.
      * @throws InvalidArgumentException If one or more of the arguments above are invalid.
      */
-    public function __construct($responseIdentifier, $minConstraint, $maxConstraint, $patternMask = '')
+    public function __construct($responseIdentifier, $minConstraint, $maxConstraint, $patternMask = '', $extraData = [])
     {
         $this->setResponseIdentifier($responseIdentifier);
         $this->setMinConstraint($minConstraint);
         $this->setMaxConstraint($maxConstraint);
         $this->setPatternMask($patternMask);
         $this->setAssociationValidityConstraints(new AssociationValidityConstraintCollection());
+        $this->setExtraData($extraData);
     }
 
     /**
@@ -277,5 +283,15 @@ class ResponseValidityConstraint extends QtiComponent
         return new QtiComponentCollection(
             $this->getAssociationValidityConstraints()->getArrayCopy()
         );
+    }
+
+    public function getExtraData()
+    {
+        return $this->extraData;
+    }
+
+    public function setExtraData($extraData)
+    {
+        $this->extraData = $extraData;
     }
 }

--- a/src/qtism/data/state/ResponseValidityConstraint.php
+++ b/src/qtism/data/state/ResponseValidityConstraint.php
@@ -66,24 +66,28 @@ class ResponseValidityConstraint extends QtiComponent
 
     /**
      * The collection of nested AssociationValidityConstraints objects.
+     *
+     * @var AssociationValidityConstraintCollection
      */
     private $associationValidityConstraints;
 
     /**
-     *  Provide additional information about the ResponseValidityConstraint.
+     * Metadata defined by @see \qtism\data\content\interactions\Interaction instantiating this ResponseValidityConstraint
      */
     private $extraData = [];
 
     /**
      * Create a new ResponseValidityConstraint object.
      *
-     * If the $patternMask attribute is provided, it represent a constraint to be applied on all string
+     * If the $patternMask attribute is provided, it represents a constraint to be applied on all string
      * values contained by the variable described in the $responseÏdentifier variable.
      *
      * @param string $responseIdentifier The identifier of the response the validity constraint applies to.
      * @param int $minConstraint The minimum cardinality the value to be set to the response must have.
      * @param int $maxConstraint The maximum cardinality the value to be set the response must have.
      * @param string $patternMask (optional) A XML Schema regular expression.
+     * @param array $extraData (optional) Metadata defined by the Interaction instantiating this ResponseValidityConstraint
+     *    @see \qtism\data\content\interactions\Interaction
      * @throws InvalidArgumentException If one or more of the arguments above are invalid.
      */
     public function __construct($responseIdentifier, $minConstraint, $maxConstraint, $patternMask = '', $extraData = [])
@@ -285,12 +289,12 @@ class ResponseValidityConstraint extends QtiComponent
         );
     }
 
-    public function getExtraData()
+    public function getExtraData(): array
     {
         return $this->extraData;
     }
 
-    public function setExtraData($extraData)
+    public function setExtraData(array $extraData)
     {
         $this->extraData = $extraData;
     }

--- a/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
@@ -85,6 +85,16 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
         $extendedTextInteraction->setPatternMask(true);
     }
 
+    public function testPatternMaskIgnoredForDisabledValidation(): void
+    {
+        $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
+        $extendedTextInteraction->setPatternMask('pattern');
+        $extendedTextInteraction->disabledMaxWordValidation();
+
+        $this->assertEmpty($extendedTextInteraction->getPatternMask());
+        $this->assertFalse($extendedTextInteraction->hasPatternMask());
+    }
+
     public function testSetPlaceholderTextWrongType(): void
     {
         $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
@@ -103,6 +113,16 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
         $this->expectExceptionMessage("The 'maxStrings' argument must be a strictly positive (> 0) integer or -1, 'boolean' given.");
 
         $extendedTextInteraction->setMaxStrings(true);
+    }
+
+    public function testMaxStringsIgnoredForDisableValidation(): void
+    {
+        $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
+        $extendedTextInteraction->setMaxStrings(10);
+        $extendedTextInteraction->disabledMaxWordValidation();
+
+        $this->assertEquals(-1, $extendedTextInteraction->getMaxStrings());
+        $this->assertFalse($extendedTextInteraction->hasMaxStrings());
     }
 
     public function testSetMinStringsWrongType(): void

--- a/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
+++ b/test/qtismtest/data/content/interactions/ExtendedTextInteractionTest.php
@@ -85,16 +85,6 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
         $extendedTextInteraction->setPatternMask(true);
     }
 
-    public function testPatternMaskIgnoredForDisabledValidation(): void
-    {
-        $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
-        $extendedTextInteraction->setPatternMask('pattern');
-        $extendedTextInteraction->disabledMaxWordValidation();
-
-        $this->assertEmpty($extendedTextInteraction->getPatternMask());
-        $this->assertFalse($extendedTextInteraction->hasPatternMask());
-    }
-
     public function testSetPlaceholderTextWrongType(): void
     {
         $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
@@ -113,16 +103,6 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
         $this->expectExceptionMessage("The 'maxStrings' argument must be a strictly positive (> 0) integer or -1, 'boolean' given.");
 
         $extendedTextInteraction->setMaxStrings(true);
-    }
-
-    public function testMaxStringsIgnoredForDisableValidation(): void
-    {
-        $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
-        $extendedTextInteraction->setMaxStrings(10);
-        $extendedTextInteraction->disabledMaxWordValidation();
-
-        $this->assertEquals(-1, $extendedTextInteraction->getMaxStrings());
-        $this->assertFalse($extendedTextInteraction->hasMaxStrings());
     }
 
     public function testSetMinStringsWrongType(): void
@@ -197,5 +177,11 @@ class ExtendedTextInteractionTest extends QtiSmTestCase
         $this->expectExceptionMessage("The 'format' argument must be a value from the TextFormat enumeration, 'integer' given.");
 
         $extendedTextInteraction->setFormat(999);
+    }
+
+    public function testExtraDataIsProvidedForValidityConstrains(): void
+    {
+        $extendedTextInteraction = new ExtendedTextInteraction('RESPONSE');
+        $this::assertNotEmpty($extendedTextInteraction->getResponseValidityConstraint()->getExtraData());
     }
 }

--- a/test/qtismtest/data/state/ResponseValidityConstraintTest.php
+++ b/test/qtismtest/data/state/ResponseValidityConstraintTest.php
@@ -100,6 +100,8 @@ class ResponseValidityConstraintTest extends QtiSmTestCase
     public function testExtraDataCouldBeProvidedToConstrain(): void
     {
         $responseValidityConstraint = new ResponseValidityConstraint('RESPONSE', 0, 0, ['qtiClassName' => 'test']);
-        $this::assertEquals(['qtiClassName' => 'test'], $responseValidityConstraint->getExtraData());
+        $extraData = $responseValidityConstraint->getExtraData();
+        $this->assertNotEmpty($extraData);
+        $this::assertEquals('test', $extraData['qtiClassName']);
     }
 }

--- a/test/qtismtest/data/state/ResponseValidityConstraintTest.php
+++ b/test/qtismtest/data/state/ResponseValidityConstraintTest.php
@@ -99,7 +99,7 @@ class ResponseValidityConstraintTest extends QtiSmTestCase
 
     public function testExtraDataCouldBeProvidedToConstrain(): void
     {
-        $responseValidityConstraint = new ResponseValidityConstraint('RESPONSE', 0, 0, ['qtiClassName' => 'test']);
+        $responseValidityConstraint = new ResponseValidityConstraint('RESPONSE', 0, 0, 'patternMask', ['qtiClassName' => 'test']);
         $extraData = $responseValidityConstraint->getExtraData();
         $this->assertNotEmpty($extraData);
         $this::assertEquals('test', $extraData['qtiClassName']);

--- a/test/qtismtest/data/state/ResponseValidityConstraintTest.php
+++ b/test/qtismtest/data/state/ResponseValidityConstraintTest.php
@@ -96,4 +96,10 @@ class ResponseValidityConstraintTest extends QtiSmTestCase
         $this::assertCount(1, $responseValidityConstraint->getAssociationValidityConstraints());
         $this::assertEquals('MYID', $responseValidityConstraint->getAssociationValidityConstraints()[0]->getIdentifier());
     }
+
+    public function testExtraDataCouldBeProvidedToConstrain(): void
+    {
+        $responseValidityConstraint = new ResponseValidityConstraint('RESPONSE', 0, 0, ['qtiClassName' => 'test']);
+        $this::assertEquals(['qtiClassName' => 'test'], $responseValidityConstraint->getExtraData());
+    }
 }


### PR DESCRIPTION
# Skip validation for ExtendTextINteraction [TR-6169](https://oat-sa.atlassian.net/browse/TR-6169)
https://oat-sa.atlassian.net/browse/TR-6169

## Description 
Skip validation for size on XHTML text 

## Related PRs
- https://github.com/oat-sa/tao-deliver-be/pull/1346

[TR-6169]: https://oat-sa.atlassian.net/browse/TR-6169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ