### PR TITLE
fix: trim multibyte characters completely when marshaling a string value, leaving no ill-formed parts of a multibyte character

### DIFF
--- a/src/qtism/common/datatypes/QtiBoolean.php
+++ b/src/qtism/common/datatypes/QtiBoolean.php
@@ -33,7 +33,7 @@ use qtism\common\enums\Cardinality;
 class QtiBoolean extends QtiScalar
 {
     /**
-     * Check whether or not the intrinsic $value is a PHP boolean.
+     * Check whether the intrinsic $value is a PHP boolean.
      *
      * @param mixed $value A given value.
      * @throws InvalidArgumentException

--- a/src/qtism/common/datatypes/QtiCoords.php
+++ b/src/qtism/common/datatypes/QtiCoords.php
@@ -191,7 +191,7 @@ class QtiCoords extends IntegerCollection implements QtiDatatype
     }
 
     /**
-     * Whether or not $obj is equals to $this. Two Coords objects are
+     * Whether $obj is equals to $this. Two Coords objects are
      * considered to be equal if they have the same coordinates and shape.
      *
      * @param mixed $obj

--- a/src/qtism/common/datatypes/QtiDirectedPair.php
+++ b/src/qtism/common/datatypes/QtiDirectedPair.php
@@ -36,7 +36,7 @@ use qtism\common\enums\Cardinality;
 class QtiDirectedPair extends QtiPair
 {
     /**
-     * Whether or not $obj is equal to $this. Two DirectedPair objects
+     * Whether $obj is equal to $this. Two DirectedPair objects
      * are considered to be equal if their first and second values are the same.
      *
      * @param mixed $obj

--- a/src/qtism/common/datatypes/QtiDuration.php
+++ b/src/qtism/common/datatypes/QtiDuration.php
@@ -164,7 +164,7 @@ class QtiDuration implements QtiDatatype
      */
     public function getDays($total = false): int
     {
-        return ($total == true) ? $this->getInterval()->days : $this->getInterval()->d;
+        return $total ? $this->getInterval()->days : $this->getInterval()->d;
     }
 
     /**
@@ -374,7 +374,7 @@ class QtiDuration implements QtiDatatype
     }
 
     /**
-     * Whether or not the duration is negative e.g. -PT20S = -20 seconds.
+     * Whether the duration is negative e.g. -PT20S = -20 seconds.
      *
      * @return bool
      */

--- a/src/qtism/common/datatypes/QtiFile.php
+++ b/src/qtism/common/datatypes/QtiFile.php
@@ -53,7 +53,7 @@ interface QtiFile extends QtiDatatype
     public function getMimeType();
 
     /**
-     * Whether or not a file name is defined for this file.
+     * Whether a file name is defined for this file.
      *
      * @return bool
      */

--- a/src/qtism/common/datatypes/QtiFloat.php
+++ b/src/qtism/common/datatypes/QtiFloat.php
@@ -33,7 +33,7 @@ use qtism\common\enums\Cardinality;
 class QtiFloat extends QtiScalar
 {
     /**
-     * Check whether or not $value is a Float object.
+     * Check whether $value is a Float object.
      *
      * @param mixed $value
      * @throws InvalidArgumentException If $value is not an instance of Float.

--- a/src/qtism/common/datatypes/QtiIdentifier.php
+++ b/src/qtism/common/datatypes/QtiIdentifier.php
@@ -33,7 +33,7 @@ use qtism\common\enums\Cardinality;
 class QtiIdentifier extends QtiString
 {
     /**
-     * Checks whether or not $value is a string value.
+     * Checks whether $value is a string value.
      *
      * @param mixed $value
      * @throws InvalidArgumentException If $value is not a string value.

--- a/src/qtism/common/datatypes/QtiIntOrIdentifier.php
+++ b/src/qtism/common/datatypes/QtiIntOrIdentifier.php
@@ -33,7 +33,7 @@ use qtism\common\enums\Cardinality;
 class QtiIntOrIdentifier extends QtiScalar
 {
     /**
-     * Checks whether or not $value is a valid integer or string to be
+     * Checks whether $value is a valid integer or string to be
      * used as the intrinsic value of this object.
      *
      * @param mixed $value

--- a/src/qtism/common/datatypes/QtiInteger.php
+++ b/src/qtism/common/datatypes/QtiInteger.php
@@ -38,7 +38,7 @@ use qtism\common\enums\Cardinality;
 class QtiInteger extends QtiScalar
 {
     /**
-     * Checks whether or not $value is an integer compliant
+     * Checks whether $value is an integer compliant
      * with the QTI Integer datatype. Will check the range to make sure
      * its contained into [-2147483648,2147483647].
      *

--- a/src/qtism/common/datatypes/QtiPair.php
+++ b/src/qtism/common/datatypes/QtiPair.php
@@ -133,7 +133,7 @@ class QtiPair implements QtiDatatype
      * of $obj are the same as the ones of $obj.
      *
      * @param mixed $obj A value to compare.
-     * @return bool Whether or not the equality could be established.
+     * @return bool Whether the equality could be established.
      */
     public function equals($obj): bool
     {

--- a/src/qtism/common/datatypes/QtiPoint.php
+++ b/src/qtism/common/datatypes/QtiPoint.php
@@ -103,7 +103,7 @@ class QtiPoint implements QtiDatatype
         if (is_int($y)) {
             $this->y = $y;
         } else {
-            $msg = "The Y argument must be an integer value, '" . gettype($x) . "' given.";
+            $msg = "The Y argument must be an integer value, '" . gettype($y) . "' given.";
             throw new InvalidArgumentException($msg);
         }
     }
@@ -123,7 +123,7 @@ class QtiPoint implements QtiDatatype
      * are considered to be the same if they have the same coordinates.
      *
      * @param mixed $obj An object.
-     * @return bool Whether or not the equality is established.
+     * @return bool Whether the equality is established.
      */
     public function equals($obj): bool
     {

--- a/src/qtism/common/datatypes/QtiScalar.php
+++ b/src/qtism/common/datatypes/QtiScalar.php
@@ -81,7 +81,7 @@ abstract class QtiScalar implements QtiDatatype
     }
 
     /**
-     * Whether or not $this is equal to $obj. Two Scalar
+     * Whether $this is equal to $obj. Two Scalar
      * objects are considered to be identical if their intrinsic
      * values are strictly (===) equal.
      *

--- a/src/qtism/common/datatypes/QtiString.php
+++ b/src/qtism/common/datatypes/QtiString.php
@@ -33,7 +33,7 @@ use qtism\common\enums\Cardinality;
 class QtiString extends QtiScalar
 {
     /**
-     * Checks whether or not $value is a valid string.
+     * Checks whether $value is a valid string.
      *
      * @param mixed $value
      * @throws InvalidArgumentException If $value is not a valid string.
@@ -69,7 +69,7 @@ class QtiString extends QtiScalar
     }
 
     /**
-     * Whether or not the current QtiString object is equal to $obj.
+     * Whether the current QtiString object is equal to $obj.
      *
      * Two QtiString objects are considered to be identical if their intrinsic
      * values are equals. If the current QtiString is an empty string, and $obj

--- a/src/qtism/common/datatypes/QtiUri.php
+++ b/src/qtism/common/datatypes/QtiUri.php
@@ -33,7 +33,7 @@ use qtism\common\enums\Cardinality;
 class QtiUri extends QtiString
 {
     /**
-     * Checks whether or not $value is a string.
+     * Checks whether $value is a string.
      *
      * @param mixed $value
      * @throws InvalidArgumentException If $value is not a valid string.

--- a/src/qtism/common/datatypes/files/FileHash.php
+++ b/src/qtism/common/datatypes/files/FileHash.php
@@ -228,7 +228,7 @@ class FileHash implements QtiFile, JsonSerializable
     }
 
     /**
-     * Whether or not the File has a file name.
+     * Whether the File has a file name.
      *
      * @return bool
      */
@@ -238,7 +238,7 @@ class FileHash implements QtiFile, JsonSerializable
     }
 
     /**
-     * Whether or not two File objects are equals. Two File values
+     * Whether two File objects are equals. Two File values
      * are considered to be identical if they have the same file name,
      * mime-type and hash.
      *

--- a/src/qtism/common/datatypes/files/FileSystemFile.php
+++ b/src/qtism/common/datatypes/files/FileSystemFile.php
@@ -211,7 +211,7 @@ class FileSystemFile implements QtiFile
      * @param string $source The source path.
      * @param string $destination Where the file resulting from $source will be stored.
      * @param string $mimeType The MIME type of the file.
-     * @param mixed $withFilename Whether or not consider the $source's filename to be the $destination's file name. Give true to use the current file name. Give a string to select a different one. Default is true.
+     * @param mixed $withFilename Whether consider the $source's filename to be the $destination's file name. Give true to use the current file name. Give a string to select a different one. Default is true.
      * @return FileSystemFile
      * @throws RuntimeException If something wrong happens.
      */
@@ -336,7 +336,7 @@ class FileSystemFile implements QtiFile
     }
 
     /**
-     * Whether or not the File has a file name.
+     * Whether the File has a file name.
      *
      * @return bool
      */

