### PR TITLE
fix: null-safe dereferencing of record-typed variables fields via the `<fieldValue>` operand

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -6,16 +6,23 @@ on:
   pull_request:
     branches: [ develop ]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ ubuntu-latest ]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        coverage: [ false ]
+        include:
+          - php-version: '8.4'
+            coverage: true
 
     steps:
       - uses: actions/checkout@v3
@@ -26,7 +33,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
@@ -35,7 +42,13 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run test suite
+        if: ${{ !matrix.coverage }}
+        run: vendor/bin/phpunit
+
+      - name: Run test suite with code coverage
+        if: ${{ matrix.coverage }}
         run: php -dxdebug.mode=coverage vendor/bin/phpunit --coverage-clover coverage.xml
 
       - name: Push coverage report
+        if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@v2

--- a/src/qtism/runtime/expressions/operators/FieldValueProcessor.php
+++ b/src/qtism/runtime/expressions/operators/FieldValueProcessor.php
@@ -24,6 +24,7 @@
 namespace qtism\runtime\expressions\operators;
 
 use qtism\data\expressions\operators\FieldValue;
+use qtism\runtime\common\RecordContainer;
 
 /**
  * The FieldValueProcessor class aims at processing FieldValue expressions.
@@ -45,16 +46,20 @@ class FieldValueProcessor extends OperatorProcessor
     #[\ReturnTypeWillChange]
     public function process()
     {
-        $operands = $this->getOperands();
+        $operand = $this->getOperands()[0];
 
-        if ($operands->exclusivelyRecord() === false) {
+        if ($operand === null) {
+            return null;
+        }
+
+        if (!$operand instanceof RecordContainer) {
             $msg = 'The FieldValue operator only accepts operands with a cardinality of record.';
             throw new OperatorProcessingException($msg, $this, OperatorProcessingException::WRONG_CARDINALITY);
         }
 
         $fieldIdentifier = $this->getExpression()->getFieldIdentifier();
 
-        return $operands[0][$fieldIdentifier];
+        return $operand[$fieldIdentifier];
     }
 
     /**

--- a/test/qtismtest/common/dom/SerializableDomDocumentTest.php
+++ b/test/qtismtest/common/dom/SerializableDomDocumentTest.php
@@ -81,7 +81,7 @@ class SerializableDomDocumentTest extends QtiSmTestCase
         $dom->$method();
     }
 
-    public function testCheckThatUnsetIsWorkingSimilarToRealDomObject(): void
+    public function testMagicMutatorsAndAccessors(): void
     {
         $serializableDOM = $this->getSerializableDomDocument();
         $coreDom = new DOMDocument($serializableDOM->xmlVersion, $serializableDOM->encoding);
@@ -89,11 +89,11 @@ class SerializableDomDocumentTest extends QtiSmTestCase
         $this->assertEquals($coreDom->xmlVersion, $serializableDOM->version);
         $this->assertEquals($coreDom->encoding, $serializableDOM->encoding);
 
-        unset($coreDom->xmlVersion);
-        unset($coreDom->encoding);
+        $coreDom->xmlVersion = null;
+        $coreDom->encoding = 'ASCII';
 
-        unset($serializableDOM->xmlVersion);
-        unset($serializableDOM->encoding);
+        $serializableDOM->xmlVersion = null;
+        $serializableDOM->encoding = 'ASCII';
 
         $this->assertEquals($coreDom->xmlVersion, $serializableDOM->version);
         $this->assertEquals($coreDom->encoding, $serializableDOM->encoding);

--- a/test/qtismtest/runtime/expressions/operators/FieldValueProcessorTest.php
+++ b/test/qtismtest/runtime/expressions/operators/FieldValueProcessorTest.php
@@ -5,6 +5,7 @@ namespace qtismtest\runtime\expressions\operators;
 use qtism\common\datatypes\QtiInteger;
 use qtism\common\datatypes\QtiPoint;
 use qtism\common\enums\BaseType;
+use qtism\data\expressions\Expression;
 use qtism\data\QtiComponent;
 use qtism\data\storage\xml\marshalling\MarshallerNotFoundException;
 use qtism\runtime\common\MultipleContainer;
@@ -24,7 +25,7 @@ class FieldValueProcessorTest extends QtiSmTestCase
         $expression = $this->createFakeExpression();
         $operands = new OperandsCollection();
         $this->expectException(ExpressionProcessingException::class);
-        $processor = new FieldValueProcessor($expression, $operands);
+        new FieldValueProcessor($expression, $operands);
     }
 
     public function testTooMuchOperands(): void
@@ -34,7 +35,7 @@ class FieldValueProcessorTest extends QtiSmTestCase
         $operands[] = new RecordContainer();
         $operands[] = new RecordContainer();
         $this->expectException(ExpressionProcessingException::class);
-        $processor = new FieldValueProcessor($expression, $operands);
+        new FieldValueProcessor($expression, $operands);
     }
 
     public function testNullOne(): void
@@ -55,9 +56,9 @@ class FieldValueProcessorTest extends QtiSmTestCase
         $operands = new OperandsCollection();
         // null value as operand.
         $operands[] = null;
-        $this->expectException(ExpressionProcessingException::class);
         $processor = new FieldValueProcessor($expression, $operands);
         $result = $processor->process();
+        $this::assertNull($result);
     }
 
     public function testWrongCardinalityOne(): void
@@ -68,7 +69,7 @@ class FieldValueProcessorTest extends QtiSmTestCase
         $operands[] = new QtiInteger(10);
         $processor = new FieldValueProcessor($expression, $operands);
         $this->expectException(ExpressionProcessingException::class);
-        $result = $processor->process();
+        $processor->process();
     }
 
     public function testWrongCardinalityTwo(): void
@@ -79,7 +80,7 @@ class FieldValueProcessorTest extends QtiSmTestCase
         $operands[] = new QtiPoint(1, 2);
         $processor = new FieldValueProcessor($expression, $operands);
         $this->expectException(ExpressionProcessingException::class);
-        $result = $processor->process();
+        $processor->process();
     }
 
     public function testWrongCardinalityThree(): void
@@ -91,7 +92,7 @@ class FieldValueProcessorTest extends QtiSmTestCase
         // Wrong container (Multiple, Ordered)
         $processor = new FieldValueProcessor($expression, $operands);
         $this->expectException(ExpressionProcessingException::class);
-        $result = $processor->process();
+        $processor->process();
     }
 
     public function testFieldValue(): void
@@ -116,7 +117,7 @@ class FieldValueProcessorTest extends QtiSmTestCase
      * @return QtiComponent
      * @throws MarshallerNotFoundException
      */
