### PR TITLE
feat: validate branch rule

### DIFF
--- a/src/qtism/data/AssessmentTest.php
+++ b/src/qtism/data/AssessmentTest.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/AssessmentTest.php
+++ b/src/qtism/data/AssessmentTest.php
@@ -805,7 +805,7 @@ class AssessmentTest extends QtiComponent implements QtiIdentifiable
         // Special cases
 
         switch ($branch->getTarget()) {
-            case 'EXIT_TEST':
+            case BranchRule::EXIT_TEST:
                 $prevItem = DataUtils::getLastItem($this, $component, $sections);
 
                 if ($prevItem == null) {
@@ -826,7 +826,7 @@ class AssessmentTest extends QtiComponent implements QtiIdentifiable
                 }
                 break;
 
-            case 'EXIT_TESTPART':
+            case BranchRule::EXIT_TESTPART:
                 $prevItem = DataUtils::getLastItem($this, $component, $sections);
                 $targetItem = null;
                 $currentTpFound = false;
@@ -866,7 +866,7 @@ class AssessmentTest extends QtiComponent implements QtiIdentifiable
                 }
                 break;
 
-            case 'EXIT_SECTION':
+            case BranchRule::EXIT_SECTION:
                 if ($component->getQtiClassName() == 'testPart') {
                     break;
                 }

--- a/src/qtism/data/BranchRuleTargetException.php
+++ b/src/qtism/data/BranchRuleTargetException.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Tom Verhoof <tomv@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/QtiComponentCollection.php
+++ b/src/qtism/data/QtiComponentCollection.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/QtiComponentCollection.php
+++ b/src/qtism/data/QtiComponentCollection.php
@@ -44,7 +44,8 @@ class QtiComponentCollection extends AbstractCollection
     protected function checkType($value): void
     {
         if (!$value instanceof QtiComponent) {
-            $msg = "QtiComponentCollection class only accept QtiComponent objects, '" . get_class($value) . "' given.";
+            $msg = "QtiComponentCollection class only accept QtiComponent objects, '" .
+                (is_object($value) ? get_class($value) : gettype($value)) . "' given.";
             throw new InvalidArgumentException($msg);
         }
     }

--- a/src/qtism/data/results/AssessmentResult.php
+++ b/src/qtism/data/results/AssessmentResult.php
@@ -108,7 +108,9 @@ class AssessmentResult extends QtiComponent
         }
 
         if ($this->hasItemResults()) {
-            $components[] = $this->getItemResults()->getArrayCopy();
+            foreach ($this->getItemResults() as $itemResult) {
+                $components[] = $itemResult;
+            }
         }
 
         return new QtiComponentCollection($components);

--- a/src/qtism/data/results/AssessmentResult.php
+++ b/src/qtism/data/results/AssessmentResult.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2018-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2018-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Moyon Camille <camille@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/results/ItemResult.php
+++ b/src/qtism/data/results/ItemResult.php
@@ -157,10 +157,11 @@ class ItemResult extends QtiComponent
      */
     public function getComponents(): QtiComponentCollection
     {
+        $components = [];
         if ($this->hasItemVariables()) {
-            $components = $this->getItemVariables()->toArray();
-        } else {
-            $components = [];
+            foreach ($this->getItemVariables() as $itemVariable) {
+                $components[] = $itemVariable;
+            }
         }
         return new QtiComponentCollection($components);
     }

--- a/src/qtism/data/results/ItemResult.php
+++ b/src/qtism/data/results/ItemResult.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2018-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2018-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Moyon Camille <camille@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/results/ResultResponseVariable.php
+++ b/src/qtism/data/results/ResultResponseVariable.php
@@ -109,7 +109,7 @@ class ResultResponseVariable extends ItemVariable
     {
         $components = [$this->getCandidateResponse()];
         if ($this->hasCorrectResponse()) {
-            $components = array_merge($components, $this->getCorrectResponse());
+            $components[] = $this->getCorrectResponse();
         }
         return new QtiComponentCollection($components);
     }

--- a/src/qtism/data/results/ResultResponseVariable.php
+++ b/src/qtism/data/results/ResultResponseVariable.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2018-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2018-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Moyon Camille <camille@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/results/TestResult.php
+++ b/src/qtism/data/results/TestResult.php
@@ -99,10 +99,11 @@ class TestResult extends QtiComponent
      */
     public function getComponents(): QtiComponentCollection
     {
+        $components = [];
         if ($this->hasItemVariables()) {
-            $components = $this->getItemVariables()->toArray();
-        } else {
-            $components = [];
+            foreach ($this->getItemVariables() as $itemVariable) {
+                $components[] = $itemVariable;
+            }
         }
         return new QtiComponentCollection($components);
     }