--- a/src/qtism/common/storage/BinaryStreamAccess.php
+++ b/src/qtism/common/storage/BinaryStreamAccess.php
@@ -227,13 +227,17 @@ class BinaryStreamAccess extends AbstractStreamAccess
      */
     public function readString(): string
     {
+        $substitute = mb_substitute_character();
+        mb_substitute_character('none');
         try {
             $binLength = $this->getStream()->read(2);
             $length = current($this->tryUnpack('S', $binLength));
 
-            return $this->getStream()->read($length);
+            return mb_scrub($this->getStream()->read($length));
         } catch (StreamException $e) {
             $this->handleBinaryStreamException($e, BinaryStreamAccessException::STRING);
+        } finally {
+            mb_substitute_character($substitute);
         }
 
         return '';
@@ -252,8 +256,11 @@ class BinaryStreamAccess extends AbstractStreamAccess
         $len = strlen((string)$string);
 
         if ($len > $maxLen) {
-            $len = $maxLen;
-            $string = substr($string, 0, $maxLen);
+            $substitute = mb_substitute_character();
+            mb_substitute_character('none');
+            $string = mb_scrub(substr($string, 0, $maxLen));
+            $len = strlen($string);
+            mb_substitute_character($substitute);
         }
 
         try {

--- a/src/qtism/common/storage/BinaryStreamAccess.php
+++ b/src/qtism/common/storage/BinaryStreamAccess.php
@@ -333,7 +333,7 @@ class BinaryStreamAccess extends AbstractStreamAccess
      *
      * @param StreamException $e The StreamException object to deal with.
      * @param int $typeError The BinaryStreamAccess exception code to be thrown in case of error.
-     * @param bool $read Whether or not the error occurred in a reading/writing context.
+     * @param bool $read Whether the error occurred in a reading/writing context.
      * @throws BinaryStreamAccessException The resulting BinaryStreamAccessException.
      */
     protected function handleBinaryStreamException(StreamException $e, $typeError, $read = true): void

--- a/src/qtism/common/storage/MemoryStream.php
+++ b/src/qtism/common/storage/MemoryStream.php
@@ -279,7 +279,7 @@ class MemoryStream implements IStream
     }
 
     /**
-     * Specify whether or not the stream is open.
+     * Specify whether the stream is open.
      *
      * @param bool $open
      */

--- a/src/qtism/common/utils/Arrays.php
+++ b/src/qtism/common/utils/Arrays.php
@@ -29,7 +29,7 @@ namespace qtism\common\utils;
 class Arrays
 {
     /**
-     * Whether or not a given $array is an associative array.
+     * Whether a given $array is an associative array.
      *
      * @param array $array An array
      * @return bool

--- a/src/qtism/common/utils/Format.php
+++ b/src/qtism/common/utils/Format.php
@@ -97,7 +97,7 @@ class Format
     public static function isIdentifier(string $string, bool $strict = true): bool
     {
         if (!$strict) {
-            return preg_match("/^[a-zA-Z_][a-zA-Z0-9_\.-]*$/u", $string) === 1;
+            return preg_match("/^[a-zA-Z_][a-zA-Z0-9_.-]*$/u", $string) === 1;
         }
 
         if (!isset($string[0]) || !isset(CharacterMap::$identifier_first[$string[0]])) {
@@ -130,14 +130,14 @@ class Format
      */
     public static function sanitizeIdentifier(string $dirtyIdentifier): string
     {
-        if (preg_match("/^[a-zA-Z_][a-zA-Z0-9_\.-]*$/u", $dirtyIdentifier)) {
+        if (preg_match("/^[a-zA-Z_][a-zA-Z0-9_.-]*$/u", $dirtyIdentifier)) {
             return $dirtyIdentifier;
         }
 
         $cleanIdentifier = preg_replace('/^[^a-zA-Z_]+/u', '', $dirtyIdentifier); // Cleaning start
-        $cleanIdentifier = preg_replace("/[^a-zA-Z0-9_\.-]+/u", '', $cleanIdentifier); // Cleaning content
+        $cleanIdentifier = preg_replace("/[^a-zA-Z0-9_.-]+/u", '', $cleanIdentifier); // Cleaning content
 
-        if (preg_match("/^[a-zA-Z_][a-zA-Z0-9_\.-]*$/u", $cleanIdentifier)) {
+        if (preg_match("/^[a-zA-Z_][a-zA-Z0-9_.-]*$/u", $cleanIdentifier)) {
             return $cleanIdentifier;
         }
 
@@ -296,7 +296,7 @@ class Format
     }
 
     /**
-     * Whether or not a given string is a variable ref.
+     * Whether a given string is a variable ref.
      * Valid example: '{myIdentifier1}', 'myIdentifier1'.
      *
      * @param string $string A given string.
@@ -315,7 +315,7 @@ class Format
     }
 
     /**
-     * Whether or not a given string is a coordinate collection.
+     * Whether a given string is a coordinate collection.
      *
      * For compatibility reasons, float formatted numbers will also
      * be accepted as valid numbers to compose coordinates.
@@ -615,7 +615,7 @@ class Format
 
     public static function isMimeType(string $string): bool
     {
-        return preg_match('/^[-a-z]+\/[-+\.a-z0-9]+$/', $string) === 1;
+        return preg_match('/^[-a-z]+\/[-+.a-z0-9]+$/', $string) === 1;
     }
 
     /**

--- a/src/qtism/common/utils/Reflection.php
+++ b/src/qtism/common/utils/Reflection.php
@@ -82,7 +82,7 @@ class Reflection
     }
 
     /**
-     * Whether or not a given $object is an instance of $className. This method
+     * Whether a given $object is an instance of $className. This method
      * exists because is_sublcass_of() does not take into account interfaces
      * in PHP 5.3.
      *

--- a/src/qtism/common/utils/Url.php
+++ b/src/qtism/common/utils/Url.php
@@ -67,13 +67,13 @@ class Url
     }
 
     /**
-     * Whether or not a given $url is relative.
+     * Whether a given $url is relative.
      *
      * @param string $url
      * @return bool
      */
     public static function isRelative($url): bool
     {
-        return (preg_match("/^[a-z][a-z0-9+\-\.]+:(\/\/){0,1}|^\//i", $url) === 0) ? true : false;
+        return (preg_match("/^[a-z][a-z0-9+\-.]+:(\/\/){0,1}|^\//i", $url) === 0) ? true : false;
     }
 }

--- a/src/qtism/data/AssessmentItem.php
+++ b/src/qtism/data/AssessmentItem.php
@@ -306,7 +306,7 @@ class AssessmentItem extends QtiComponent implements QtiIdentifiable, IAssessmen
     }
 
     /**
-     * Whether or not a value is defined for the label attribute.
+     * Whether a value is defined for the label attribute.
      *
      * @return bool
      */
@@ -426,7 +426,7 @@ class AssessmentItem extends QtiComponent implements QtiIdentifiable, IAssessmen
     }
 
     /**
-     * Whether or not a value is defined for the toolName attribute.
+     * Whether a value is defined for the toolName attribute.
      *
      * @return bool
      */

--- a/src/qtism/data/ExtendedAssessmentItemRef.php
+++ b/src/qtism/data/ExtendedAssessmentItemRef.php
@@ -634,7 +634,7 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
     /**
      * Has a title.
      *
-     * Whether or not a title was found in the referenced assessmentItem.
+     * Whether a title was found in the referenced assessmentItem.
      *
      * @return bool
      */
@@ -675,7 +675,7 @@ class ExtendedAssessmentItemRef extends AssessmentItemRef implements IAssessment
     /**
      * Has a label.
      *
-     * Whether or not a label was found in the referenced assessmentItem.
+     * Whether a label was found in the referenced assessmentItem.
      *
      * @return bool
      */

--- a/src/qtism/data/ExternalQtiComponent.php
+++ b/src/qtism/data/ExternalQtiComponent.php
@@ -121,7 +121,7 @@ class ExternalQtiComponent extends QtiComponent implements IExternal, QtiNamespa
     }
 
     /**
-     * Whether or not a target namespace is defined.
+     * Whether a target namespace is defined.
      *
      * @return bool
      */

--- a/src/qtism/data/IAssessmentItem.php
+++ b/src/qtism/data/IAssessmentItem.php
@@ -211,7 +211,7 @@ interface IAssessmentItem extends QtiIdentifiable
     /**
      * Has a label.
      *
-     * Whether or not the assessmentItem has a label.
+     * Whether the assessmentItem has a label.
      *
      * @return bool
      */

--- a/src/qtism/data/ItemSessionControl.php
+++ b/src/qtism/data/ItemSessionControl.php
@@ -44,7 +44,7 @@ class ItemSessionControl extends QtiComponent
      * that any applicable feedback must be shown. This applies to both Modal
      * Feedback and Integrated Feedback where applicable. However, once the
      * maximum number of allowed attempts have been used (or for adaptive items,
-     * completionStatus has been set to completed) whether or not feedback is shown
+     * completionStatus has been set to completed) whether feedback is shown
      * is controlled by the showFeedback constraint.
      *
      * @var int