-    public function createFakeExpression($identifier = ''): QtiComponent
+    public function createFakeExpression($identifier = ''): Expression
     {
         // The following XML Component creation
         // underlines the need of a <record> operator... :)

--- a/test/qtismtest/runtime/processing/ResponseProcessingEngineTest.php
+++ b/test/qtismtest/runtime/processing/ResponseProcessingEngineTest.php
@@ -221,7 +221,7 @@ class ResponseProcessingEngineTest extends QtiSmTestCase
 
         self::assertNotNull($exceptions);
         self::assertEquals(
-            'The FieldValue operator only accepts operands with a cardinality of record.',
+            'No variable with identifier \'SCORE\' to be set in the current state.',
             $exceptions->getProcessingExceptions()[0]->getMessage()
         );
     }


### PR DESCRIPTION
# [COECDP25-952](https://oat-sa.atlassian.net/browse/COECDP25-952)

This PR makes `FieldValue` processor less strict, and resolve into a `null` value in case the referenced variable itself is a `null`.

e.g. the following rule will produce a `null` instead of failing with an exception if the `RESPONSE` variable is not set at all.

```xml
<fieldValue fieldIdentifier="result">
  <variable identifier="RESPONSE"/>
</fieldValue>
```

In other words, instead of treating that expression as `RESPONSE.result`, we will treat it as `RESPONSE?.result`.

According to https://www.imsglobal.org/sites/default/files/spec/qti/v3/info/index.html#Data_FieldValue, the 
> The field value operator takes a sub-expression with a record container value. The result is the value of the field with the specified field-identifier. If there is no field with that identifier then the result of the operator is NULL.

Arguably, there is no field with any identifier if the whole variable cannot be dereferenced.


[COECDP25-952]: https://oat-sa.atlassian.net/browse/COECDP25-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Before the fix


https://github.com/user-attachments/assets/37dc23d3-849a-426a-b902-aafe1fc955de



## After the fix


https://github.com/user-attachments/assets/05a964b6-a76e-46b4-8c88-e01668a5cd92

