### PR TITLE
Fix/broken cli

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"league/flysystem": "^1.0|2.1.1|^3.0",
 		"league/mime-type-detection": "^1.0",
 		"oat-sa/lib-beeme": "0.2.0",
-		"wp-cli/php-cli-tools": "0.12.1"
+		"wp-cli/php-cli-tools": "0.11.22"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~9|~7",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"league/flysystem": "^1.0|2.1.1|^3.0",
 		"league/mime-type-detection": "^1.0",
 		"oat-sa/lib-beeme": "0.2.0",
-		"wp-cli/php-cli-tools": "0.10.3"
+		"wp-cli/php-cli-tools": "0.12.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~9|~7",

--- a/src/qtism/cli/Render.php
+++ b/src/qtism/cli/Render.php
@@ -33,6 +33,7 @@ use qtism\runtime\rendering\markup\AbstractMarkupRenderingEngine;
 use qtism\runtime\rendering\markup\goldilocks\GoldilocksRenderingEngine;
 use qtism\runtime\rendering\markup\xhtml\XhtmlRenderingEngine;
 use qtism\runtime\rendering\RenderingException;
+use qtism\data\storage\xml\filesystem\FilesystemFactory;
 
 /**
  * Render CLI Module.
@@ -167,10 +168,11 @@ class Render extends Cli
         // Load XML Document.
         $source = $arguments['source'];
         $doc = new XmlDocument();
+        $doc->setFileSystem(FilesystemFactory::local(getcwd()));
         $validate = !($arguments['novalidate'] === true);
 
         try {
-            $doc->load(realpath($source), $validate);
+            $doc->load($source, $validate);
 
             $renderingData = '';
 

--- a/src/qtism/cli/Render.php
+++ b/src/qtism/cli/Render.php
@@ -280,14 +280,14 @@ class Render extends Cli
                 $body = substr($body, 0, strlen('</div>') * -1);
                 $body = "<body {$body}</body>{$nl}";
             } else {
-                $body = $xml->saveXml($xml->documentElement) . {$nl};
+                $body = $xml->saveXml($xml->documentElement) . $nl;
             }
 
             if ($arguments['document'] === true) {
                 $footer = "</html>\n";
             }
         } else {
-            $body = $xml->saveXml($xml->documentElement) . {$nl};
+            $body = $xml->saveXml($xml->documentElement) . $nl;
         }
 
         // Indent body...
@@ -358,7 +358,7 @@ class Render extends Cli
             $footer .= "</html>\n";
         }
 
-        $body = $xml->saveXml($xml->documentElement) . {$nl};
+        $body = $xml->saveXml($xml->documentElement) . $nl;
 
         // Indent body...
         $indentBody = '';

--- a/src/qtism/cli/Render.php
+++ b/src/qtism/cli/Render.php
@@ -170,7 +170,7 @@ class Render extends Cli
         $validate = !($arguments['novalidate'] === true);
 
         try {
-            $doc->load($source, $validate);
+            $doc->load(realpath($source), $validate);
 
             $renderingData = '';
 


### PR DESCRIPTION
This PR aims at fixing the `render` command of the CLI. 

* It includes an update of library `wp-cli/php-cli-tools` to version `0.11.22`.
* It also include a fix for a previous change that made the `render` command broken.
* Makes possible to use relative paths as CLI argument.

In order to test, invoke from CLI the following command which should not return any error.

```
./bin/qtisdk render -df --source test/samples/ims/items/2_1_1/choice.xml --flavour goldilocks
```