@@ -101,7 +101,7 @@ class ItemSessionControl extends QtiComponent
     /**
      * From IMS QTI:
      *
-     * This constraint controls whether or not the system may provide the candidate with a
+     * This constraint controls whether the system may provide the candidate with a
      * way of entering the solution state. The default is false.
      *
      * @var bool
@@ -114,7 +114,7 @@ class ItemSessionControl extends QtiComponent
      *
      * Some delivery systems support the capture of candidate comments. The comment is not
      * part of the assessed responses but provides feedback from the candidate to the other
-     * actors in the assessment process. This constraint controls whether or not the candidate
+     * actors in the assessment process. This constraint controls whether the candidate
      * is allowed to provide a comment on the item during the session.
      *
      * @var bool
@@ -292,7 +292,7 @@ class ItemSessionControl extends QtiComponent
     /**
      * Is the candidate allowed to skip items?
      *
-     * Know whether or not the Delivery Engine allow the candidate to skip items.
+     * Know whether the Delivery Engine allow the candidate to skip items.
      *
      * @return bool true if allowed, false if not.
      */
@@ -304,7 +304,7 @@ class ItemSessionControl extends QtiComponent
     /**
      * Set if the candidate is allowed to skip items.
      *
-     * Set whether or not the Delivery Engine allows the candidate to skip items.
+     * Set whether the Delivery Engine allows the candidate to skip items.
      *
      * @param bool $allowSkipping true if allowed, false otherwise.
      * @throws InvalidArgumentException If $allowSkipping is not a valid boolean.
@@ -350,7 +350,7 @@ class ItemSessionControl extends QtiComponent
     /**
      * Set if the responses must be validated.
      *
-     * Set whether or not responses must be validated by the Delivery Engine.
+     * Set whether responses must be validated by the Delivery Engine.
      *
      * @param bool $validateResponses true if responses must be validated, false if not.
      * @throws InvalidArgumentException If $validateResponses is not a boolean.

--- a/src/qtism/data/QtiComponentIterator.php
+++ b/src/qtism/data/QtiComponentIterator.php
@@ -276,7 +276,7 @@ class QtiComponentIterator implements Iterator
     }
 
     /**
-     * Whether or not a given $component has already been traversed by
+     * Whether a given $component has already been traversed by
      * the iterator.
      *
      * @param QtiComponent $component

--- a/src/qtism/data/TestFeedback.php
+++ b/src/qtism/data/TestFeedback.php
@@ -40,7 +40,7 @@ class TestFeedback extends QtiComponent
      * (referred to as atEnd).
      *
      * The value of an outcome variable is used in conjunction with the showHide and
-     * identifier attributes to determine whether or not the feedback is actually
+     * identifier attributes to determine whether the feedback is actually
      * shown in a similar way to feedbackElement (Item Model).
      *
      * @var int

--- a/src/qtism/data/TestFeedbackRef.php
+++ b/src/qtism/data/TestFeedbackRef.php
@@ -39,7 +39,7 @@ class TestFeedbackRef extends QtiComponent
      * (referred to as atEnd).
      *
      * The value of an outcome variable is used in conjunction with the showHide and
-     * identifier attributes to determine whether or not the feedback is actually
+     * identifier attributes to determine whether the feedback is actually
      * shown in a similar way to feedbackElement (Item Model).
      *
      * @var int

--- a/src/qtism/data/content/Flow.php
+++ b/src/qtism/data/content/Flow.php
@@ -51,7 +51,7 @@ interface Flow extends ObjectFlow
     public function getXmlBase(): string;
 
     /**
-     * Whether or not a value is defined for the xml:base attribute.
+     * Whether a value is defined for the xml:base attribute.
      *
      * @return bool
      */

--- a/src/qtism/data/content/ModalFeedback.php
+++ b/src/qtism/data/content/ModalFeedback.php
@@ -223,7 +223,7 @@ class ModalFeedback extends QtiComponent
     }
 
     /**
-     * Whether or not a value is defined for the title attribute.
+     * Whether a value is defined for the title attribute.
      *
      * @return bool
      */

--- a/src/qtism/data/content/ModalFeedbackCollection.php
+++ b/src/qtism/data/content/ModalFeedbackCollection.php
@@ -32,7 +32,7 @@ use qtism\data\QtiComponentCollection;
 class ModalFeedbackCollection extends QtiComponentCollection
 {
     /**
-     * Checks whether or not $value is an instance of ModalFeedback.
+     * Checks whether $value is an instance of ModalFeedback.
      *
      * @param mixed $value
      * @throws InvalidArgumentException If $value is not an instance of ModalFeedback.

--- a/src/qtism/data/content/ModalFeedbackRule.php
+++ b/src/qtism/data/content/ModalFeedbackRule.php
@@ -113,7 +113,7 @@ class ModalFeedbackRule extends QtiComponent
 
     /**
      * Set the identifier of the outcome variable that will be used has a lookup
-     * to know whether or not the content of the modalFeedback has to be shown.
+     * to know whether the content of the modalFeedback has to be shown.
      *
      * @param string $outcomeIdentifier A QTI identifier.
      * @throws InvalidArgumentException If $outcomeIdentifier is not a valid QTI identifier.
@@ -130,7 +130,7 @@ class ModalFeedbackRule extends QtiComponent
 
     /**
      * Get the identifier of the outcome variable that will be used has a lookup
-     * to know whether or not the content of the modalFeedback has to be shown.
+     * to know whether the content of the modalFeedback has to be shown.
      *
      * @return string A QTI identifier.
      */

--- a/src/qtism/data/content/PrintedVariable.php
+++ b/src/qtism/data/content/PrintedVariable.php
@@ -333,7 +333,7 @@ class PrintedVariable extends BodyElement implements FlowStatic, InlineStatic, T
     }
 
     /**
-     * Whether or not an index is defined for the printedVariable.
+     * Whether an index is defined for the printedVariable.
      *
      * @return bool
      */
@@ -399,7 +399,7 @@ class PrintedVariable extends BodyElement implements FlowStatic, InlineStatic, T
     }
 
     /**
-     * Whether or not the printedVariable has a value for the field attribute.
+     * Whether the printedVariable has a value for the field attribute.
      *
      * @return bool
      */

--- a/src/qtism/data/content/interactions/AssociableHotspot.php
+++ b/src/qtism/data/content/interactions/AssociableHotspot.php
@@ -248,7 +248,7 @@ class AssociableHotspot extends Choice implements AssociableChoice, Hotspot
     }
 
     /**
-     * Whether or not the associableHotspot has an hotspotLabel.
+     * Whether the associableHotspot has an hotspotLabel.
      *
      * @return bool
      */

--- a/src/qtism/data/content/interactions/Gap.php
+++ b/src/qtism/data/content/interactions/Gap.php
@@ -63,7 +63,7 @@ class Gap extends Choice implements AssociableChoice, InlineStatic
      * Create a new Gap object.
      *
      * @param string $identifier The identifier of the gap.
-     * @param bool $required Whether or not the Gap is required to be filled to form a valid response.
+     * @param bool $required Whether the Gap is required to be filled to form a valid response.
      * @param string $id The identifier of the bodyElement.
      * @param string $class The class of the bodyElement.
      * @param string $lang The language of the bodyElement.

--- a/src/qtism/data/content/interactions/GraphicOrderInteraction.php
+++ b/src/qtism/data/content/interactions/GraphicOrderInteraction.php
@@ -168,7 +168,7 @@ class GraphicOrderInteraction extends GraphicInteraction
     }
 
     /**
-     * Whether or not a value is defined for the minChoices attribute.
+     * Whether a value is defined for the minChoices attribute.
      *
      * @return bool
      */
@@ -211,7 +211,7 @@ class GraphicOrderInteraction extends GraphicInteraction
     }
 
     /**
-     * Whether or not a value is defined for the maxChoice attribute.
+     * Whether a value is defined for the maxChoice attribute.
      *
      * @return bool
      */

--- a/src/qtism/data/content/interactions/Hotspot.php
+++ b/src/qtism/data/content/interactions/Hotspot.php
@@ -79,7 +79,7 @@ interface Hotspot
     public function getHotspotLabel(): string;
 
     /**
-     * Whether or not a value is defined for the hotspotLabel
+     * Whether a value is defined for the hotspotLabel
      * attribute.
      *
      * @return bool

--- a/src/qtism/data/content/interactions/HotspotChoice.php
+++ b/src/qtism/data/content/interactions/HotspotChoice.php
@@ -155,7 +155,7 @@ class HotspotChoice extends Choice implements Hotspot
     }
 
     /**
-     * Whether or not a value is defined for the hotspotLabel attribute.
+     * Whether a value is defined for the hotspotLabel attribute.
      *
      * @return bool
      */

--- a/src/qtism/data/content/interactions/MediaInteraction.php
+++ b/src/qtism/data/content/interactions/MediaInteraction.php
@@ -116,7 +116,7 @@ class MediaInteraction extends BlockInteraction
     }
 
     /**
-     * Set whether or not the media must start as soon as the candidate starts the attempt.
+     * Set whether the media must start as soon as the candidate starts the attempt.
      *
      * @param bool $autostart
      * @throws InvalidArgumentException If $autostart is not a boolean value.
@@ -214,7 +214,7 @@ class MediaInteraction extends BlockInteraction
     }
 
     /**
-     * Set whether or not the continuous play (subject to maxPlays) of the media is in force.
+     * Set whether the continuous play (subject to maxPlays) of the media is in force.
      *
      * @param bool $loop
      * @throws InvalidArgumentException If $loop is not a boolean value.

--- a/src/qtism/data/content/interactions/PositionObjectInteraction.php
+++ b/src/qtism/data/content/interactions/PositionObjectInteraction.php
@@ -205,7 +205,7 @@ class PositionObjectInteraction extends Interaction
     }
 
     /**
-     * Whether or not a value is defined for the minChoices attribute.
+     * Whether a value is defined for the minChoices attribute.
      *
      * @return bool
      */