--- a/src/qtism/data/results/TestResult.php
+++ b/src/qtism/data/results/TestResult.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2018-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2018-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Moyon Camille <camille@taotesting.com>
  * @license GPLv2

--- a/src/qtism/data/rules/BranchRule.php
+++ b/src/qtism/data/rules/BranchRule.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @license GPLv2
@@ -54,7 +54,7 @@ class BranchRule extends QtiComponent implements Rule
     public const EXIT_TESTPART = 'EXIT_TESTPART';
     public const EXIT_SECTION = 'EXIT_SECTION';
 
-    public const SPECIAL_TARGETS = [
+    public const RESERVED_TARGETS = [
         self::EXIT_TEST,
         self::EXIT_TESTPART,
         self::EXIT_SECTION,

--- a/src/qtism/data/rules/BranchRule.php
+++ b/src/qtism/data/rules/BranchRule.php
@@ -50,6 +50,16 @@ use qtism\data\QtiComponentCollection;
  */
 class BranchRule extends QtiComponent implements Rule
 {
+    public const EXIT_TEST = 'EXIT_TEST';
+    public const EXIT_TESTPART = 'EXIT_TESTPART';
+    public const EXIT_SECTION = 'EXIT_SECTION';
+
+    public const SPECIAL_TARGETS = [
+        self::EXIT_TEST,
+        self::EXIT_TESTPART,
+        self::EXIT_SECTION,
+    ];
+
     /**
      * The expression of the BranchRule.
      *

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -696,21 +696,22 @@ class XmlDocument extends QtiDocument
             return;
         }
 
+        $errors = [];
         foreach ($branchRules as $branchRule) {
-            $error = [];
             $target = $branchRule->getTarget();
             if (empty($target)) {
-                $error[] = 'BranchRule is missing a target attribute';
-            } else {
-                $targetElement = $docComponent->getComponentByIdentifier($target);
-                if ($targetElement === null && !in_array($target, BranchRule::SPECIAL_TARGETS, true)) {
-                    $error[] = sprintf('BranchRule target "%s" does not exist in the document', $target);
-                }
+                $errors[] = 'BranchRule is missing a target attribute';
+                continue;
+            }
+
+            $targetElement = $docComponent->getComponentByIdentifier($target);
+            if ($targetElement === null && !in_array($target, BranchRule::SPECIAL_TARGETS, true)) {
+                $errors[] = sprintf('BranchRule target "%s" does not exist in the document', $target);
             }
         }
 
-        if (!empty($error)) {
-            throw new BranchRuleTargetException(implode('; ', $error));
+        if (!empty($errors)) {
+            throw new BranchRuleTargetException(implode('; ', $errors));
         }
     }
 }

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2025 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  * @author Jérôme Bogaerts <jerome@taotesting.com>
  * @author Julien Sébire <julien@taotesting.com>
@@ -170,7 +170,7 @@ class XmlDocument extends QtiDocument
      * @param bool $validate Whether the file must be validated unsing XML Schema? Default is false.
      * @throws XmlStorageException If an error occurs while loading the QTI-XML file.
      */
-    public function load(string $url, ?bool $validate = false): void
+    public function load(string $url, bool $validate = false): void
     {
         $this->loadImplementation($this->loadFromFile($url), $validate);
         $this->setUrl($url);
@@ -705,7 +705,7 @@ class XmlDocument extends QtiDocument
             }
 
             $targetElement = $docComponent->getComponentByIdentifier($target);
-            if ($targetElement === null && !in_array($target, BranchRule::SPECIAL_TARGETS, true)) {
+            if ($targetElement === null && !in_array($target, BranchRule::RESERVED_TARGETS, true)) {
                 $errors[] = sprintf('BranchRule target "%s" does not exist in the document', $target);
             }
         }

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -691,7 +691,7 @@ class XmlDocument extends QtiDocument
      */
     private function validateDocComponent(QtiComponent $docComponent): void
     {
-        $branchRules = $docComponent->getComponentsByClassName('branchRule');
+        $branchRules = $docComponent->getComponentsByClassName('branchRule', true);
         if ($branchRules->count() === 0) {
             return;
         }

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -698,7 +698,7 @@ class XmlDocument extends QtiDocument
             $error = [];
             $target = $branchRule->getTarget();
             if (empty($target)) {
-                $error[] = BranchRuleTargetException::UNKNOWN_TARGET;
+                $error[] = 'BranchRule is missing a target attribute';
             } else {
                 $targetElement = $docComponent->getComponentByIdentifier($target);
                 if ($targetElement === null) {

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -170,7 +170,7 @@ class XmlDocument extends QtiDocument
      * @param bool $validate Whether the file must be validated unsing XML Schema? Default is false.
      * @throws XmlStorageException If an error occurs while loading the QTI-XML file.
      */
-    public function load(string $url, $validate = false): void
+    public function load(string $url, ?bool $validate = false): void
     {
         $this->loadImplementation($this->loadFromFile($url), $validate);
         $this->setUrl($url);
@@ -195,6 +195,7 @@ class XmlDocument extends QtiDocument
      * @param mixed $data
      * @param bool $validate
      * @throws XmlStorageException
+     * @throws BranchRuleTargetException
      */
     protected function loadImplementation($data, bool $validate): void
     {

--- a/src/qtism/data/storage/xml/XmlDocument.php
+++ b/src/qtism/data/storage/xml/XmlDocument.php
@@ -41,6 +41,7 @@ use qtism\data\QtiComponent;
 use qtism\data\QtiComponentCollection;
 use qtism\data\QtiComponentIterator;
 use qtism\data\QtiDocument;
+use qtism\data\rules\BranchRule;
 use qtism\data\storage\xml\filesystem\FilesystemFactory;
 use qtism\data\storage\xml\filesystem\FilesystemInterface;
 use qtism\data\storage\xml\filesystem\FilesystemException;
@@ -701,7 +702,7 @@ class XmlDocument extends QtiDocument
                 $error[] = 'BranchRule is missing a target attribute';
             } else {
                 $targetElement = $docComponent->getComponentByIdentifier($target);
-                if ($targetElement === null) {
+                if ($targetElement === null && !in_array($target, BranchRule::SPECIAL_TARGETS, true)) {
                     $error[] = sprintf('BranchRule target "%s" does not exist in the document', $target);
                 }
             }

--- a/test/qtismtest/data/storage/xml/XmlDocumentTest.php
+++ b/test/qtismtest/data/storage/xml/XmlDocumentTest.php
@@ -15,6 +15,7 @@ use qtism\data\content\TextRun;
 use qtism\data\content\xhtml\A;
 use qtism\data\content\xhtml\presentation\Hr;
 use qtism\data\content\xhtml\text\Div;
+use qtism\data\BranchRuleTargetException;
 use qtism\data\storage\xml\marshalling\MarshallingException;
 use qtism\data\storage\xml\XmlDocument;
 use qtism\data\storage\xml\XmlStorageException;
@@ -525,6 +526,85 @@ class XmlDocumentTest extends QtiSmTestCase
         $uri = self::samplesDir() . 'invalid/xsdinvalid.xml';
         $doc = new XmlDocument('2.1.0');
         $doc->load($uri, true);
+    }
+    
+    /**
+     * Test loading a document with valid branch rule targets
+     */
+    public function testValidBranchRuleTargets(): void
+    {
+        $doc = new XmlDocument();
+        $doc->load(self::samplesDir() . 'custom/branch_rules/test_with_valid_branch_rules.xml', true);
+        
+        // If we get here, the document loaded and validated successfully
+        $this::assertTrue(true);
+    }
+    
+    /**
+     * Test loading a document with special branch rule targets (EXIT_TEST, etc.)
+     */
+    public function testSpecialTargetBranchRules(): void
+    {
+        $doc = new XmlDocument();
+        $doc->load(self::samplesDir() . 'custom/branch_rules/test_with_special_targets.xml', true);
+        
+        // If we get here, the document loaded and validated successfully
+        $this::assertTrue(true);
+    }
+    
+    /**
+     * Test loading a document with an invalid branch rule target 
+     * should throw a BranchRuleTargetException
+     */
+    public function testInvalidBranchRuleTarget(): void
+    {
+        $doc = new XmlDocument();
+        
+        $this->expectException(BranchRuleTargetException::class);
+        $this->expectExceptionMessage('BranchRule target "nonexistent_item" does not exist in the document');
+        
+        $doc->load(self::samplesDir() . 'custom/branch_rules/test_with_invalid_target_branch_rule.xml', true);
+    }
+    
+    /**
+     * Test loading a document with multiple branch rules where one has an invalid target
+     * should throw a BranchRuleTargetException
+     */
+    public function testMultipleBranchRulesWithOneInvalid(): void
+    {
+        $doc = new XmlDocument();
+        
+        $this->expectException(BranchRuleTargetException::class);
+        $this->expectExceptionMessage('BranchRule target "nonexistent_item" does not exist in the document');
+        
+        $doc->load(self::samplesDir() . 'custom/branch_rules/test_with_multiple_branch_rules.xml', true);
+    }
+    
+    /**
+     * Test loading a document with a missing branch rule target
+     * should throw an XmlStorageException due to XML Schema validation failure
+     */
+    public function testMissingBranchRuleTarget(): void
+    {
+        $doc = new XmlDocument();
+        
+        $this->expectException(XmlStorageException::class);
+        
+        $doc->load(self::samplesDir() . 'custom/branch_rules/test_with_missing_target_branch_rule.xml', true);
+    }
+    
+    /**
+     * Test loading a document with multiple invalid branch rule targets
+     * should throw a BranchRuleTargetException with multiple error messages
+     */
+    public function testMultipleInvalidBranchRuleTargets(): void
+    {
+        $doc = new XmlDocument();
+        
+        $this->expectException(BranchRuleTargetException::class);
+        $this->expectExceptionMessage('BranchRule target "nonexistent_item1" does not exist in the document; BranchRule target "nonexistent_item2" does not exist in the document');
+        
+        $doc->load(self::samplesDir() . 'custom/branch_rules/test_with_multiple_invalid_targets.xml', true);
     }
 
     public function testXIncludeNoComponent(): void

--- a/test/samples/custom/branch_rules/test_with_invalid_target_branch_rule.xml
+++ b/test/samples/custom/branch_rules/test_with_invalid_target_branch_rule.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+                identifier="test-with-invalid-target-branch-rule" 
+                title="Test with Invalid Target Branch Rule">
+    <testPart identifier="part1" navigationMode="linear" submissionMode="individual">
+        <assessmentSection identifier="section1" title="Section 1" visible="true">
+            <assessmentItemRef identifier="item1" href="./item1.xml">
+                <branchRule target="nonexistent_item">
+                    <match>
+                        <baseValue baseType="boolean">true</baseValue>
+                        <baseValue baseType="boolean">true</baseValue>
+                    </match>
+                </branchRule>
+            </assessmentItemRef>
+        </assessmentSection>
+    </testPart>
+</assessmentTest>

--- a/test/samples/custom/branch_rules/test_with_missing_target_branch_rule.xml
+++ b/test/samples/custom/branch_rules/test_with_missing_target_branch_rule.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+                identifier="test-with-missing-target-branch-rule" 
+                title="Test with Missing Target Branch Rule">
+    <testPart identifier="part1" navigationMode="linear" submissionMode="individual">
+        <assessmentSection identifier="section1" title="Section 1" visible="true">
+            <assessmentItemRef identifier="item1" href="./item1.xml">
+                <branchRule>
+                    <match>
+                        <baseValue baseType="boolean">true</baseValue>
+                        <baseValue baseType="boolean">true</baseValue>
+                    </match>
+                </branchRule>
+            </assessmentItemRef>
+        </assessmentSection>
+    </testPart>
+</assessmentTest>

--- a/test/samples/custom/branch_rules/test_with_multiple_branch_rules.xml
+++ b/test/samples/custom/branch_rules/test_with_multiple_branch_rules.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+                identifier="test-with-multiple-branch-rules" 
+                title="Test with Multiple Branch Rules">
+    <testPart identifier="part1" navigationMode="linear" submissionMode="individual">
+        <assessmentSection identifier="section1" title="Section 1" visible="true">
+            <assessmentItemRef identifier="item1" href="./item1.xml">
+                <branchRule target="item2">
+                    <match>
+                        <baseValue baseType="boolean">true</baseValue>
+                        <baseValue baseType="boolean">true</baseValue>
+                    </match>
+                </branchRule>
+                <branchRule target="nonexistent_item">
+                    <match>
+                        <baseValue baseType="boolean">false</baseValue>
+                        <baseValue baseType="boolean">false</baseValue>
+                    </match>
+                </branchRule>
+            </assessmentItemRef>
+            <assessmentItemRef identifier="item2" href="./item2.xml" />
+        </assessmentSection>
+    </testPart>
+</assessmentTest>

--- a/test/samples/custom/branch_rules/test_with_multiple_invalid_targets.xml
+++ b/test/samples/custom/branch_rules/test_with_multiple_invalid_targets.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+                identifier="test-with-multiple-invalid-targets" 
+                title="Test with Multiple Invalid Targets">
+    <testPart identifier="part1" navigationMode="linear" submissionMode="individual">
+        <assessmentSection identifier="section1" title="Section 1" visible="true">
+            <assessmentItemRef identifier="item1" href="./item1.xml">
+                <branchRule target="nonexistent_item1">
+                    <match>
+                        <baseValue baseType="boolean">true</baseValue>
+                        <baseValue baseType="boolean">true</baseValue>
+                    </match>
+                </branchRule>
+            </assessmentItemRef>
+            <assessmentItemRef identifier="item2" href="./item2.xml">
+                <branchRule target="nonexistent_item2">
+                    <match>
+                        <baseValue baseType="boolean">true</baseValue>
+                        <baseValue baseType="boolean">true</baseValue>
+                    </match>
+                </branchRule>
+            </assessmentItemRef>
+        </assessmentSection>
+    </testPart>
+</assessmentTest>

--- a/test/samples/custom/branch_rules/test_with_special_targets.xml
+++ b/test/samples/custom/branch_rules/test_with_special_targets.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+                identifier="test-with-special-targets" 
+                title="Test with Special Target Branch Rules">
+    <testPart identifier="part1" navigationMode="linear" submissionMode="individual">
+        <assessmentSection identifier="section1" title="Section 1" visible="true">
+            <assessmentItemRef identifier="item1" href="./item1.xml">
+                <branchRule target="EXIT_TEST">
+                    <match>
+                        <baseValue baseType="boolean">true</baseValue>
+                        <baseValue baseType="boolean">true</baseValue>
+                    </match>
+                </branchRule>
+            </assessmentItemRef>
+            <assessmentItemRef identifier="item2" href="./item2.xml">
+                <branchRule target="EXIT_TESTPART">
+                    <match>
+                        <baseValue baseType="boolean">true</baseValue>
+                        <baseValue baseType="boolean">true</baseValue>
+                    </match>
+                </branchRule>
+            </assessmentItemRef>
+            <assessmentItemRef identifier="item3" href="./item3.xml">
+                <branchRule target="EXIT_SECTION">
+                    <match>
+                        <baseValue baseType="boolean">true</baseValue>
+                        <baseValue baseType="boolean">true</baseValue>
+                    </match>
+                </branchRule>
+            </assessmentItemRef>
+        </assessmentSection>
+    </testPart>
+</assessmentTest>

--- a/test/samples/custom/branch_rules/test_with_valid_branch_rules.xml
+++ b/test/samples/custom/branch_rules/test_with_valid_branch_rules.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentTest xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" 
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"
+                identifier="test-with-valid-branch-rules" 
+                title="Test with Valid Branch Rules">
+    <testPart identifier="part1" navigationMode="linear" submissionMode="individual">
+        <assessmentSection identifier="section1" title="Section 1" visible="true">
+            <assessmentItemRef identifier="item1" href="./item1.xml" />
+            <assessmentItemRef identifier="item2" href="./item2.xml">
+                <branchRule target="item3">
+                    <match>
+                        <baseValue baseType="boolean">true</baseValue>
+                        <baseValue baseType="boolean">true</baseValue>
+                    </match>
+                </branchRule>
+            </assessmentItemRef>
+            <assessmentItemRef identifier="item3" href="./item3.xml" />
+        </assessmentSection>
+    </testPart>
+</assessmentTest>


### PR DESCRIPTION
If validation is enabled validate QtiComponent against branching rules
This can be tested using publication endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional validation when loading XML now checks branch-rule targets and reports comprehensive errors for invalid or missing targets.

- Bug Fixes
  - Correct response is now added properly to results, preventing structure/type issues.
  - Result components are fully enumerated (flattened) so all item results and variables appear as expected.
  - Improved error messages for invalid component types.

- API Changes
  - XML load function now accepts an optional validation flag, enabling stricter consistency checks during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->