### PR TITLE
fix: add `fieldIdentifier` and `baseType` properties to the `Value` class when the value forms part of a record

### DIFF
--- a/src/qtism/runtime/common/Variable.php
+++ b/src/qtism/runtime/common/Variable.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2
@@ -563,10 +563,10 @@ abstract class Variable
                 break;
 
             case Cardinality::RECORD:
-                foreach ($this->getValue() as $v) {
+                foreach ($this->getValue() as $k => $v) {
                     $values[] = $v === null
-                        ? $this->createRecordNullValue()
-                        : $this->createRecordValue($v);
+                        ? $this->createRecordNullValue($k)
+                        : $this->createRecordValue($v, $k);
                 }
                 break;
         }
@@ -583,26 +583,23 @@ abstract class Variable
         return new Value($value instanceof QtiScalar ? $value->getValue() : $value);
     }
 
-    /**
-     * @param QtiDatatype $value
-     * @return Value
-     */
-    private function createRecordValue(QtiDatatype $value): Value
+    private function createRecordValue(QtiDatatype $qtiValue, string $fieldIdentifier): Value
     {
-        $value = $this->createValue($value);
+        $value = $this->createValue($qtiValue);
         $value->setPartOfRecord(true);
+        $value->setFieldIdentifier($fieldIdentifier);
+        $value->setBaseType($qtiValue->getBaseType());
         return $value;
     }
 
     /**
      * Creates a null value to fill a gap in a record set.
-     *
-     * @return Value
      */
-    private function createRecordNullValue(): Value
+    private function createRecordNullValue(string $fieldIdentifier): Value
     {
         $value = new Value(null);
         $value->setPartOfRecord(true);
+        $value->setFieldIdentifier($fieldIdentifier);
         return $value;
     }
 

--- a/test/qtismtest/runtime/common/ResponseVariableTest.php
+++ b/test/qtismtest/runtime/common/ResponseVariableTest.php
@@ -14,6 +14,7 @@ use qtism\common\enums\BaseType;
 use qtism\common\enums\Cardinality;
 use qtism\data\state\AreaMapping;
 use qtism\data\state\Mapping;
+use qtism\data\state\ResponseDeclaration;
 use qtism\runtime\common\MultipleContainer;
 use qtism\runtime\common\OrderedContainer;
 use qtism\runtime\common\RecordContainer;
@@ -54,6 +55,7 @@ class ResponseVariableTest extends QtiSmTestCase
 				</areaMapping>
 			</responseDeclaration>
 		');
+        /** @var ResponseDeclaration $responseDeclaration */
         $responseDeclaration = $factory->createMarshaller($element)->unmarshall($element);
         $responseVariable = ResponseVariable::createFromDataModel($responseDeclaration);
         $this::assertInstanceOf(ResponseVariable::class, $responseVariable);
@@ -126,12 +128,16 @@ class ResponseVariableTest extends QtiSmTestCase
 
         $this::assertCount(1, $values);
         $this::assertSame(10, $values[0]->getValue());
+        $this::assertSame('', $values[0]->getFieldIdentifier());
+        $this::assertSame(-1, $values[0]->getBaseType());
 
         $responseVariable = new ResponseVariable('MYVAR', Cardinality::SINGLE, BaseType::FLOAT, new QtiFloat(10.1));
         $values = $responseVariable->getDataModelValues();
 
         $this::assertCount(1, $values);
         $this::assertSame(10.1, $values[0]->getValue());
+        $this::assertSame('', $values[0]->getFieldIdentifier());
+        $this::assertSame(-1, $values[0]->getBaseType());
     }
 
     public function testGetNonScalarDataModelValuesSingleCardinality(): void
@@ -143,6 +149,8 @@ class ResponseVariableTest extends QtiSmTestCase
 
         $this::assertCount(1, $values);
         $this::assertTrue($qtiPair->equals($values[0]->getValue()));
+        $this::assertSame('', $values[0]->getFieldIdentifier());
+        $this::assertSame(-1, $values[0]->getBaseType());
 
         // QtiPoint
         $qtiPoint = new QtiPoint(1, 1);
@@ -151,6 +159,8 @@ class ResponseVariableTest extends QtiSmTestCase
 
         $this::assertCount(1, $values);
         $this::assertTrue($qtiPoint->equals($values[0]->getValue()));
