### PR TITLE
chore: fixing syntax throwing an error

### DIFF
--- a/src/qtism/cli/Render.php
+++ b/src/qtism/cli/Render.php
@@ -280,14 +280,14 @@ class Render extends Cli
                 $body = substr($body, 0, strlen('</div>') * -1);
                 $body = "<body {$body}</body>{$nl}";
             } else {
-                $body = $xml->saveXml($xml->documentElement) . {$nl};
+                $body = $xml->saveXml($xml->documentElement) . $nl;
             }
 
             if ($arguments['document'] === true) {
                 $footer = "</html>\n";
             }
         } else {
-            $body = $xml->saveXml($xml->documentElement) . {$nl};
+            $body = $xml->saveXml($xml->documentElement) . $nl;
         }
 
         // Indent body...
@@ -358,7 +358,7 @@ class Render extends Cli
             $footer .= "</html>\n";
         }
 
-        $body = $xml->saveXml($xml->documentElement) . {$nl};
+        $body = $xml->saveXml($xml->documentElement) . $nl;
 
         // Indent body...
         $indentBody = '';


### PR DESCRIPTION
It is there to fix a small problem, introduced in one of the previous PRs.

As per the customer report, it shows syntax errors when trying to run the command from the SDK readme:
```sh
./vendor/bin/qtisdk render -df --source /Users/*/Downloads/i6422d9afb42b32279aab31294164637a8/qti.xml --flavour goldilocks > ./qti.html
PHP Parse error:  syntax error, unexpected token "{" in /Users/*/Downloads/test/taoApi/vendor/qtism/qtism/src/qtism/cli/Render.php on line 283
```
Which is pretty logical, since variable interpolation won't work outside of "string context".