### PR TITLE
fix: add unicode modifier to calculate also jp symbols

### DIFF
--- a/qtism/runtime/expressions/operators/Utils.php
+++ b/qtism/runtime/expressions/operators/Utils.php
@@ -341,7 +341,7 @@ class Utils
         $pattern = self::pregAddDelimiter('^' . $pattern . '$');
 
         // XSD regexp always case-sensitive (nothing to do), dot matches white-spaces (use PCRE_DOTALL).
-        $pattern .= 's';
+        $pattern .= 'su';
 
         return $pattern;
     }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-353

We need to add Unicode modifier for patterns for properly calculating JP symbols 

For example:
```
var_dump( preg_match('/^[\s\S]{0,5}$/s', 'あいうえお')) ; // int(0)
but
var_dump( preg_match('/^[\s\S]{0,5}$/su', '12345') );   // int(1)
var_dump( preg_match('/^[\s\S]{0,5}$/su', 'abcdf') );   // int(1)
var_dump( preg_match('/^[\s\S]{0,5}$/su', 'あいうえお') ); // int(1)
```