--- a/src/qtism/data/content/interactions/SliderInteraction.php
+++ b/src/qtism/data/content/interactions/SliderInteraction.php
@@ -95,7 +95,7 @@ class SliderInteraction extends BlockInteraction
      * From IMS QTI:
      *
      * By default, sliders are labelled only at their ends. The stepLabel
-     * attribute controls whether or not each step on the slider should
+     * attribute controls whether each step on the slider should
      * also be labelled. It is unlikely that delivery engines will be
      * able to guarantee to label steps so this attribute should be
      * treated only as request.
@@ -233,7 +233,7 @@ class SliderInteraction extends BlockInteraction
     }
 
     /**
-     * Whether or not a value is defined for the step attribute.
+     * Whether a value is defined for the step attribute.
      *
      * @return bool
      */
@@ -243,7 +243,7 @@ class SliderInteraction extends BlockInteraction
     }
 
     /**
-     * Set whether or not each step on the slider has to be labelled.
+     * Set whether each step on the slider has to be labelled.
      *
      * @param bool $stepLabel
      * @throws InvalidArgumentException If $stepLabel is not a boolean value.

--- a/src/qtism/data/content/interactions/UploadInteraction.php
+++ b/src/qtism/data/content/interactions/UploadInteraction.php
@@ -89,7 +89,7 @@ class UploadInteraction extends BlockInteraction
     }
 
     /**
-     * Whether or not a value is defined for the 'type'
+     * Whether a value is defined for the 'type'
      * attribute.
      *
      * @return bool

--- a/src/qtism/data/content/xhtml/text/Blockquote.php
+++ b/src/qtism/data/content/xhtml/text/Blockquote.php
@@ -83,7 +83,7 @@ class Blockquote extends SimpleBlock
     }
 
     /**
-     * Whether or not a value is defined for the cite attribute.
+     * Whether a value is defined for the cite attribute.
      *
      * @return bool
      */

--- a/src/qtism/data/expressions/NumberPresented.php
+++ b/src/qtism/data/expressions/NumberPresented.php
@@ -28,7 +28,7 @@ namespace qtism\data\expressions;
  *
  * This expression, which can only be used in outcomes processing, calculates the
  * number of items in a given sub-set that have been attempted (at least once).
- * In other words, items with which the user has interacted, whether or not they
+ * In other words, items with which the user has interacted, whether they
  * provided a response. The result is an integer with single cardinality.
  */
 class NumberPresented extends ItemSubset

--- a/src/qtism/data/expressions/operators/CustomOperator.php
+++ b/src/qtism/data/expressions/operators/CustomOperator.php
@@ -120,7 +120,7 @@ class CustomOperator extends Operator implements IExternal
     }
 
     /**
-     * Whether or not a value is defined for the class attribute.
+     * Whether a value is defined for the class attribute.
      *
      * @return bool
      */
@@ -158,7 +158,7 @@ class CustomOperator extends Operator implements IExternal
     }
 
     /**
-     * Whether or not a value is defined for the definition attribute.
+     * Whether a value is defined for the definition attribute.
      *
      * @return bool
      */

--- a/src/qtism/data/expressions/operators/Equal.php
+++ b/src/qtism/data/expressions/operators/Equal.php
@@ -76,7 +76,7 @@ class Equal extends Operator
     /**
      * From IMS QTI:
      *
-     * Controls whether or not the lower bound is included in the comparison.
+     * Controls whether the lower bound is included in the comparison.
      *
      * @var bool
      * @qtism-bean-property
@@ -97,8 +97,8 @@ class Equal extends Operator
      * @param ExpressionCollection $expressions A collection of Expression objects.
      * @param int $toleranceMode The tolerance mode, a value from the ToleranceMode enumeration.
      * @param array $tolerance An array of 1 or 2 elements which are float or variableRef values.
-     * @param bool $includeLowerBound Whether or not to include the lower bound in the comparison.
-     * @param bool $includeUpperBound Whether or not to include the upper bound in the comparison.
+     * @param bool $includeLowerBound Whether to include the lower bound in the comparison.
+     * @param bool $includeUpperBound Whether to include the upper bound in the comparison.
      * @throws UnexpectedValueException If The tolerance argument is ABSOLUTE or RELATIVE but no $tolerance array is given.
      * @throws InvalidArgumentException If $toleranceMode is not a value from the ToleranceMode, if $tolerance is not a valid tolerance array, if $includeLowerBound/$includeUpperBound is not a boolean.
      */

--- a/src/qtism/data/expressions/operators/StringMatch.php
+++ b/src/qtism/data/expressions/operators/StringMatch.php
@@ -40,7 +40,7 @@ class StringMatch extends Operator
     /**
      * From IMS QTI:
      *
-     * Whether or not the match is to be carried out case sensitively.
+     * Whether the match is to be carried out case sensitively.
      *
      * @var bool
      * @qtism-bean-property
@@ -63,7 +63,7 @@ class StringMatch extends Operator
      * Create a new instance of StringMatch.
      *
      * @param ExpressionCollection $expressions A collection of Expression objects.
-     * @param bool $caseSensitive Whether or not the match to be carried out case sensitively.
+     * @param bool $caseSensitive Whether the match to be carried out case sensitively.
      * @param bool $substring Deprecated argument, use the substring operator instead.
      * @throws InvalidArgumentException If $caseSensitive or $substring are not booleans or if the $expressions count is greather than 2.
      */
@@ -75,7 +75,7 @@ class StringMatch extends Operator
     }
 
     /**
-     * Set Whether or not the match is to be carried out case sensitively.
+     * Set Whether the match is to be carried out case sensitively.
      *
      * @param bool $caseSensitive Case sensitiveness.
      * @throws InvalidArgumentException If $caseSensitive is not a boolean.

--- a/src/qtism/data/expressions/operators/Substring.php
+++ b/src/qtism/data/expressions/operators/Substring.php
@@ -40,7 +40,7 @@ class Substring extends Operator
     /**
      * From IMS QTI:
      *
-     * Used to control whether or not the substring is matched case sensitively.
+     * Used to control whether the substring is matched case sensitively.
      * If true then the match is case sensitive and, for example, "Hell" is not
      * a substring of "Shell". If false then the match is not case sensitive and "Hell"
      * is a substring of "Shell".
@@ -80,7 +80,7 @@ class Substring extends Operator
     }
 
     /**
-     * Whether or not the operator is case sensitive.
+     * Whether the operator is case sensitive.
      *
      * @return bool
      */

--- a/src/qtism/data/rules/OutcomeCondition.php
+++ b/src/qtism/data/rules/OutcomeCondition.php
@@ -139,7 +139,7 @@ class OutcomeCondition extends QtiComponent implements OutcomeRule
     }
 
     /**
-     * Whether or not an OutcomeElse object is defined for the outcome condition.
+     * Whether an OutcomeElse object is defined for the outcome condition.
      *
      * @return bool
      */

--- a/src/qtism/data/rules/ResponseCondition.php
+++ b/src/qtism/data/rules/ResponseCondition.php
@@ -139,7 +139,7 @@ class ResponseCondition extends QtiComponent implements ResponseRule
     }
 
     /**
-     * Whether or not a ResponseElse object is defined for the response condition.
+     * Whether a ResponseElse object is defined for the response condition.
      *
      * @return bool
      */

--- a/src/qtism/data/rules/TemplateCondition.php
+++ b/src/qtism/data/rules/TemplateCondition.php
@@ -141,7 +141,7 @@ class TemplateCondition extends QtiComponent implements TemplateRule
     }
 
     /**
-     * Whether or not a TemplateElse object is defined for this template condition.
+     * Whether a TemplateElse object is defined for this template condition.
      *
      * @return bool
      */