+        $this::assertSame('', $values[0]->getFieldIdentifier());
+        $this::assertSame(-1, $values[0]->getBaseType());
 
         // QtiFile
         $fileManager = new FileSystemFileManager();
@@ -186,7 +196,11 @@ class ResponseVariableTest extends QtiSmTestCase
 
         $this::assertCount(2, $values);
         $this::assertEquals(10, $values[0]->getValue());
+        $this::assertSame('', $values[0]->getFieldIdentifier());
+        $this::assertSame(-1, $values[0]->getBaseType());
         $this::assertEquals(12, $values[1]->getValue());
+        $this::assertSame('', $values[1]->getFieldIdentifier());
+        $this::assertSame(-1, $values[1]->getBaseType());
     }
 
     public function testGetNonScalarDataModelValuesMultipleCardinality(): void
@@ -208,7 +222,11 @@ class ResponseVariableTest extends QtiSmTestCase
 
         $this::assertCount(2, $values);
         $this::assertTrue($qtiPair1->equals($values[0]->getValue()));
+        $this::assertSame('', $values[0]->getFieldIdentifier());
+        $this::assertSame(-1, $values[0]->getBaseType());
         $this::assertTrue($qtiPair2->equals($values[1]->getValue()));
+        $this::assertSame('', $values[1]->getFieldIdentifier());
+        $this::assertSame(-1, $values[1]->getBaseType());
 
         // QtiPoint
         $qtiPoint1 = new QtiPoint(0, 0);
@@ -227,7 +245,11 @@ class ResponseVariableTest extends QtiSmTestCase
 
         $this::assertCount(2, $values);
         $this::assertTrue($qtiPoint1->equals($values[0]->getValue()));
+        $this::assertSame('', $values[0]->getFieldIdentifier());
+        $this::assertSame(-1, $values[0]->getBaseType());
         $this::assertTrue($qtiPoint2->equals($values[1]->getValue()));
+        $this::assertSame('', $values[1]->getFieldIdentifier());
+        $this::assertSame(-1, $values[1]->getBaseType());
     }
 
     public function testGetDataModelValuesRecordCardinality(): void
@@ -251,9 +273,17 @@ class ResponseVariableTest extends QtiSmTestCase
 
         $this::assertCount(4, $values);
         $this::assertSame(12, $values[0]->getValue());
+        $this::assertSame('twelve', $values[0]->getFieldIdentifier());
+        $this::assertSame(BaseType::INTEGER, $values[0]->getBaseType());
         $this::assertSame('bar', $values[1]->getValue());
+        $this::assertSame('foo', $values[1]->getFieldIdentifier());
+        $this::assertSame(BaseType::STRING, $values[1]->getBaseType());
         $this::assertNull($values[2]->getValue());
+        $this::assertSame('null', $values[2]->getFieldIdentifier());
+        $this::assertSame(-1, $values[2]->getBaseType());
         $this::assertTrue($qtiPair->equals($values[3]->getValue()));
+        $this::assertSame('pair', $values[3]->getFieldIdentifier());
+        $this::assertSame(BaseType::PAIR, $values[3]->getBaseType());
     }
 
     public function testClone(): void


### PR DESCRIPTION
# [TR-5267](https://oat-sa.atlassian.net/browse/TR-5267)

This PR adds `fieldIdentifier` and `baseType` attributes to the `<value>` that is part of a record-typed `<candidateResponse>`

That's exactly what the 1EdTech specs prescribe to do [here](https://www.imsglobal.org/question/qtiv2p2p1/QTIv2p2-Results-InfoBindModelv1p0p1/imsqtiv2p2_result_v1p0_InfoBindv1p0p1.html#DerivedCharacteristic_Value.Attr_fieldIdentifier)

## How to test

1. Complete a test with a `record`-typed response variable
2. Generate the results.xml

## Results

|Before|After|
|-|-|
|<img width="771" alt="image" src="https://github.com/user-attachments/assets/697d09b8-273b-4078-8746-469176e4e05c">|<img width="771" alt="image" src="https://github.com/user-attachments/assets/00c8f7c9-f0ba-488c-9cd3-e75a797e832f">|


[TR-5267]: https://oat-sa.atlassian.net/browse/TR-5267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