### PR TITLE
Fix default namespace elements marshalling

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         coverage: [ false ]
         include:
-          - php-version: '8.4'
+          - php-version: '8.5'
             coverage: true
 
     steps:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,24 +1,22 @@
 name: Sonarqube_CI
 on:
 
+  pull_request:
+    types:
+      - labeled
+
   push:
     branches:
       - master
       - main
-      - develop
-
-  pull_request: 
-    types: [opened, synchronize, reopened]
-    branches: 
-      - '**'
-  workflow_dispatch:
 
 jobs:
   build:
     name: Sonarqube_CI
+    if: ${{ github.event.label.name == 'sonar_check' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -26,11 +24,11 @@ jobs:
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_HOST_URL: 'https://sonarqube.taotesting.info/sonarqube/'
 
       # Job will fail when the Quality Gate is red
       - name: Sonarqube quality gate check
-        id: sonarqube-quality-gate-check      
+        id: sonarqube-quality-gate-check
         uses: sonarsource/sonarqube-quality-gate-action@master
         timeout-minutes: 5
         env:

--- a/src/qtism/data/QtiIdentifiableTrait.php
+++ b/src/qtism/data/QtiIdentifiableTrait.php
@@ -65,7 +65,7 @@ trait QtiIdentifiableTrait
      */
     public function attach(SplObserver $observer): void
     {
-        $this->getObservers()->attach($observer);
+        $this->getObservers()[$observer] = null;
     }
 
     /**
@@ -75,7 +75,7 @@ trait QtiIdentifiableTrait
      */
     public function detach(SplObserver $observer): void
     {
-        $this->getObservers()->detach($observer);
+        unset($this->getObservers()[$observer]);
     }
 
     /**

--- a/src/qtism/data/storage/xml/marshalling/MarshallerFactory.php
+++ b/src/qtism/data/storage/xml/marshalling/MarshallerFactory.php
@@ -25,9 +25,6 @@ namespace qtism\data\storage\xml\marshalling;
 
 use DOMElement;
 use InvalidArgumentException;
-use qtism\data\ExternalQtiComponent;
-use qtism\data\content\xhtml\html5\Figure;
-use qtism\data\content\xhtml\html5\Figcaption;
 use qtism\data\QtiComponent;
 use qtism\data\storage\xml\QtiNamespaced;
 use qtism\data\storage\xml\Utils;
@@ -42,6 +39,8 @@ use RuntimeException;
  */
 abstract class MarshallerFactory
 {
+    private const DEFAULT_NAMESPACE = 'qtism';
+
     /**
      * An associative array where keys are QTI class names
      * and values are fully qualified marshaller PHP class names.
@@ -299,46 +298,46 @@ abstract class MarshallerFactory
      *
      * @param string $qtiClassName A QTI class name.
      * @param string $marshallerClassName A PHP marshaller class name (fully qualified).
-     * @param string $ns
+     * @param ?string $ns
      */
-    public function addMappingEntry($qtiClassName, $marshallerClassName, $ns = 'qtism'): void
+    public function addMappingEntry($qtiClassName, $marshallerClassName, $ns = null): void
     {
-        $this->mapping[$ns][$qtiClassName] = $marshallerClassName;
+        $this->mapping[$ns ?? self::DEFAULT_NAMESPACE][$qtiClassName] = $marshallerClassName;
     }
 
     /**
      * Whether a mapping entry is defined for a given $qtiClassName.
      *
      * @param string $qtiClassName A QTI class name.
-     * @param string $ns
+     * @param ?string $ns
      * @return bool Whether a mapping entry is defined.
      */
-    public function hasMappingEntry($qtiClassName, $ns = 'qtism'): bool
+    public function hasMappingEntry($qtiClassName, $ns = null): bool
     {
-        return isset($this->mapping[$ns][$qtiClassName]);
+        return isset($this->mapping[$ns ?? self::DEFAULT_NAMESPACE][$qtiClassName]);
     }
 
     /**
      * Get the mapping entry.
      *
      * @param string $qtiClassName A QTI class name.
-     * @param string $ns
+     * @param ?string $ns
      * @return false|string False if does not exist, otherwise a fully qualified class name.
      */
-    public function getMappingEntry($qtiClassName, $ns = 'qtism')
+    public function getMappingEntry($qtiClassName, $ns = null)
     {
-        return $this->mapping[$ns][$qtiClassName] ?? false;
+        return $this->mapping[$ns ?? self::DEFAULT_NAMESPACE][$qtiClassName] ?? false;
     }
 
     /**
      * Remove a mapping for $qtiClassName.
      *
      * @param string $qtiClassName A QTI class name.
-     * @param string $ns
+     * @param ?string $ns
      */
-    public function removeMappingEntry($qtiClassName, $ns = 'qtism'): void
+    public function removeMappingEntry($qtiClassName, $ns = null): void
     {
-        unset($this->mapping[$ns][$qtiClassName]);
+        unset($this->mapping[$ns ?? self::DEFAULT_NAMESPACE][$qtiClassName]);
     }
 
     /**


### PR DESCRIPTION
This PR:

1. Fixes incorrect fallback to the default qtism namespace when marshaling QTI elements
2. Stops relying on deprecated SplObject::attach/detach methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded PHP test coverage in CI to run against additional PHP versions.
  * Enhanced XML marshalling mapping management with support for an optional namespace (defaults when omitted).
* **Bug Fixes**
  * Improved reliability of observer registration and removal behavior.
* **Chores**
  * Updated SonarQube workflow triggers and scan settings, and upgraded the checkout action version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->