--- a/src/qtism/data/rules/TemplateElseIfCollection.php
+++ b/src/qtism/data/rules/TemplateElseIfCollection.php
@@ -33,7 +33,7 @@ use qtism\data\QtiComponentCollection;
 class TemplateElseIfCollection extends QtiComponentCollection
 {
     /**
-     * Check whether or not $value is an instance of TemplateElseIf.
+     * Check whether $value is an instance of TemplateElseIf.
      *
      * @param mixed $value
      * @throws InvalidArgumentException If $value is not an instance of TemplateElseIf.

--- a/src/qtism/data/rules/TemplateRuleCollection.php
+++ b/src/qtism/data/rules/TemplateRuleCollection.php
@@ -33,7 +33,7 @@ use qtism\data\QtiComponentCollection;
 class TemplateRuleCollection extends QtiComponentCollection
 {
     /**
-     * Check whether or not $value is an instance of TemplateRule.
+     * Check whether $value is an instance of TemplateRule.
      *
      * @param mixed $value
      * @throws InvalidArgumentException If $value is not an instance of TemplateRule.

--- a/src/qtism/data/state/MapEntry.php
+++ b/src/qtism/data/state/MapEntry.php
@@ -61,7 +61,7 @@ class MapEntry extends QtiComponent
     /**
      * From IMS QTI:
      *
-     * Used to control whether or not a mapEntry string is matched case sensitively.
+     * Used to control whether a mapEntry string is matched case sensitively.
      *
      * @var bool
      * @qtism-bean-property

--- a/src/qtism/data/state/ResponseDeclaration.php
+++ b/src/qtism/data/state/ResponseDeclaration.php
@@ -35,7 +35,7 @@ use qtism\data\QtiComponentCollection;
  *
  * At runtime, response variables are instantiated as part of an item session.
  * Their values are always initialized to NULL (no value) regardless of
- * whether or not a default value is given in the declaration. A response
+ * whether a default value is given in the declaration. A response
  * variable with a NULL value indicates that the candidate has not offered
  * a response, either because they have not attempted the item at all or
  * because they have attempted it and chosen not to provide a response.

--- a/src/qtism/data/state/TemplateDeclaration.php
+++ b/src/qtism/data/state/TemplateDeclaration.php
@@ -42,7 +42,7 @@ class TemplateDeclaration extends VariableDeclaration
     /**
      * From IMS QTI:
      *
-     * This attribute determines whether or not the template variable's
+     * This attribute determines whether the template variable's
      * value should be substituted for object parameter values that match its name.
      * See param for more information.
      *
@@ -54,7 +54,7 @@ class TemplateDeclaration extends VariableDeclaration
     /**
      * From IMS QTI:
      *
-     * This attribute determines whether or not the template variable's value should
+     * This attribute determines whether the template variable's value should
      * be substituted for identifiers that match its name in MathML expressions.
      * See Combining Template Variables and MathML for more information.
      *
@@ -77,7 +77,7 @@ class TemplateDeclaration extends VariableDeclaration
     }
 
     /**
-     * Set whether or not the template variable's value should be substituted for
+     * Set whether the template variable's value should be substituted for
      * object parameters.
      *
      * @param bool $paramVariable A boolean value.
@@ -94,7 +94,7 @@ class TemplateDeclaration extends VariableDeclaration
     }
 
     /**
-     * Lets you know whether or not the template variable's value should be substituted for
+     * Lets you know whether the template variable's value should be substituted for
      * object parameters.
      *
      * @return bool

--- a/src/qtism/data/state/Value.php
+++ b/src/qtism/data/state/Value.php
@@ -100,7 +100,7 @@ class Value extends QtiComponent
     }
 
     /**
-     * Set whether or not the value is part of a record.
+     * Set whether the value is part of a record.
      *
      * @param bool $partOfRecord
      * @throws InvalidArgumentException If $partOfRecord is not a boolean.
@@ -152,7 +152,7 @@ class Value extends QtiComponent
     }
 
     /**
-     * Whether or not a field identifier is defined.
+     * Whether a field identifier is defined.
      *
      * @return bool
      */

--- a/src/qtism/data/state/VariableDeclaration.php
+++ b/src/qtism/data/state/VariableDeclaration.php
@@ -171,7 +171,7 @@ class VariableDeclaration extends QtiComponent implements QtiIdentifiable
     }
 
     /**
-     * Whether or not the baseType attribute is defined for this
+     * Whether the baseType attribute is defined for this
      * VariableDeclaration.
      *
      * @return bool
@@ -204,7 +204,7 @@ class VariableDeclaration extends QtiComponent implements QtiIdentifiable
     }
 
     /**
-     * Whether or not a DefaultValue object is contained by the VariableDeclaration.
+     * Whether a DefaultValue object is contained by the VariableDeclaration.
      *
      * @return bool
      */

--- a/src/qtism/data/storage/php/PhpStreamAccess.php
+++ b/src/qtism/data/storage/php/PhpStreamAccess.php
@@ -349,7 +349,7 @@ class PhpStreamAccess extends AbstractStreamAccess
      * @param string $objectname The name of the variable where the object on which you want to call the method is stored e.g. 'foobar'.
      * @param string $methodname The name of the method you want to call.
      * @param PhpArgumentCollection $arguments A collection of PhpArgument objects.
-     * @param bool $static Whether or not the call is static.
+     * @param bool $static Whether the call is static.
      * @throws StreamAccessException If an error occurs while writing the method call.
      */
     public function writeMethodCall(

--- a/src/qtism/data/storage/php/marshalling/PhpMarshaller.php
+++ b/src/qtism/data/storage/php/marshalling/PhpMarshaller.php
@@ -115,10 +115,10 @@ abstract class PhpMarshaller
 
     /**
      * Implementations of this class must implement this method which states
-     * whether or not the value $toMarshall can be handled or not.
+     * whether the value $toMarshall can be handled or not.
      *
      * @param mixed $toMarshall The value the current PhpMarshaller implementation has to deal with.
-     * @return bool Whether or not the value $toMarshall can be marshalled or not by this implementation.
+     * @return bool Whether the value $toMarshall can be marshalled or not by this implementation.
      */
     abstract protected function isMarshallable($toMarshall): bool;
 }

--- a/src/qtism/data/storage/php/marshalling/PhpScalarMarshaller.php
+++ b/src/qtism/data/storage/php/marshalling/PhpScalarMarshaller.php
@@ -46,7 +46,7 @@ class PhpScalarMarshaller extends PhpMarshaller
     }
 
     /**
-     * Checks whether or not the given value is marshallable by this implementation.
+     * Checks whether the given value is marshallable by this implementation.
      *
      * @param mixed $toMarshall
      * @return bool

--- a/src/qtism/data/storage/xml/Utils.php
+++ b/src/qtism/data/storage/xml/Utils.php
@@ -160,7 +160,7 @@ class Utils
      *
      * @param DOMElement $from The source DOMElement.
      * @param DOMElement $into The target DOMElement.
-     * @param bool $deep Whether or not to import the whole node hierarchy.
+     * @param bool $deep Whether to import the whole node hierarchy.
      */
     public static function importChildNodes(DOMElement $from, DOMElement $into, $deep = true): void
     {
@@ -204,7 +204,7 @@ class Utils
      * * & --> &amp;
      *
      * @param string $string An input string.
-     * @param bool $isAttribute Whether or not to escape ', >, < which do not have to be escaped in attributes.
+     * @param bool $isAttribute Whether to escape ', >, < which do not have to be escaped in attributes.
      * @return string An escaped string.
      */
     public static function escapeXmlSpecialChars($string, $isAttribute = false): string

--- a/src/qtism/data/storage/xml/XmlCompactDocument.php
+++ b/src/qtism/data/storage/xml/XmlCompactDocument.php
@@ -61,7 +61,7 @@ use SplObjectStorage;
 class XmlCompactDocument extends XmlDocument
 {
     /**
-     * Whether or not the rubricBlock elements
+     * Whether the rubricBlock elements
      * must be separated from the core document.
      *
      * @var bool
@@ -69,7 +69,7 @@ class XmlCompactDocument extends XmlDocument
     private $explodeRubricBlocks = false;
 
     /**
-     * Whether or not the testFeedback elements
+     * Whether the testFeedback elements
      * must be separated from the core document.
      *
      * @var bool

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -165,7 +165,7 @@ class XmlDocument extends QtiDocument
      * local filesystem.
      *
      * @param string $url The Uniform Resource Identifier that identifies/locate the file.
-     * @param bool $validate Whether or not the file must be validated unsing XML Schema? Default is false.
+     * @param bool $validate Whether the file must be validated unsing XML Schema? Default is false.
      * @throws XmlStorageException If an error occurs while loading the QTI-XML file.
      */
     public function load(string $url, $validate = false): void
@@ -452,7 +452,7 @@ class XmlDocument extends QtiDocument
      * the include components can be resolved by calling this method. Files will
      * be included following the rules described by the XInclude specification.
      *
-     * @param bool $validate Whether or not validate files being included. Default is false.
+     * @param bool $validate Whether validate files being included. Default is false.
      * @throws XmlStorageException If an error occurred while parsing or validating files to be included.
      * @throws ReflectionException
      */
@@ -513,7 +513,7 @@ class XmlDocument extends QtiDocument
      * this method will try to resolve responseProcessing fragments referenced by responseProcessing
      * elements having a templateLocation attribute.
      *
-     * @param bool $validate Whether or not validate files being included. Default is false.
+     * @param bool $validate Whether validate files being included. Default is false.
      * @throws LogicException If the method is called prior the load or loadFromString method was called.
      * @throws XmlStorageException If an error occurred while parsing or validating files to be included.
      */
@@ -560,7 +560,7 @@ class XmlDocument extends QtiDocument
      * to assessmentSections are resolved. assessmentSectionRefs will be replaced with their assessmentSection
      * content.
      *
-     * @param bool $validate (optional) Whether or not validate the content of included assessmentSectionRefs.
+     * @param bool $validate (optional) Whether validate the content of included assessmentSectionRefs.
      * @throws LogicException If the method is called prior the load or loadFromString method was called.
      * @throws XmlStorageException If an error occurred while parsing or validating files to be included.
      */

--- a/src/qtism/data/storage/xml/marshalling/Marshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/Marshaller.php
@@ -359,7 +359,7 @@ abstract class Marshaller
      * Get Attribute Name to Use for Marshalling
      *
      * This method provides the attribute name to be used to retrieve an element attribute value
-     * by considering whether or not the Marshaller implementation is running in Web Component
+     * by considering whether the Marshaller implementation is running in Web Component
      * Friendly mode.
      *
      * Examples:
@@ -760,7 +760,7 @@ abstract class Marshaller
     /**
      * Is Web Component Friendly
      *
-     * Whether or not the Marshaller should work in Web Component Friendly mode.
+     * Whether the Marshaller should work in Web Component Friendly mode.
      *
      * @return bool
      */

--- a/src/qtism/data/storage/xml/marshalling/MarshallerFactory.php
+++ b/src/qtism/data/storage/xml/marshalling/MarshallerFactory.php
@@ -51,7 +51,7 @@ abstract class MarshallerFactory
     private $mapping = [];
 
     /**
-     * Whether or not element and attribute serialization must be Web Component friendly.
+     * Whether element and attribute serialization must be Web Component friendly.
      *
      * @var bool
      */
@@ -344,7 +344,7 @@ abstract class MarshallerFactory
     /**
      * Set Web Componenent Friendship
      *
-     * Sets whether or not consider Web Component friendly QTI components.
+     * Sets whether consider Web Component friendly QTI components.
      *
      * @param bool $webComponentFriendly
      */
@@ -356,7 +356,7 @@ abstract class MarshallerFactory
     /**
      * Web Component Friendship Status
      *
-     * Whether or not Web Component friendly QTI components are considered.
+     * Whether Web Component friendly QTI components are considered.
      *
      * @return bool
      */

--- a/src/qtism/data/storage/xml/marshalling/RecursiveMarshaller.php
+++ b/src/qtism/data/storage/xml/marshalling/RecursiveMarshaller.php
@@ -373,7 +373,7 @@ abstract class RecursiveMarshaller extends Marshaller
     abstract protected function marshallChildrenKnown(QtiComponent $component, array $elements): DOMElement;
 
     /**
-     * Whether or not a QtiComponent object is final. In other words, whether $component
+     * Whether a QtiComponent object is final. In other words, whether $component
      * contains child QtiComponent objects.
      *
      * @param QtiComponent $component

--- a/src/qtism/data/storage/xml/schemes/qtiv3p0/imsqtiv3p0_schemas_v1.html
+++ b/src/qtism/data/storage/xml/schemes/qtiv3p0/imsqtiv3p0_schemas_v1.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head></head>
+	<head>
+		<title>Question &amp; Test Interoperability 3.0</title>
+	</head>
 	<body>
 		<h1>Question &amp; Test Interoperability 3.0</h1>
 		<h2>Final Specification (2022-05-01) - XML Schema and Vocabulary Documents Version 1</h2>

--- a/src/qtism/runtime/common/Container.php
+++ b/src/qtism/runtime/common/Container.php
@@ -90,7 +90,7 @@ class Container extends AbstractCollection implements Comparable
 
     /**
      * In the QTI runtime model, an empty container is considered to
-     * have the NULL value. This method helps you to know whether or not
+     * have the NULL value. This method helps you to know whether
      * the container has the NULL value.
      *
      * @return bool Whether the container has to be considered as NULL.

--- a/src/qtism/runtime/common/ResponseVariable.php
+++ b/src/qtism/runtime/common/ResponseVariable.php
@@ -37,7 +37,7 @@ use qtism\data\state\VariableDeclaration;
  * A note from IMS about response variables initialization:
  *
  * At runtime, response variables are instantiated as part of an item session. Their values are always initialized to
- * NULL (no value) regardless of whether or not a default value is given in the declaration. A response variable with a NULL
+ * NULL (no value) regardless of whether a default value is given in the declaration. A response variable with a NULL
  * value indicates that the candidate has not offered a response, either because they have not attempted the item at all or
  * because they have attempted it and chosen not to provide a response.
  *

--- a/src/qtism/runtime/common/State.php
+++ b/src/qtism/runtime/common/State.php
@@ -107,7 +107,7 @@ class State extends AbstractCollection
         } elseif ($variable instanceof Variable) {
             $variableIdentifier = $variable->getIdentifier();
         } else {
-            $msg = "The variable argument must be a Variable object or a string, '" . $variable . "' given";
+            $msg = "The variable argument must be a Variable object or a string, '" . gettype($variable) . "' given";
             throw new InvalidArgumentException($msg);
         }
 
@@ -197,7 +197,7 @@ class State extends AbstractCollection
     }
 
     /**
-     * Whether or not the State contains NULL only values.
+     * Whether the State contains NULL only values.
      *
      * Please note that in QTI terms, empty containers and empty strings are considered
      * to be NULL as well. Moreover, if the State is empty of any variable, the method
@@ -221,7 +221,7 @@ class State extends AbstractCollection
     }
 
     /**
-     * Whether or not the State contains only values that are equals to their variable default value only.
+     * Whether the State contains only values that are equals to their variable default value only.
      *
      * @return bool
      */

--- a/src/qtism/runtime/common/TemplateVariable.php
+++ b/src/qtism/runtime/common/TemplateVariable.php
@@ -39,7 +39,7 @@ class TemplateVariable extends Variable
     /**
      * From IMS QTI:
      *
-     * This attribute determines whether or not the template variable's value should be substituted for
+     * This attribute determines whether the template variable's value should be substituted for
      * object parameter values that match its name. See param for more information.
      *
      * @var bool
@@ -49,7 +49,7 @@ class TemplateVariable extends Variable
     /**
      * From IMS QTI:
      *
-     * This attribute determines whether or not the template variable's value should be substituted
+     * This attribute determines whether the template variable's value should be substituted
      * for identifiers that match its name in MathML expressions. See Combining Template Variables
      * and MathML for more information.
      *
@@ -73,7 +73,7 @@ class TemplateVariable extends Variable
     }
 
     /**
-     * Set whether or not the template's value should be substituted for object
+     * Set whether the template's value should be substituted for object
      * parameter values.
      *
      * @param bool $paramVariable
@@ -90,7 +90,7 @@ class TemplateVariable extends Variable
     }
 
     /**
-     * Let you know whether or not the template variable's value should be substituted
+     * Let you know whether the template variable's value should be substituted
      * for object parameter values.
      *
      * @return bool

--- a/src/qtism/runtime/common/Utils.php
+++ b/src/qtism/runtime/common/Utils.php
@@ -261,7 +261,7 @@ class Utils
     }
 
     /**
-     * Whether or not a QtiDatatype is considered to be null.
+     * Whether a QtiDatatype is considered to be null.
      *
      * As per the QTI specification, the NULL value, empty strings and empty containers
      * are always treated as NULL values.
@@ -277,7 +277,7 @@ class Utils
     }
 
     /**
-     * Whether or not two QtiDatatype instances are equals.
+     * Whether two QtiDatatype instances are equals.
      *
      * Because the runtime model
      * also deals with null values, this utility method helps to determine equality

--- a/src/qtism/runtime/expressions/NumberPresentedProcessor.php
+++ b/src/qtism/runtime/expressions/NumberPresentedProcessor.php
@@ -34,7 +34,7 @@ use qtism\data\expressions\NumberPresented;
  *
  * This expression, which can only be used in outcomes processing, calculates the number
  * of items in a given sub-set that have been attempted (at least once). In other words,
- * items with which the user has interacted, whether or not they provided a response. The
+ * items with which the user has interacted, whether they provided a response. The
  * result is an integer with single cardinality.
  */
 class NumberPresentedProcessor extends ItemSubsetProcessor

--- a/src/qtism/runtime/pci/json/Unmarshaller.php
+++ b/src/qtism/runtime/pci/json/Unmarshaller.php
@@ -138,7 +138,7 @@ class Unmarshaller
             throw new UnmarshallingException($msg, $code);
         }
 
-        // Check whether or not $json is a state (no 'base' nor 'list' keys found),
+        // Check whether $json is a state (no 'base' nor 'list' keys found),
         // a base, a list or a record.
         $keys = array_keys($json);
 
@@ -205,59 +205,45 @@ class Unmarshaller
             switch ($keys[0]) {
                 case 'boolean':
                     return $this->unmarshallBoolean($unit);
-                    break;
 
                 case 'integer':
                     return $this->unmarshallInteger($unit);
-                    break;
 
                 case 'float':
                     return $this->unmarshallFloat($unit);
-                    break;
 
                 case 'string':
                     return $this->unmarshallString($unit);
-                    break;
 
                 case 'point':
                     return $this->unmarshallPoint($unit);
-                    break;
 
                 case 'pair':
                     return $this->unmarshallPair($unit);
-                    break;
 
                 case 'directedPair':
                     return $this->unmarshallDirectedPair($unit);
-                    break;
 
                 case 'duration':
                     return $this->unmarshallDuration($unit);
-                    break;
 
                 case 'file':
                     return $this->unmarshallFile($unit);
-                    break;
 
                 case FileHash::FILE_HASH_KEY:
                     return $this->unmarshallFileHash($unit);
-                    break;
 
                 case 'uri':
                     return $this->unmarshallUri($unit);
-                    break;
 
                 case 'intOrIdentifier':
                     return $this->unmarshallIntOrIdentifier($unit);
-                    break;
 
                 case 'identifier':
                     return $this->unmarshallIdentifier($unit);
-                    break;
 
                 default:
                     throw new UnmarshallingException("Unknown QTI baseType '" . $keys[0] . "'");
-                    break;
             }
         } catch (InvalidArgumentException $e) {
             $msg = 'A value does not satisfy its baseType.';

--- a/src/qtism/runtime/rendering/css/CssScoper.php
+++ b/src/qtism/runtime/rendering/css/CssScoper.php
@@ -108,13 +108,6 @@ class CssScoper implements Renderable
     private $previousChar = false;
 
     /**
-     * The previously read significant char.
-     *
-     * @var string
-     */
-    private $previousSignificantChar = false;
-
-    /**
      * The currently read char.
      *
      * @var string
@@ -143,19 +136,19 @@ class CssScoper implements Renderable
     private $previousState = false;
 
     /**
-     * Whether or not map QTI classes to their qti-X CSS classes.
+     * Whether map QTI classes to their qti-X CSS classes.
      *
      * @var bool
      */
     private $mapQtiClasses = false;
 
     /**
-     * Whether or not map -qti-* like peuso classes to qti-X CSS classes.
+     * Whether map -qti-* like peuso classes to qti-X CSS classes.
      */
     private $mapQtiPseudoClasses = false;
 
     /**
-     * @var bool Whether or not using the Web Component Friendly mode.
+     * @var bool Whether using the Web Component Friendly mode.
      */
     private $webComponentFriendly = false;
 
@@ -336,8 +329,8 @@ class CssScoper implements Renderable
     /**
      * Create a new CssScoper object.
      *
-     * @param bool $mapQtiClasses Whether or not to map QTI classes (e.g. simpleChoice) to their qti-X CSS class equivalent. Default is false.
-     * @param bool $mapQtiPseudoClasses Whether or not to map QTI pseudo classes (e.g. -qti-selected) to their qti-X CSS class equivalent. Default is false.
+     * @param bool $mapQtiClasses Whether to map QTI classes (e.g. simpleChoice) to their qti-X CSS class equivalent. Default is false.
+     * @param bool $mapQtiPseudoClasses Whether to map QTI pseudo classes (e.g. -qti-selected) to their qti-X CSS class equivalent. Default is false.
      */
     public function __construct($mapQtiClasses = false, $mapQtiPseudoClasses = false)
     {
@@ -491,7 +484,6 @@ class CssScoper implements Renderable
         $this->setBuffer([]);
         $this->setOutput('');
         $this->setPreviousChar(false);
-        $this->setPreviousSignificantChar(false);
 
         if (($data = @file_get_contents($file)) !== false) {
             $stream = new MemoryStream($data);
@@ -580,20 +572,6 @@ class CssScoper implements Renderable
     protected function afterCharReading($char): void
     {
         $this->setPreviousChar($char);
-
-        if (self::isWhiteSpace($char) === false) {
-            $this->setPreviousSignificantChar($char);
-        }
-    }
-
-    /**
-     * Set the previous significant char.
-     *
-     * @param string $char
-     */
-    protected function setPreviousSignificantChar($char): void
-    {
-        $this->previousSignificantChar = $char;
     }
 
     /**

--- a/src/qtism/runtime/rendering/markup/AbstractMarkupRenderingEngine.php
+++ b/src/qtism/runtime/rendering/markup/AbstractMarkupRenderingEngine.php
@@ -343,7 +343,7 @@ abstract class AbstractMarkupRenderingEngine implements Renderable
 
     /**
      * Set the array used to 'tag' components in order to know
-     * whether or not they are already explored.
+     * whether they are already explored.
      *
      * @return array
      */
@@ -509,7 +509,7 @@ abstract class AbstractMarkupRenderingEngine implements Renderable
     }
 
     /**
-     * Whether or not the currently explored Component object
+     * Whether the currently explored Component object
      * is a final leaf of the tree structured explored hierarchy.
      *
      * @return bool

--- a/src/qtism/runtime/rendering/markup/MarkupPostRenderer.php
+++ b/src/qtism/runtime/rendering/markup/MarkupPostRenderer.php
@@ -32,14 +32,14 @@ use qtism\runtime\rendering\RenderingException;
 class MarkupPostRenderer implements Renderable
 {
     /**
-     * Whether or not format the XML output.
+     * Whether format the XML output.
      *
      * @var bool
      */
     private $formatOutput = false;
 
     /**
-     * Whether or not clean up XML declarations.
+     * Whether clean up XML declarations.
      *
      * @var bool
      */
@@ -70,9 +70,9 @@ class MarkupPostRenderer implements Renderable
     /**
      * Create a new MarkupPostRenderer object.
      *
-     * @param bool $formatOutput Whether or not format the XML output.
-     * @param bool $cleanUpXmlDeclaration Whether or not clean up XML declaration (i.e. <?xml version="1.0" ... ?>).
-     * @param bool $templateOriented Whether or not replace qtism control statements (e.g. qtism-if, qtism-endif) or qtism functions (e.g. qtism-printedVariable) into PHP control statements/function calls.
+     * @param bool $formatOutput Whether format the XML output.
+     * @param bool $cleanUpXmlDeclaration Whether clean up XML declaration (i.e. <?xml version="1.0" ... ?>).
+     * @param bool $templateOriented Whether replace qtism control statements (e.g. qtism-if, qtism-endif) or qtism functions (e.g. qtism-printedVariable) into PHP control statements/function calls.
      */
     public function __construct($formatOutput = false, $cleanUpXmlDeclaration = false, $templateOriented = false)
     {

--- a/src/qtism/runtime/rendering/markup/xhtml/Utils.php
+++ b/src/qtism/runtime/rendering/markup/xhtml/Utils.php
@@ -121,7 +121,7 @@ class Utils
     }
 
     /**
-     * Whether or not a given $node element has the given CSS $class(es).
+     * Whether a given $node element has the given CSS $class(es).
      *
      * @param DOMElement $node
      * @param string|array $class A class or an array of CSS classes.

--- a/src/qtism/runtime/storage/common/AbstractStorage.php
+++ b/src/qtism/runtime/storage/common/AbstractStorage.php
@@ -143,9 +143,9 @@ abstract class AbstractStorage
     abstract public function retrieve($sessionId);
 
     /**
-     * Whether or not an AssessmentTestSession object exits in persistence for a given session ID.
+     * Whether an AssessmentTestSession object exits in persistence for a given session ID.
      *
-     * This method allows you to know whether or not an AssessmentTestSession object
+     * This method allows you to know whether an AssessmentTestSession object
      * with session ID $sessionId exists as a persistent entity.
      *
      * @param string $sessionId

--- a/src/qtism/runtime/tests/AbstractSessionManager.php
+++ b/src/qtism/runtime/tests/AbstractSessionManager.php
@@ -126,7 +126,7 @@ abstract class AbstractSessionManager
     abstract protected function instantiateAssessmentItemSession(IAssessmentItem $assessmentItem, $navigationMode, $submissionMode): AssessmentItemSession;
 
     /**
-     * Contains the Route create logic depending on whether or not
+     * Contains the Route create logic depending on whether
      * an optional Route to be used is given or not.
      *
      * @param AssessmentTest $test

--- a/src/qtism/runtime/tests/AssessmentItemSession.php
+++ b/src/qtism/runtime/tests/AssessmentItemSession.php
@@ -97,7 +97,7 @@ use qtism\runtime\tests\Utils as TestUtils;
  *
  * In a typical non-Adaptive Test the items are selected in advance and the candidate's
  * interaction with all items is reported at the end of the test session, regardless of
- * whether or not the candidate actually attempted all the items. In effect, item sessions
+ * whether the candidate actually attempted all the items. In effect, item sessions
  * are created in the initial state for all items at the start of the test and are
  * maintained in parallel. In an Adaptive Test the items that are to be presented are
  * selected during the session based on the responses and outcomes associated with the
@@ -217,7 +217,7 @@ class AssessmentItemSession extends State
     private $assessmentItem;
 
     /**
-     * Whether or not the session (SUSPENDED or INTERACTING) is currently attempting an attempt.
+     * Whether the session (SUSPENDED or INTERACTING) is currently attempting an attempt.
      * In other words, a candidate begun an attempt and did not ended it yet.
      *
      * @var bool
@@ -249,7 +249,7 @@ class AssessmentItemSession extends State
      * @param IAssessmentItem $assessmentItem The description of the item that the session handles.
      * @param int $navigationMode (optional) A value from the NavigationMode enumeration.
      * @param int $submissionMode (optional) A value from the SubmissionMode enumeration.
-     * @param bool $autoTemplateProcessing (optional) Whether or not template processing must occur automatically. Default is true.
+     * @param bool $autoTemplateProcessing (optional) Whether template processing must occur automatically. Default is true.
      * @throws InvalidArgumentException If $navigationMode or $submission is not a value from the NavigationMode/SubmissionMode enumeration.
      * @see \qtism\runtime\tests\AssessmentItemSession::setItemSessionControl() The setItemSessionControl() method.
      * @see \qtism\runtime\tests\AssessmentItemSession::setTimeLimits() The setTimeLimits() method.
@@ -679,7 +679,7 @@ class AssessmentItemSession extends State
          * In simultaneous mode, response processing cannot take place until the testPart is
          * complete so each item session passes between the interacting and suspended states only.
          * By definition the candidate can take one and only one attempt at each item and feedback
-         * cannot be seen during the test. Whether or not the candidate can return to review
+         * cannot be seen during the test. Whether the candidate can return to review
          * their responses and/or any item-level feedback after the test, is outside the scope
          * of this specification. Simultaneous mode is typical of paper-based tests.
          */
@@ -1076,7 +1076,7 @@ class AssessmentItemSession extends State
 
     /**
      * Whether the item of the session has been attempted (at least once).
-     * In other words, items which the user has interacted, whether or not they provided a response.
+     * In other words, items which the user has interacted, whether they provided a response.
      *
      * @return bool
      */
@@ -1243,7 +1243,7 @@ class AssessmentItemSession extends State
     /**
      * Whether the current session affects visibility of modal feedbacks.
      *
-     * This method will detect whether or not the current is composed by a scope of
+     * This method will detect whether the current is composed by a scope of
      * variable set in such a way that at least one modalFeedback elements must be displayed.
      *
      * Please note that if the current itemSessionControl's showFeedback attribute value is false
@@ -1269,7 +1269,7 @@ class AssessmentItemSession extends State
         // is lesser or equal to 1, no feedback must be shown. This is very problematic in case of a linear test, where it is logic
         // to set the maxAttempts to 1, because the number of attempts is defacto 1 in such a linear test. In such a context, no
         // feedbacks can be shown. QTI-SDK Developers decided that it was more sensitive to show feedbacks if maxAttempts is lesser
-        // or equal to 1. However, "once the maximum number of allowed attempts have been used whether or not the feeback is shown
+        // or equal to 1. However, "once the maximum number of allowed attempts have been used whether the feeback is shown
         // is still controlled by the showFeedback constraint.
 
         $mustModalFeedback = false;
@@ -1304,7 +1304,7 @@ class AssessmentItemSession extends State
     /**
      * Apply templateProcessing on the session if a templateProcessing is described.
      *
-     * @return bool Whether or not the template processing occurred.
+     * @return bool Whether the template processing occurred.
      * @throws RuleProcessingException
      */
     public function templateProcessing(): bool
@@ -1330,7 +1330,7 @@ class AssessmentItemSession extends State
     /**
      * Check whether or not the item can be skipped.
      *
-     * This method checks whether or not the item can be skipped depending on the current itemSessionControl
+     * This method checks whether the item can be skipped depending on the current itemSessionControl
      * configuration and the $responses provided to end the attempt.
      *
      * @param State $responses
@@ -1366,7 +1366,7 @@ class AssessmentItemSession extends State
     /**
      * Check Response Validity Constraints of the item.
      *
-     * This method checks whether or not a set of $responses are all valid against the Response Validity Constraints
+     * This method checks whether a set of $responses are all valid against the Response Validity Constraints
      * in force for the item managed by the AssessmentItemSession.
      *
      * @param State $responses

--- a/src/qtism/runtime/tests/DurationStore.php
+++ b/src/qtism/runtime/tests/DurationStore.php
@@ -35,7 +35,7 @@ use qtism\runtime\common\State;
 class DurationStore extends State
 {
     /**
-     * Checks whether or not $value:
+     * Checks whether $value:
      *
      * * is an instance of OutcomeVariable
      * * has a 'duration' QTI baseType.

--- a/src/qtism/runtime/tests/RouteItem.php
+++ b/src/qtism/runtime/tests/RouteItem.php
@@ -423,7 +423,7 @@ class RouteItem
     /**
      * Get the TimeLimits in force for the RouteItem.
      *
-     * @param bool $excludeItem Whether or not include the TimeLimits in force for the assessment item of the RouteItem.
+     * @param bool $excludeItem Whether include the TimeLimits in force for the assessment item of the RouteItem.
      * @return RouteTimeLimitsCollection
      */
     public function getTimeLimits($excludeItem = false): RouteTimeLimitsCollection

--- a/src/qtism/runtime/tests/SelectableRoute.php
+++ b/src/qtism/runtime/tests/SelectableRoute.php
@@ -135,7 +135,7 @@ class SelectableRoute extends Route
     }
 
     /**
-     * Set whether or not the RouteItem objects held by the Route must be kept together.
+     * Set whether the RouteItem objects held by the Route must be kept together.
      *
      * @param bool $keepTogether
      */

--- a/src/qtism/runtime/tests/TimeConstraint.php
+++ b/src/qtism/runtime/tests/TimeConstraint.php
@@ -173,7 +173,7 @@ class TimeConstraint
     }
 
     /**
-     * Whether or not a maxTime constraint is in force for the timeLimits (if existing) bound to the source
+     * Whether a maxTime constraint is in force for the timeLimits (if existing) bound to the source
      * of the time constraint.
      *
      * @return bool
@@ -184,7 +184,7 @@ class TimeConstraint
     }
 
     /**
-     * Whether or not a minTime constraint is in force for the timeLimits (if existing) bound to the source of
+     * Whether a minTime constraint is in force for the timeLimits (if existing) bound to the source of
      * the time constraint.
      *
      * Please note that minTimes are applicable to assessmentSection and assessmentItems only when linear navigation

--- a/src/qtism/runtime/tests/TimeConstraintCollection.php
+++ b/src/qtism/runtime/tests/TimeConstraintCollection.php
@@ -32,7 +32,7 @@ use qtism\common\collections\AbstractCollection;
 class TimeConstraintCollection extends AbstractCollection
 {
     /**
-     * Checks whether or not $value is an instance of TimeConstraint.
+     * Checks whether $value is an instance of TimeConstraint.
      *
      * @param mixed $value
      * @throws InvalidArgumentException If $value is not an instance of TimeConstraint.

--- a/test/qtismtest/data/storage/xml/XmlUtilsTest.php
+++ b/test/qtismtest/data/storage/xml/XmlUtilsTest.php
@@ -297,7 +297,7 @@ class XmlUtilsTest extends QtiSmTestCase
             ['float', 1.1, '<foo float="1.1"/>'],
             ['double', 1.1, '<foo double="1.1"/>'],
             ['boolean', true, '<foo boolean="true"/>'],
-            ['not-existing',  null, '<foo not-existing=""/>'],
+            ['not-existing', null, '<foo not-existing=""/>'],
         ];
     }
 
@@ -400,39 +400,40 @@ class XmlUtilsTest extends QtiSmTestCase
 
     public function testProcessSpecialCharsetWithoutError(): void
     {
-        $xml = ('<assessmentResult
-	xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p1"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<context/>
-	<testResult identifier="44127db28512-suomynona#903756e974e7#e94025be336b1f89159af64b1f6eda5d470ac8d61#local-dev-acc.nextgen-stack-local" datestamp="2024-10-30T12:56:32+00:00"/>
-	<itemResult identifier="item-1" datestamp="2024-10-30T12:56:32+00:00" sessionStatus="final">
-		<responseVariable identifier="numAttempts" cardinality="single" baseType="integer">
-			<candidateResponse>
-				<value>1</value>
-			</candidateResponse>
-		</responseVariable>
-		<responseVariable identifier="duration" cardinality="single" baseType="duration">
-			<candidateResponse>
-				<value>PT22S</value>
-			</candidateResponse>
-		</responseVariable>
-		<outcomeVariable identifier="completionStatus" cardinality="single" baseType="identifier">
-			<value>completed</value>
-		</outcomeVariable>
-		<outcomeVariable identifier="SCORE" cardinality="single" baseType="float">
-			<value>0</value>
-		</outcomeVariable>
-		<outcomeVariable identifier="MAXSCORE" cardinality="single" baseType="float">
-			<value>1</value>
-		</outcomeVariable>
-		<responseVariable identifier="RESPONSE" cardinality="single" baseType="string">
-			<candidateResponse>
-				<value>%s</value>
-			</candidateResponse>
-		</responseVariable>
-	</itemResult>
+        $xml = <<<'XML'
+<assessmentResult
+    xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <context/>
+    <testResult identifier="44127db28512-suomynona#903756e974e7#e94025be336b1f89159af64b1f6eda5d470ac8d61#local-dev-acc.nextgen-stack-local" datestamp="2024-10-30T12:56:32+00:00"/>
+    <itemResult identifier="item-1" datestamp="2024-10-30T12:56:32+00:00" sessionStatus="final">
+        <responseVariable identifier="numAttempts" cardinality="single" baseType="integer">
+            <candidateResponse>
+                <value>1</value>
+            </candidateResponse>
+        </responseVariable>
+        <responseVariable identifier="duration" cardinality="single" baseType="duration">
+            <candidateResponse>
+                <value>PT22S</value>
+            </candidateResponse>
+        </responseVariable>
+        <outcomeVariable identifier="completionStatus" cardinality="single" baseType="identifier">
+            <value>completed</value>
+        </outcomeVariable>
+        <outcomeVariable identifier="SCORE" cardinality="single" baseType="float">
+            <value>0</value>
+        </outcomeVariable>
+        <outcomeVariable identifier="MAXSCORE" cardinality="single" baseType="float">
+            <value>1</value>
+        </outcomeVariable>
+        <responseVariable identifier="RESPONSE" cardinality="single" baseType="string">
+            <candidateResponse>
+                <value>%s</value>
+            </candidateResponse>
+        </responseVariable>
+    </itemResult>
 </assessmentResult>
-');
+XML;
         $this->assertNotNull(Utils::findExternalNamespaces(sprintf($xml, Utils::valueAsString("160\u{0008}"))));
     }
 

--- a/test/qtismtest/runtime/common/StateTest.php
+++ b/test/qtismtest/runtime/common/StateTest.php
@@ -236,7 +236,7 @@ class StateTest extends QtiSmTestCase
         $state = new State();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("The variable argument must be a Variable object or a string, '1' given");
+        $this->expectExceptionMessage("The variable argument must be a Variable object or a string, 'boolean' given");
 
         $state->unsetVariable(true);
     }


### PR DESCRIPTION
This PR properly trims string values as part of the binary stream, so that no partial multibyte character is left there.

The actual fix is https://github.com/oat-sa/qti-sdk/pull/417/commits/b9a932646aa9c1a813c8e8a0b48df6cc3240f3a9. The rest is just fluff.